### PR TITLE
[WIP] Citation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ SETUP_METADATA = \
                                language="c++",
                                extra_compile_args=EXTRA_COMPILE_ARGS,
                                extra_link_args=EXTRA_LINK_ARGS)],
-    "install_requires": ["screed>=0.9", "ijson", "khmer>=2.1<3.0"],
+    "install_requires": ["screed>=0.9", "ijson", "khmer>=2.1<3.0", "duecredit>=0.6.3"],
     "setup_requires": ['Cython>=0.25.2', "setuptools>=18.0"],
     "extras_require": {
         'test' : ['pytest', 'pytest-cov', 'numpy', 'matplotlib', 'scipy'],

--- a/sourmash/__init__.py
+++ b/sourmash/__init__.py
@@ -11,6 +11,8 @@ from ._minhash import (MinHash, get_minhash_default_seed, get_minhash_max_hash)
 DEFAULT_SEED = get_minhash_default_seed()
 MAX_HASH = get_minhash_max_hash()
 
+from .due import due, Doi, BibTeX
+
 from .signature import (load_signatures, load_one_signature, SourmashSignature,
                         save_signatures)
 from .sbtmh import load_sbt_index, search_sbt_index, create_sbt_index
@@ -24,3 +26,11 @@ from . import signature
 thisdir = os.path.dirname(__file__)
 version_file = open(os.path.join(thisdir, 'VERSION'))
 VERSION = version_file.read().strip()
+
+due.cite(Doi("10.21105/joss.00027"),
+         description="Compute MinHash signatures for nucleotide (DNA/RNA) and protein sequences",
+         path="sourmash",
+         version=VERSION,
+         cite_module=True)
+
+del Doi, BibTeX

--- a/sourmash/due.py
+++ b/sourmash/due.py
@@ -1,0 +1,73 @@
+# emacs: at the end of the file
+# ex: set sts=4 ts=4 sw=4 et:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### #
+"""
+
+Stub file for a guaranteed safe import of duecredit constructs:  if duecredit
+is not available.
+
+To use it, place it into your project codebase to be imported, e.g. copy as
+
+    cp stub.py /path/tomodule/module/due.py
+
+Note that it might be better to avoid naming it duecredit.py to avoid shadowing
+installed duecredit.
+
+Then use in your code as
+
+    from .due import due, Doi, BibTeX
+
+See  https://github.com/duecredit/duecredit/blob/master/README.md for examples.
+
+Origin:     Originally a part of the duecredit
+Copyright:  2015-2016  DueCredit developers
+License:    BSD-2
+"""
+
+__version__ = '0.0.5'
+
+
+class InactiveDueCreditCollector(object):
+    """Just a stub at the Collector which would not do anything"""
+    def _donothing(self, *args, **kwargs):
+        """Perform no good and no bad"""
+        pass
+
+    def dcite(self, *args, **kwargs):
+        """If I could cite I would"""
+        def nondecorating_decorator(func):
+            return func
+        return nondecorating_decorator
+
+    cite = load = add = _donothing
+
+    def __repr__(self):
+        return self.__class__.__name__ + '()'
+
+
+def _donothing_func(*args, **kwargs):
+    """Perform no good and no bad"""
+    pass
+
+
+try:
+    from duecredit import due, BibTeX, Doi, Url
+    if 'due' in locals() and not hasattr(due, 'cite'):
+        raise RuntimeError(
+            "Imported due lacks .cite. DueCredit is now disabled")
+except Exception as e:
+    if type(e).__name__ != 'ImportError':
+        import logging
+        logging.getLogger("duecredit").error(
+            "Failed to import duecredit due to %s" % str(e))
+    # Initiate due stub
+    due = InactiveDueCreditCollector()
+    BibTeX = Doi = Url = _donothing_func
+
+# Emacs mode definitions
+# Local Variables:
+# mode: python
+# py-indent-offset: 4
+# tab-width: 4
+# indent-tabs-mode: nil
+# End:


### PR DESCRIPTION
Fixes #259 #255 

Uses [duecredit](https://github.com/duecredit/duecredit) to implement citation. This is pretty nice because it will collect appropriate citations for other software too. As an example, running `sourmash compute` results in
```
$ DUECREDIT_ENABLE=yes sourmash compute ...

DueCredit Report:
- Compute MinHash signatures for nucleotide (DNA/RNA) and protein sequences / sourmash/ (v 2.0.0a6) [1]

1 packages cited
0 modules cited
0 functions cited

References
----------

[1] Brown, C.T. & Irber, L., 2016. sourmash: a library for MinHash sketching of DNA. The Journal of Open Source Software, 1(5), p.27.
```
but running `sourmash compare` gives us the `numpy` citation too:
```
$ DUECREDIT_ENABLE=yes sourmash compare ...

DueCredit Report:
- Scientific tools library / numpy (v 1.14.3) [1]
- Compute MinHash signatures for nucleotide (DNA/RNA) and protein sequences / sourmash/ (v 2.0.0a6) [2]

2 packages cited
0 modules cited
0 functions cited

References
----------

[1] Van Der Walt, S., Colbert, S.C. & Varoquaux, G., 2011. The NumPy array: a structure for efficient numerical computation. Computing in Science & Engineering, 13(2), pp.22–30.
[2] Brown, C.T. & Irber, L., 2016. sourmash: a library for MinHash sketching of DNA. The Journal of Open Source Software, 1(5), p.27.
```

## TODO:

- [ ] Provide the basic sourmash citation thru argparse too (see https://github.com/dib-lab/khmer/blob/9323ca4e17bccac9ec1a7d5e8321eeec61cd17cd/khmer/khmer_args.py#L78 for example)
- [x] Wait for a duecredit version that allows outputting to `stderr` by default (check duecredit/duecredit#135) (see https://github.com/dib-lab/sourmash/pull/478#issuecomment-392404425)
- [ ] Add tests (see https://github.com/MDAnalysis/mdanalysis/pull/1822/files#diff-61cf2a678e9b5f5d6d2338f797266a30 for example)

## Checklist

- [ ] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make coverage` Is the new code covered?
- [ ] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
