### PR TITLE
[WIP] refactor signature compatibility checking in sourmash compare 

### DIFF
--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -256,8 +256,9 @@ def test_do_compare_output_multiple_k():
         print(status, out, err)
 
         assert status == -1
+        assert 'a signature in short2.fa.sig is incompatible with other signatures.' in err
+        assert 'new ksize 31, vs previous 21' in err
         assert 'multiple k-mer sizes loaded; please specify one' in err
-        assert '(saw k-mer sizes 21, 31)' in err
 
 
 def test_do_compare_output_multiple_moltype():
@@ -278,8 +279,11 @@ def test_do_compare_output_multiple_moltype():
                                            fail_ok=True)
 
         assert status == -1
-        assert 'multiple molecule types loaded;' in err
-
+        print(out)
+        print(err)
+        assert 'a signature in short2.fa.sig is incompatible with other signatures.' in err
+        assert 'new moltype protein, vs previous DNA' in err
+        assert 'multiple molecule types loaded; please specify --dna, --protein' in err
 
 
 def test_do_compare_dayhoff():
@@ -772,6 +776,11 @@ def test_compare_no_choose_molecule_fail():
                                            in_directory=location,
                                            fail_ok=True)
 
+        print(out)
+        print(err)
+
+        assert 'a signature in short.fa.sig is incompatible with other signatures.' in err
+        assert 'new moltype DNA, vs previous protein' in err
         assert 'multiple molecule types loaded; please specify' in err
         assert status != 0
 


### PR DESCRIPTION
Fixes #513 by reporting the first signature file that breaks signature comparisons in sourmash compare.

I suspect further refactoring can be done to make this code cleaner and more reusable; please hold.

- [ ] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make coverage` Is the new code covered?
- [ ] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
