### PR TITLE
[MRG] remove __reduce__ from MinHash class

### DIFF
--- a/sourmash/_minhash.py
+++ b/sourmash/_minhash.py
@@ -202,24 +202,6 @@ class MinHash(RustObject):
         else:
             self.add_many(mins)
 
-    def __reduce__(self):
-        "alternative pickling protocol."
-        return (
-            MinHash,
-            (
-                self.num,
-                self.ksize,
-                self.is_protein,
-                self.dayhoff,
-                self.hp,
-                self.track_abundance,
-                self.seed,
-                self.max_hash,
-                self.get_mins(with_abundance=self.track_abundance),
-                0,
-            ),
-        )
-
     def __eq__(self, other):
         "equality testing via =="
         return self.__getstate__() == other.__getstate__()


### PR DESCRIPTION
Removes `__reduce__`, which was needed for Python 2.7.

Fixes #895 

NOTE: merge into `latest`, this is a breaking change for 3.x.

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make coverage` Is the new code covered?
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
