### PR TITLE
Output unassigned hashes from "gather" to same moltype

### DIFF
--- a/sourmash/commands.py
+++ b/sourmash/commands.py
@@ -696,10 +696,17 @@ def gather(args):
             notify('no unassigned hashes! not saving.')
         else:
             notify('saving unassigned hashes to "{}"', args.output_unassigned)
-
+            moltype_kwds = {}
+            if args.protein or args.hp or args.dayhoff:
+                moltype_kwds['is_protein'] = True
+                if args.hp:
+                    moltype_kwds['hp'] = True
+                elif args.dayhoff:
+                    moltype_kwds['dayhoff'] = True
+                  
             with_abundance = next_query.minhash.track_abundance
             e = MinHash(ksize=query.minhash.ksize, n=0, max_hash=new_max_hash,
-                        track_abundance=with_abundance)
+                        track_abundance=with_abundance, **moltype_kwds)
             if with_abundance:
                 abunds = next_query.minhash.hashes
                 e.set_abundances(abunds)


### PR DESCRIPTION
Currently, unassigned hashes are output to a MinHash without a moltype, which means the default is DNA. After testing out `gather` on some protein data and analyzing the output results, turns out the moltype of the input signature is not preserved. This (hopefully) fixes that!


- [ ] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make coverage` Is the new code covered?
- [ ] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
