### PR TITLE
[MRG] cache nodes in SBT during search

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,8 @@ SETUP_METADATA = {
         ]
     },
     "install_requires": ['screed>=0.9', 'cffi>=1.14.0', 'numpy',
-                         'matplotlib', 'scipy', 'deprecation>=2.0.6'],
+                         'matplotlib', 'scipy', 'deprecation>=2.0.6',
+                         'cachetools >=4,<5'],
     "setup_requires": [
         "setuptools>=38.6.0",
         "milksnake",

--- a/sourmash/cli/gather.py
+++ b/sourmash/cli/gather.py
@@ -55,6 +55,10 @@ def subparser(subparsers):
         '--md5', default=None,
         help='select the signature with this md5 as query'
     )
+    subparser.add_argument(
+        '--cache-size', default=0, type=int, metavar='N',
+        help='number of internal SBT nodes to cache in memory (default: 0, cache all nodes)'
+    )
     add_ksize_arg(subparser, 31)
     add_moltype_args(subparser)
 

--- a/sourmash/commands.py
+++ b/sourmash/commands.py
@@ -618,8 +618,12 @@ def gather(args):
         sys.exit(-1)
 
     # set up the search databases
+    cache_size = args.cache_size
+    if args.cache_size == 0:
+        cache_size = None
     databases = sourmash_args.load_dbs_and_sigs(args.databases, query, False,
-                                                args.traverse_directory)
+                                                args.traverse_directory,
+                                                cache_size=cache_size)
 
     if not len(databases):
         error('Nothing found to search!')

--- a/sourmash/sbt.py
+++ b/sourmash/sbt.py
@@ -125,8 +125,18 @@ class _NodesCache(Cache):
     def popitem(self):
         """Remove and return the `(key, value)` pair least recently used."""
         try:
-            common = self.__counter.most_common()
+            # Select least frequently used keys,
+            # limit to 50 items to avoid dealing with huge lists
+            common = self.__counter.most_common()[:50]
+
+            # common might include different values, so let's use
+            # only keys that have the same value as the first one
+            # (all those with the same count are least frequently used items)
             count = common[0][1]
+
+            # we want to remove the item closest to the leaves,
+            # and since node ids increase as they get farther from the root
+            # we just need to select the maximum key/node id
             (key, _) = max(c for c in common if c[1] == count)
         except IndexError:
             msg = '%s is empty' % self.__class__.__name__

--- a/sourmash/sbt_storage.py
+++ b/sourmash/sbt_storage.py
@@ -7,7 +7,7 @@ import tarfile
 from tempfile import NamedTemporaryFile
 import zipfile
 from abc import ABC
-
+from pathlib import Path
 
 class Storage(ABC):
 
@@ -78,11 +78,8 @@ class FSStorage(Storage):
         return newpath
 
     def load(self, path):
-        out = BytesIO()
-        with open(os.path.join(self.location, self.subdir, path), 'rb') as f:
-            out.write(f.read())
-
-        return out.getvalue()
+        path = Path(self.location) / self.subdir / path
+        return path.read_bytes()
 
 
 class TarStorage(Storage):

--- a/sourmash/sbtmh.py
+++ b/sourmash/sbtmh.py
@@ -5,10 +5,11 @@ from .sbt import Leaf, SBT, GraphFactory
 from . import signature
 
 
-def load_sbt_index(filename, print_version_warning=True):
+def load_sbt_index(filename, *, print_version_warning=True, cache_size=None):
     "Load and return an SBT index."
     return SBT.load(filename, leaf_loader=SigLeaf.load,
-                    print_version_warning=print_version_warning)
+                    print_version_warning=print_version_warning,
+                    cache_size=cache_size)
 
 
 def create_sbt_index(bloom_filter_size=1e5, n_children=2):

--- a/sourmash/sourmash_args.py
+++ b/sourmash/sourmash_args.py
@@ -240,7 +240,7 @@ def check_lca_db_is_compatible(filename, db, query):
     return 1
 
 
-def load_dbs_and_sigs(filenames, query, is_similarity_query, traverse=False):
+def load_dbs_and_sigs(filenames, query, is_similarity_query, traverse=False, *, cache_size=None):
     """
     Load one or more SBTs, LCAs, and/or signatures.
 
@@ -256,7 +256,7 @@ def load_dbs_and_sigs(filenames, query, is_similarity_query, traverse=False):
         notify('loading from {}...', filename, end='\r')
 
         try:
-            db, dbtype = _load_database(filename, traverse, False)
+            db, dbtype = _load_database(filename, traverse, False, cache_size=cache_size)
         except IOError as e:
             notify(str(e))
             sys.exit(-1)
@@ -342,7 +342,7 @@ class DatabaseType(Enum):
     LCA = 3
 
 
-def _load_database(filename, traverse, traverse_yield_all):
+def _load_database(filename, traverse, traverse_yield_all, *, cache_size=None):
     """Load file as a database - list of signatures, LCA, SBT, etc.
 
     Return (db, dbtype), where dbtype is a DatabaseType enum.
@@ -393,7 +393,7 @@ def _load_database(filename, traverse, traverse_yield_all):
 
     if not loaded:                    # try load as SBT
         try:
-            db = load_sbt_index(filename)
+            db = load_sbt_index(filename, cache_size=cache_size)
             loaded = True
             dbtype = DatabaseType.SBT
         except:

--- a/tests/test_sbt.py
+++ b/tests/test_sbt.py
@@ -935,3 +935,18 @@ def test_sbt_dayhoff_command_search(c):
     c.run_sourmash('gather', sigfile1, db_out, '--threshold', '0.0')
     assert 'found 1 matches total' in c.last_result.out
     assert 'the recovered matches hit 100.0% of the query' in c.last_result.out
+
+
+def test_sbt_node_cache():
+    tree = SBT.load(utils.get_test_data('v6.sbt.json'),
+                    leaf_loader=SigLeaf.load,
+                    cache_size=1)
+
+    testdata1 = utils.get_test_data(utils.SIG_FILES[0])
+    to_search = load_one_signature(testdata1)
+
+    results = list(tree.find(search_minhashes_containment, to_search, 0.1))
+    assert len(results) == 4
+
+    assert tree._nodescache.currsize == 1
+    assert tree._nodescache.currsize == 1


### PR DESCRIPTION
PR based on discussions in #93 #520 #204

Set up a cache in `SBT` for controlling how much memory is used. Adding a dependency on [cachetools](https://cachetools.readthedocs.io/en/stable/) because it's a very convenient API (and it is available in conda-forge too).

When a node is removed from the cache, it calls `node.unload()` to release memory (but only if the Node is backed by a `Storage`, so we can reload the data if needed).

(I think this PR will be required for making the new updated GenBank SBTs usable...)

## TODO

- [x] expose CACHE_SIZE as an option in the command line
- [x] more benchmarking to see running time impacts

## Checklist

- [ ] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make coverage` Is the new code covered?
- [ ] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
