### PR TITLE
[MRG] Deprecate TarStorage

### DIFF
--- a/sourmash/sbt_storage.py
+++ b/sourmash/sbt_storage.py
@@ -8,6 +8,10 @@ from tempfile import NamedTemporaryFile
 import zipfile
 from abc import ABC
 
+from deprecation import deprecated
+
+from . import VERSION
+
 
 class Storage(ABC):
 
@@ -87,6 +91,9 @@ class FSStorage(Storage):
 
 class TarStorage(Storage):
 
+    @deprecated(deprecated_in="3.5", removed_in="4.0",
+                current_version=VERSION,
+                details='Use ZipStorage instead')
     def __init__(self, path=None):
         # TODO: leave it open, or close/open every time?
 


### PR DESCRIPTION
I don't think anyone is using `TarStorage`, and `ZipStorage` is a better alternative anyway.

This PR is merging into `stable`, for removal of `TarStorage` for 4.0

## Checklist

- [ ] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make coverage` Is the new code covered?
- [ ] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
