### PR TITLE
[MRG] fix Rust panic error in signature creation

### DIFF
--- a/src/core/src/signature.rs
+++ b/src/core/src/signature.rs
@@ -357,15 +357,15 @@ impl Signature {
         if #[cfg(feature = "parallel")] {
             self.signatures
                 .par_iter_mut()
-                .for_each(|sketch| {
-                    sketch.add_protein(&seq).unwrap(); }
-                );
+                .try_for_each(|sketch| {
+                    sketch.add_protein(&seq) }
+                )?;
         } else {
             self.signatures
                 .iter_mut()
-                .for_each(|sketch| {
-                    sketch.add_protein(&seq).unwrap(); }
-                );
+                .try_for_each(|sketch| {
+                    sketch.add_protein(&seq) }
+                )?;
         }
         }
 

--- a/tests/test_sourmash_sketch.py
+++ b/tests/test_sourmash_sketch.py
@@ -9,6 +9,7 @@ import glob
 import json
 import csv
 import pytest
+import screed
 
 from . import sourmash_tst_utils as utils
 import sourmash
@@ -97,6 +98,25 @@ def test_protein_override_bad_2():
     with pytest.raises(ValueError):
         factory = _signatures_for_sketch_factory(['k=21,dna'],
                                                  'protein', False)
+
+def test_protein_override_bad_rust_foo():
+    # mimic 'sourmash sketch protein -p dna'
+    factory = _signatures_for_sketch_factory([], 'protein', False)
+
+    # reach in and avoid error checking to construct a bad params_list.
+    factory.params_list = [('dna', {})]
+
+    # now, get sigs...
+    siglist = factory()
+    assert len(siglist) == 1
+    sig = siglist[0]
+
+    # try adding something
+    testdata1 = utils.get_test_data('ecoli.faa')
+    record = next(iter(screed.open(testdata1)))
+
+    sig.add_protein(record.sequence)
+
 
 def test_dayhoff_defaults():
     factory = _signatures_for_sketch_factory([], 'dayhoff', True)

--- a/tests/test_sourmash_sketch.py
+++ b/tests/test_sourmash_sketch.py
@@ -115,7 +115,10 @@ def test_protein_override_bad_rust_foo():
     testdata1 = utils.get_test_data('ecoli.faa')
     record = next(iter(screed.open(testdata1)))
 
-    sig.add_protein(record.sequence)
+    with pytest.raises(ValueError) as exc:
+        sig.add_protein(record.sequence)
+
+    assert 'Invalid hash function: "dna"' in str(exc)
 
 
 def test_dayhoff_defaults():


### PR DESCRIPTION
Fixes #1166 by adjusting rust code to raise proper error on `add_protein` with a DNA hash function.

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make coverage` Is the new code covered?
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
