### PR TITLE
[MRG] Remove `--traverse-directory` from commands & make default

### DIFF
--- a/doc/command-line.md
+++ b/doc/command-line.md
@@ -859,12 +859,8 @@ some other command.
 
 #### Loading all signatures under a directory
 
-Note that until 4.0, `--traverse-directory` may be needed for many
-commands in order for them to load signatures from a directory
-hierarchy -- `search`, `gather`, `index`, `lca index`, and `compare`,
-for example. All of the `sourmash sig` commands support loading from a
-directory if you provide it on the command line, and this will be the
-default behavior in sourmash 4.0.
+All of the `sourmash` commands support loading signatures from
+directories provided on the command line.
 
 ### Combining search databases on the command line
 

--- a/sourmash/cli/categorize.py
+++ b/sourmash/cli/categorize.py
@@ -21,7 +21,6 @@ def subparser(subparsers):
         '--threshold', default=0.08, type=float,
         help='minimum threshold for reporting matches; default=0.08'
     )
-    subparser.add_argument('--traverse-directory', action="store_true")
     subparser.add_argument(
         '--ignore-abundance', action='store_true',
         help='do NOT use k-mer abundances if present'

--- a/sourmash/cli/compare.py
+++ b/sourmash/cli/compare.py
@@ -28,10 +28,6 @@ def subparser(subparsers):
         help='calculate containment instead of similarity'
     )
     subparser.add_argument(
-        '--traverse-directory', action='store_true',
-        help='compare all signatures underneath directories'
-    )
-    subparser.add_argument(
         '--from-file',
         help='a file containing a list of signatures file to compare'
     )

--- a/sourmash/cli/gather.py
+++ b/sourmash/cli/gather.py
@@ -22,10 +22,6 @@ def subparser(subparsers):
         help='number of results to report (default: terminate at --threshold-bp)'
     )
     subparser.add_argument(
-        '--traverse-directory', action='store_true',
-        help='search all signatures underneath directories'
-    )
-    subparser.add_argument(
         '-o', '--output', metavar='FILE',
         help='output CSV containing matches to this file'
     )

--- a/sourmash/cli/index.py
+++ b/sourmash/cli/index.py
@@ -59,7 +59,7 @@ def subparser(subparsers):
     )
     subparser.add_argument(
         '-f', '--force', action='store_true',
-        help='try loading all files in provided subdirectories"'
+        help='try loading *all* files in provided subdirectories, not just .sig files"'
     )
     subparser.add_argument(
         '-s', '--sparseness', metavar='FLOAT', type=float, default=.0,

--- a/sourmash/cli/index.py
+++ b/sourmash/cli/index.py
@@ -14,7 +14,6 @@ The key options for index are:
 
  * `-k/--ksize <int>`: k-mer size to select
  * `--dna` or --protein`: nucleotide or protein signatures (default `--dna`)
- * `--traverse-directory`: load all signatures below this directory
 
 If `dbname` ends with `.sbt.json`, index will create the database as a
 collection of multiple files, with an index `dbname.sbt.json` and a
@@ -51,10 +50,6 @@ def subparser(subparsers):
         help='number of children for internal nodes; default=2'
     )
     subparser.add_argument(
-        '--traverse-directory', action='store_true',
-        help='load all signatures underneath any directories'
-    )
-    subparser.add_argument(
         '--append', action='store_true', default=False,
         help='add signatures to an existing SBT'
     )
@@ -64,7 +59,7 @@ def subparser(subparsers):
     )
     subparser.add_argument(
         '-f', '--force', action='store_true',
-        help='try loading all files with --traverse-directory'
+        help='try loading all files in provided subdirectories"'
     )
     subparser.add_argument(
         '-s', '--sparseness', metavar='FLOAT', type=float, default=.0,

--- a/sourmash/cli/lca/classify.py
+++ b/sourmash/cli/lca/classify.py
@@ -27,10 +27,6 @@ def subparser(subparsers):
         help='output CSV to the specified file; by default output to stdout'
     )
     subparser.add_argument('--scaled', type=float)
-    subparser.add_argument(
-        '--traverse-directory', action='store_true',
-        help='load all signatures underneath directories'
-    )
 
 
 def main(args):

--- a/sourmash/cli/lca/index.py
+++ b/sourmash/cli/lca/index.py
@@ -46,10 +46,6 @@ def subparser(subparsers):
     )
     subparser.add_argument('-f', '--force', action='store_true')
     subparser.add_argument(
-        '--traverse-directory', action='store_true',
-        help='load all signatures underneath directories'
-    )
-    subparser.add_argument(
         '--report', help='output a report on anomalies, if any'
     )
     subparser.add_argument(

--- a/sourmash/cli/lca/summarize.py
+++ b/sourmash/cli/lca/summarize.py
@@ -12,10 +12,6 @@ def subparser(subparsers):
     subparser.add_argument('--threshold', metavar='T', type=int, default=5,
                            help='minimum number of hashes to require for a match')
     subparser.add_argument(
-        '--traverse-directory', action='store_true',
-        help='load all signatures underneath directories'
-    )
-    subparser.add_argument(
         '-o', '--output', metavar='FILE',
         help='file to which CSV output will be written'
     )

--- a/sourmash/cli/multigather.py
+++ b/sourmash/cli/multigather.py
@@ -25,10 +25,6 @@ def subparser(subparsers):
         '-d', '--debug', action='store_true'
     )
     subparser.add_argument(
-        '--traverse-directory', action='store_true',
-        help='search all signatures underneath directories'
-    )
-    subparser.add_argument(
         '--threshold-bp', metavar='REAL', type=float, default=5e4,
         help='threshold (in bp) for reporting results (default=50,000)'
     )

--- a/sourmash/cli/search.py
+++ b/sourmash/cli/search.py
@@ -13,10 +13,6 @@ def subparser(subparsers):
         help='signatures/SBTs to search',
     )
     subparser.add_argument(
-        '--traverse-directory', action='store_true',
-        help='search all signatures underneath directories'
-    )
-    subparser.add_argument(
         '-q', '--quiet', action='store_true',
         help='suppress non-error output'
     )

--- a/sourmash/commands.py
+++ b/sourmash/commands.py
@@ -362,7 +362,6 @@ def index(args):
         siglist = sourmash_args.load_file_as_signatures(f,
                                                         ksize=args.ksize,
                                                         select_moltype=moltype,
-                                                        traverse=args.traverse_directory,
                                                         yield_all_files=args.force,
                                                         progress=progress)
 

--- a/sourmash/commands.py
+++ b/sourmash/commands.py
@@ -45,7 +45,6 @@ def compare(args):
         loaded = sourmash_args.load_file_as_signatures(filename,
                                                        ksize=args.ksize,
                                                        select_moltype=moltype,
-                                                       traverse=args.traverse_directory,
                                                        yield_all_files=args.force,
                                                        progress=progress)
         loaded = list(loaded)

--- a/sourmash/commands.py
+++ b/sourmash/commands.py
@@ -437,8 +437,7 @@ def search(args):
 
     # set up the search databases
     databases = sourmash_args.load_dbs_and_sigs(args.databases, query,
-                                                not args.containment,
-                                                args.traverse_directory)
+                                                not args.containment)
 
     # forcibly ignore abundances if query has no abundances
     if not query.minhash.track_abundance:
@@ -601,7 +600,6 @@ def gather(args):
     if args.cache_size == 0:
         cache_size = None
     databases = sourmash_args.load_dbs_and_sigs(args.databases, query, False,
-                                                args.traverse_directory,
                                                 cache_size=cache_size)
 
     if not len(databases):
@@ -709,8 +707,7 @@ def multigather(args):
     # need a query to get ksize, moltype for db loading
     query = next(iter(sourmash_args.load_file_as_signatures(inp_files[0], ksize=args.ksize, select_moltype=moltype)))
 
-    databases = sourmash_args.load_dbs_and_sigs(args.db, query, False,
-                                                args.traverse_directory)
+    databases = sourmash_args.load_dbs_and_sigs(args.db, query, False)
 
     if not len(databases):
         error('Nothing found to search!')

--- a/sourmash/commands.py
+++ b/sourmash/commands.py
@@ -512,12 +512,8 @@ def categorize(args):
     tree = load_sbt_index(args.sbt_name)
 
     # load query filenames
-    if args.traverse_directory:
-        inp_files = set(sourmash_args.traverse_find_sigs(args.queries))
-    else:
-        inp_files = set(args.queries) - already_names
-
-    inp_files = set(inp_files) - already_names
+    inp_files = set(sourmash_args.traverse_find_sigs(args.queries))
+    inp_files = inp_files - already_names
 
     notify('found {} files to query', len(inp_files))
 

--- a/sourmash/lca/command_classify.py
+++ b/sourmash/lca/command_classify.py
@@ -126,8 +126,7 @@ def classify(args):
         for query_filename in inp_files:
             n += 1
             for query_sig in load_file_as_signatures(query_filename,
-                                                     ksize=ksize,
-                                                     traverse=args.traverse_directory):
+                                                     ksize=ksize):
                 notify(u'\r\033[K', end=u'')
                 notify('... classifying {} (file {} of {})', query_sig.name(),
                        n, total_n, end='\r')

--- a/sourmash/lca/command_index.py
+++ b/sourmash/lca/command_index.py
@@ -192,7 +192,6 @@ def index(args):
         n += 1
         it = load_file_as_signatures(filename, ksize=args.ksize,
                                      select_moltype=moltype,
-                                     traverse=args.traverse_directory,
                                      yield_all_files=args.force)
         for sig in it:
             notify(u'\r\033[K', end=u'')
@@ -255,8 +254,6 @@ def index(args):
     # check -- did we find any signatures?
     if n == 0:
         error('ERROR: no signatures found. ??')
-        if args.traverse_directory and not args.force:
-            error('(note, with --traverse-directory, you may want to use -f)')
         sys.exit(1)
 
     # check -- did the signatures we found have any hashes?

--- a/sourmash/lca/command_summarize.py
+++ b/sourmash/lca/command_summarize.py
@@ -56,36 +56,6 @@ def summarize(hashvals, dblist, threshold, ignore_abundance):
     return aggregated_counts
 
 
-<<<<<<< HEAD
-def load_and_combine(filenames, ksize, scaled, with_abundance):
-    "Load individual signatures and combine them all for classification."
-    total_count = 0
-    n = 0
-    total_n = len(filenames)
-    hashvals = defaultdict(int)
-    for query_filename in filenames:
-        n += 1
-        for query_sig in sourmash_args.load_file_as_signatures(query_filename, ksize=ksize):
-            notify(u'\r\033[K', end=u'')
-            notify('... loading {} (file {} of {})', query_sig.name(), n,
-                   total_n, end='\r')
-            total_count += 1
-
-            if with_abundance and not query_sig.minhash.track_abundance:
-                notify("** error: minhash has no abundances, yet --with-abundance specified")
-                sys.exit(-1)
-
-            if not with_abundance and query_sig.minhash.track_abundance:
-                notify("NOTE: discarding abundances in query, since --with-abundance not given")
-
-            count_signature(query_sig, scaled, hashvals)
-
-    notify(u'\r\033[K', end=u'')
-    notify('loaded {} signatures from {} files total.', total_count, n)
-
-    return hashvals
-
-
 def load_singletons_and_count(filenames, ksize, scaled, ignore_abundance):
     "Load individual signatures and count them individually."
     total_count = 0

--- a/sourmash/lca/command_summarize.py
+++ b/sourmash/lca/command_summarize.py
@@ -56,7 +56,7 @@ def summarize(hashvals, dblist, threshold, with_abundance):
     return aggregated_counts
 
 
-def load_and_combine(filenames, ksize, scaled, with_abundance, traverse):
+def load_and_combine(filenames, ksize, scaled, with_abundance):
     "Load individual signatures and combine them all for classification."
     total_count = 0
     n = 0
@@ -64,7 +64,7 @@ def load_and_combine(filenames, ksize, scaled, with_abundance, traverse):
     hashvals = defaultdict(int)
     for query_filename in filenames:
         n += 1
-        for query_sig in sourmash_args.load_file_as_signatures(query_filename, ksize=ksize, traverse=traverse):
+        for query_sig in sourmash_args.load_file_as_signatures(query_filename, ksize=ksize):
             notify(u'\r\033[K', end=u'')
             notify('... loading {} (file {} of {})', query_sig.name(), n,
                    total_n, end='\r')
@@ -85,17 +85,16 @@ def load_and_combine(filenames, ksize, scaled, with_abundance, traverse):
     return hashvals
 
 
-def load_singletons_and_count(filenames, ksize, scaled, with_abundance, traverse):
+def load_singletons_and_count(filenames, ksize, scaled, with_abundance):
     "Load individual signatures and count them individually."
     total_count = 0
     n = 0
 
     # in order to get the right reporting out of this function, we need
     # to do our own traversal to expand the list of filenames, as opposed
-    # to using load_file_as_signatures(..., traverse=True)
-    if traverse:
-        filenames = sourmash_args.traverse_find_sigs(filenames)
-        filenames = list(filenames)
+    # to using load_file_as_signatures(...)
+    filenames = sourmash_args.traverse_find_sigs(filenames)
+    filenames = list(filenames)
 
     total_n = len(filenames)
 
@@ -234,7 +233,7 @@ def summarize_main(args):
 
         try:
             for filename, sig, hashvals in \
-              load_singletons_and_count(inp_files, ksize, scaled, with_abundance, args.traverse_directory):
+              load_singletons_and_count(inp_files, ksize, scaled, with_abundance):
 
                 # get the full counted list of lineage counts in this signature
                 lineage_counts = summarize(hashvals, dblist, args.threshold,
@@ -258,8 +257,7 @@ def summarize_main(args):
     else:
         # load and merge all the signatures in all the files
         # DEPRECATE for 4.0.
-        hashvals = load_and_combine(inp_files, ksize, scaled, with_abundance,
-                                    args.traverse_directory)
+        hashvals = load_and_combine(inp_files, ksize, scaled, with_abundance)
 
         # get the full counted list of lineage counts across signatures
         lineage_counts = summarize(hashvals, dblist, args.threshold,

--- a/sourmash/sig/__main__.py
+++ b/sourmash/sig/__main__.py
@@ -75,7 +75,6 @@ def cat(args):
         this_siglist = []
         try:
             loader = sourmash_args.load_file_as_signatures(sigfile,
-                                                           traverse=True,
                                                            progress=progress)
             n_loaded = 0
             for sig in loader:
@@ -128,7 +127,6 @@ def split(args):
     for sigfile in args.signatures:
         # load signatures from input file:
         this_siglist = sourmash_args.load_file_as_signatures(sigfile,
-                                                             traverse=True,
                                                              progress=progress)
 
         # save each file individually --
@@ -208,7 +206,6 @@ def describe(args):
     for signature_file in args.signatures:
         try:
             loader = sourmash_args.load_file_as_signatures(signature_file,
-                                                           traverse=True,
                                                            progress=progress)
             for sig in loader:
                 n_loaded += 1
@@ -352,7 +349,6 @@ def merge(args):
         for sigobj in sourmash_args.load_file_as_signatures(sigfile,
                                                         ksize=args.ksize,
                                                         select_moltype=moltype,
-                                                        traverse=True,
                                                         progress=progress):
 
             # first signature? initialize a bunch of stuff
@@ -413,7 +409,6 @@ def intersect(args):
         for sigobj in sourmash_args.load_file_as_signatures(sigfile,
                                                ksize=args.ksize,
                                                select_moltype=moltype,
-                                               traverse=True,
                                                progress=progress):
             if first_sig is None:
                 first_sig = sigobj
@@ -489,7 +484,6 @@ def subtract(args):
         for sigobj in sourmash_args.load_file_as_signatures(sigfile,
                                                         ksize=args.ksize,
                                                         select_moltype=moltype,
-                                                        traverse=True,
                                                         progress=progress):
             if not sigobj.minhash.is_compatible(from_mh):
                 error("incompatible minhashes; specify -k and/or molecule type.")
@@ -535,7 +529,6 @@ def rename(args):
         siglist = sourmash_args.load_file_as_signatures(filename,
                                                         ksize=args.ksize,
                                                         select_moltype=moltype,
-                                                        traverse=True,
                                                         progress=progress)
 
         for sigobj in siglist:
@@ -563,7 +556,6 @@ def extract(args):
         siglist = sourmash_args.load_file_as_signatures(filename,
                                                         ksize=args.ksize,
                                                         select_moltype=moltype,
-                                                        traverse=True,
                                                         progress=progress)
         siglist = list(siglist)
 
@@ -605,7 +597,6 @@ def filter(args):
         siglist = sourmash_args.load_file_as_signatures(filename,
                                                         ksize=args.ksize,
                                                         select_moltype=moltype,
-                                                        traverse=True,
                                                         progress=progress)
         siglist = list(siglist)
 
@@ -663,7 +654,6 @@ def flatten(args):
         siglist = sourmash_args.load_file_as_signatures(filename,
                                                         ksize=args.ksize,
                                                         select_moltype=moltype,
-                                                        traverse=True,
                                                         progress=progress)
         siglist = list(siglist)
 
@@ -712,7 +702,6 @@ def downsample(args):
         siglist = sourmash_args.load_file_as_signatures(sigfile,
                                                         ksize=args.ksize,
                                                         select_moltype=moltype,
-                                                        traverse=True,
                                                         progress=progress)
 
         for sigobj in siglist:

--- a/sourmash/sourmash_args.py
+++ b/sourmash/sourmash_args.py
@@ -461,7 +461,7 @@ def load_file_as_index(filename, traverse=True, yield_all_files=False):
 
 
 def load_file_as_signatures(filename, select_moltype=None, ksize=None,
-                            traverse=False, yield_all_files=False,
+                            traverse=True, yield_all_files=False,
                             progress=None):
     """Load 'filename' as a collection of signatures. Return an iterable.
 

--- a/sourmash/sourmash_args.py
+++ b/sourmash/sourmash_args.py
@@ -154,11 +154,22 @@ class LoadSingleSignatures(object):
 
 
 def traverse_find_sigs(filenames, yield_all_files=False):
+    endings = ('.sig', '.sig.gz')
     for filename in filenames:
-        if os.path.isfile(filename) and \
-                  (filename.endswith('.sig') or yield_all_files):
-            yield filename
-            continue
+        if os.path.isfile(filename):
+            yield_me = False
+            if yield_all_files:
+                yield_me = True
+                continue
+            else:
+                for ending in endings:
+                    if filename.endswith(ending):
+                        yield_me = True
+                        break
+
+            if yield_me:
+                yield filename
+                continue
 
         # filename is a directory --
         dirname = filename

--- a/sourmash/sourmash_args.py
+++ b/sourmash/sourmash_args.py
@@ -240,7 +240,7 @@ def check_lca_db_is_compatible(filename, db, query):
     return 1
 
 
-def load_dbs_and_sigs(filenames, query, is_similarity_query, traverse=False, *, cache_size=None):
+def load_dbs_and_sigs(filenames, query, is_similarity_query, *, cache_size=None):
     """
     Load one or more SBTs, LCAs, and/or signatures.
 
@@ -256,7 +256,7 @@ def load_dbs_and_sigs(filenames, query, is_similarity_query, traverse=False, *, 
         notify('loading from {}...', filename, end='\r')
 
         try:
-            db, dbtype = _load_database(filename, traverse, False, cache_size=cache_size)
+            db, dbtype = _load_database(filename, False, cache_size=cache_size)
         except IOError as e:
             notify(str(e))
             sys.exit(-1)
@@ -264,7 +264,7 @@ def load_dbs_and_sigs(filenames, query, is_similarity_query, traverse=False, *, 
         # are we collecting signatures from a directory/path?
         # NOTE: error messages about loading will now be attributed to
         # directory, not individual file.
-        if traverse and os.path.isdir(filename):
+        if os.path.isdir(filename):
             assert dbtype == DatabaseType.SIGLIST
 
             siglist = _select_sigs(db, moltype=query_moltype, ksize=query_ksize)
@@ -342,7 +342,7 @@ class DatabaseType(Enum):
     LCA = 3
 
 
-def _load_database(filename, traverse, traverse_yield_all, *, cache_size=None):
+def _load_database(filename, traverse_yield_all, *, cache_size=None):
     """Load file as a database - list of signatures, LCA, SBT, etc.
 
     Return (db, dbtype), where dbtype is a DatabaseType enum.
@@ -360,7 +360,7 @@ def _load_database(filename, traverse, traverse_yield_all, *, cache_size=None):
         dbtype = DatabaseType.SIGLIST
 
     # load signatures from directory
-    if not loaded and os.path.isdir(filename) and traverse:
+    if not loaded and os.path.isdir(filename):
         all_sigs = []
         for thisfile in traverse_find_sigs([filename], traverse_yield_all):
             try:
@@ -436,7 +436,7 @@ def _select_sigs(siglist, ksize, moltype):
            yield ss
 
 
-def load_file_as_index(filename, traverse=True, yield_all_files=False):
+def load_file_as_index(filename, yield_all_files=False):
     """Load 'filename' as a database; generic database loader.
 
     If 'filename' contains an SBT or LCA indexed database, will return
@@ -445,11 +445,11 @@ def load_file_as_index(filename, traverse=True, yield_all_files=False):
     If 'filename' is a JSON file containing one or more signatures, will
     return an Index object containing those signatures.
 
-    If 'filename' is a directory and traverse=True, will load *.sig underneath
+    If 'filename' is a directory, will load *.sig underneath
     this directory into an Index object. If yield_all_files=True, will
-    attempt to load all files. (traverse defaults to True here.)
+    attempt to load all files.
     """
-    db, dbtype = _load_database(filename, traverse, yield_all_files)
+    db, dbtype = _load_database(filename, yield_all_files)
     if dbtype in (DatabaseType.LCA, DatabaseType.SBT):
         return db                         # already an index!
     elif dbtype == DatabaseType.SIGLIST:
@@ -461,7 +461,7 @@ def load_file_as_index(filename, traverse=True, yield_all_files=False):
 
 
 def load_file_as_signatures(filename, select_moltype=None, ksize=None,
-                            traverse=True, yield_all_files=False,
+                            yield_all_files=False,
                             progress=None):
     """Load 'filename' as a collection of signatures. Return an iterable.
 
@@ -471,7 +471,7 @@ def load_file_as_signatures(filename, select_moltype=None, ksize=None,
     If 'filename' is a JSON file containing one or more signatures, will
     return a list of those signatures.
 
-    If 'filename' is a directory and traverse=True, will load *.sig
+    If 'filename' is a directory, will load *.sig
     underneath this directory into a list of signatures. If
     yield_all_files=True, will attempt to load all files.
 
@@ -480,7 +480,7 @@ def load_file_as_signatures(filename, select_moltype=None, ksize=None,
     if progress:
         progress.notify(filename)
 
-    db, dbtype = _load_database(filename, traverse, yield_all_files)
+    db, dbtype = _load_database(filename, yield_all_files)
 
     loader = None
     if dbtype in (DatabaseType.LCA, DatabaseType.SBT):

--- a/tests/test_lca.py
+++ b/tests/test_lca.py
@@ -715,7 +715,7 @@ def test_index_traverse():
         os.mkdir(in_dir)
         shutil.copyfile(input_sig, os.path.join(in_dir, 'q.sig'))
 
-        cmd = ['lca', 'index', taxcsv, lca_db, in_dir, '--traverse-directory']
+        cmd = ['lca', 'index', taxcsv, lca_db, in_dir]
         status, out, err = utils.runscript('sourmash', cmd)
 
         print(cmd)
@@ -743,8 +743,7 @@ def test_index_traverse_force(c):
     shutil.copyfile(input_sig, os.path.join(in_dir, 'q.txt'))
 
     # use --force
-    cmd = ['lca', 'index', taxcsv, lca_db, in_dir, '--traverse-directory',
-           '-f']
+    cmd = ['lca', 'index', taxcsv, lca_db, in_dir, '-f']
     c.run_sourmash(*cmd)
 
     out = c.last_result.out
@@ -912,8 +911,7 @@ def test_single_classify_traverse():
         os.mkdir(in_dir)
         shutil.copyfile(input_sig, os.path.join(in_dir, 'q.sig'))
 
-        cmd = ['lca', 'classify', '--db', db1, '--query', input_sig,
-               '--traverse-directory']
+        cmd = ['lca', 'classify', '--db', db1, '--query', input_sig]
         status, out, err = utils.runscript('sourmash', cmd)
 
         print(cmd)
@@ -932,8 +930,7 @@ def test_multi_query_classify_traverse():
         dir1 = utils.get_test_data('lca/dir1')
         dir2 = utils.get_test_data('lca/dir2')
 
-        cmd = ['lca', 'classify', '--db', db1, '--query', dir1, dir2,
-               '--traverse-directory']
+        cmd = ['lca', 'classify', '--db', db1, '--query', dir1, dir2]
         status, out, err = utils.runscript('sourmash', cmd)
 
         print(cmd)
@@ -1021,8 +1018,7 @@ def test_multi_db_multi_query_classify_traverse():
         dir1 = utils.get_test_data('lca/dir1')
         dir2 = utils.get_test_data('lca/dir2')
 
-        cmd = ['lca', 'classify', '--db', db1, db2, '--query', dir1, dir2,
-               '--traverse-directory']
+        cmd = ['lca', 'classify', '--db', db1, db2, '--query', dir1, dir2]
         status, out, err = utils.runscript('sourmash', cmd)
 
         print(cmd)
@@ -1361,8 +1357,7 @@ def test_single_summarize_traverse(c):
     os.mkdir(in_dir)
     shutil.copyfile(input_sig, os.path.join(in_dir, 'q.sig'))
 
-    cmd = ['lca', 'summarize', '--db', db1, '--query', in_dir,
-           '--traverse-directory']
+    cmd = ['lca', 'summarize', '--db', db1, '--query', in_dir]
     c.run_sourmash(*cmd)
 
     out = c.last_result.out
@@ -1382,7 +1377,7 @@ def test_single_summarize_singleton_traverse(c):
     shutil.copyfile(input_sig, os.path.join(in_dir, 'q.sig'))
 
     cmd = ['lca', 'summarize', '--db', db1, '--query', in_dir,
-           '--singleton', '--traverse-directory']
+           '--singleton']
     c.run_sourmash(*cmd)
 
     out = c.last_result.out

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -1901,8 +1901,7 @@ def test_do_sourmash_index_traverse():
                                            in_directory=location)
 
         status, out, err = utils.runscript('sourmash',
-                                           ['index', '-k', '31', 'zzz',
-                                            '--traverse-dir', '.'],
+                                           ['index', '-k', '31', 'zzz', '.'],
                                            in_directory=location)
 
         assert os.path.exists(os.path.join(location, 'zzz.sbt.json'))
@@ -1920,7 +1919,7 @@ def test_do_sourmash_index_traverse():
 
 @utils.in_tempdir
 def test_do_sourmash_index_traverse_force(c):
-    # test loading of files that don't end with .sig with --traverse-dir -f
+    # test loading of files that don't end with .sig with -f
     testdata1 = utils.get_test_data('short.fa')
     testdata2 = utils.get_test_data('short2.fa')
 
@@ -1932,7 +1931,7 @@ def test_do_sourmash_index_traverse_force(c):
     c.run_sourmash('compute', testdata1, '-o', out1)
     c.run_sourmash('compute', testdata2, '-o', out2)
 
-    c.run_sourmash('index', '-k', '31', 'zzz', '--traverse-dir', '.', '-f')
+    c.run_sourmash('index', '-k', '31', 'zzz', '.', '-f')
 
     err = c.last_result.err
     assert os.path.exists(c.output('zzz.sbt.json'))
@@ -1956,8 +1955,7 @@ def test_do_sourmash_index_sparseness():
                                            in_directory=location)
 
         status, out, err = utils.runscript('sourmash',
-                                           ['index', '-k', '31', 'zzz',
-                                            '--traverse-dir', '.',
+                                           ['index', '-k', '31', 'zzz', '.',
                                             '--sparseness', '1.0'],
                                            in_directory=location)
 

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -219,7 +219,7 @@ def test_compare_containment_abund_flatten(c):
 
 @utils.in_tempdir
 def test_do_traverse_directory_compare(c):
-    c.run_sourmash('compare', '--traverse-directory', '-k 21',
+    c.run_sourmash('compare', '-k 21',
                    '--dna', utils.get_test_data('compare'))
     print(c.last_result.out)
     assert 'genome-s10.fa.gz' in c.last_result.out
@@ -236,7 +236,7 @@ def test_do_traverse_directory_compare_force(c):
     shutil.copyfile(sig1, os.path.join(newdir, 'sig1'))
     shutil.copyfile(sig2, os.path.join(newdir, 'sig2'))
 
-    c.run_sourmash('compare', '--traverse-directory', '-k 21',
+    c.run_sourmash('compare', '-k 21',
                    '--dna', newdir, '-f')
     print(c.last_result.out)
     assert 'genome-s10.fa.gz' in c.last_result.out

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -1516,7 +1516,7 @@ def test_search_metagenome_traverse():
 
         query_sig = utils.get_test_data('gather/combined.sig')
 
-        cmd = 'search {} {} -k 21 --traverse-directory'
+        cmd = 'search {} {} -k 21'
         cmd = cmd.format(query_sig, testdata_dir)
         status, out, err = utils.runscript('sourmash', cmd.split(' '),
                                            in_directory=location)
@@ -3162,7 +3162,7 @@ def test_gather_metagenome_traverse():
         query_sig = utils.get_test_data('gather/combined.sig')
 
         # now, feed in the new directory --
-        cmd = 'gather {} {} -k 21 --traverse-directory --threshold-bp=0'
+        cmd = 'gather {} {} -k 21 --threshold-bp=0'
         cmd = cmd.format(query_sig, copy_testdata)
         status, out, err = utils.runscript('sourmash', cmd.split(' '),
                                            in_directory=location)
@@ -3366,17 +3366,6 @@ def test_gather_save_matches():
         assert os.path.exists(os.path.join(location, 'save.sigs'))
 
 
-@utils.in_thisdir
-def test_gather_error_loading_dir(c):
-    # test gather applied to a directory
-    query = utils.get_test_data('prot/protein/GCA_001593925.1_ASM159392v1_protein.faa.gz.sig')
-    db = utils.get_test_data('prot/protein/')
-
-    with pytest.raises(ValueError) as e:
-        c.run_sourmash('gather', query, db)
-    assert 'Error while reading signatures from' in str(c.last_result.err)
-
-
 @utils.in_tempdir
 def test_gather_error_no_sigs_traverse(c):
     # test gather applied to a directory
@@ -3385,7 +3374,7 @@ def test_gather_error_no_sigs_traverse(c):
     emptydir = c.output('')
 
     with pytest.raises(ValueError) as e:
-        c.run_sourmash('gather', query, emptydir, '--traverse-dir')
+        c.run_sourmash('gather', query, emptydir)
 
     err = c.last_result.err
     print(err)

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -3662,7 +3662,7 @@ def test_sbt_categorize():
         status, out, err = utils.runscript('sourmash', args,
                                            in_directory=location)
 
-        args = ['categorize', 'zzz', '--traverse-directory', '.',
+        args = ['categorize', 'zzz', '.',
                 '--ksize', '21', '--dna', '--csv', 'out.csv']
         status, out, err = utils.runscript('sourmash', args,
                                            in_directory=location)
@@ -3776,7 +3776,7 @@ def test_sbt_categorize_already_done_traverse():
         with open(os.path.join(location, 'in.csv'), 'wt') as fp:
             fp.write('./4.sig,genome-s10.fa.gz,0.50')
 
-        args = ['categorize', 'zzz', '--traverse-directory', '.',
+        args = ['categorize', 'zzz', '.',
                 '--ksize', '21', '--dna', '--load-csv', 'in.csv']
         status, out, err = utils.runscript('sourmash', args,
                                            in_directory=location)
@@ -3803,7 +3803,7 @@ def test_sbt_categorize_multiple_ksizes_moltypes():
         status, out, err = utils.runscript('sourmash', args,
                                            in_directory=location)
 
-        args = ['categorize', 'zzz', '--traverse-directory', '.']
+        args = ['categorize', 'zzz', '.']
         status, out, err = utils.runscript('sourmash', args,
                                            in_directory=location, fail_ok=True)
 


### PR DESCRIPTION
Old behavior in 2.x and 3.x: when the user wants to load all signatures from under a directory, they must specify `--traverse-directory` to the command.

New behavior: if a directory is provided on the command line, it is automatically traversed for signatures (`*.sig`). `-f` still forces loading filenames that do not end with `.sig`.

This PR also modifies `sourmash_args.load_dbs_sigs(...)`, `.load_file_as_index(...)`, and `load_file_as_signatures(...)`  to no longer take a `traverse`argument.

Fixes #836
Fixes #1061 

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make coverage` Is the new code covered?
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
