### PR TITLE
make cmdline sigs optional for index

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ jobs:
   include:
     - &test
       stage: test
-      python: 3.7
+      python: 3.7.9
     - <<: *test
       python: 3.8
       env:
@@ -101,13 +101,13 @@ jobs:
         - redis
         - docker
     - <<: *test
-      python: 3.7
+      python: 3.7.9
       env:
         - TOXENV=docs
 
     - &wheel
       stage: build wheel and send to github releases
-      python: 3.7
+      python: 3.7.9
       services:
         - docker
       env:

--- a/sourmash/cli/index.py
+++ b/sourmash/cli/index.py
@@ -33,7 +33,7 @@ def subparser(subparsers):
                                       usage=usage)
     subparser.add_argument('sbt_name', help='name to save index into; .sbt.zip or .sbt.json file')
     subparser.add_argument(
-        'signatures', nargs='+',
+        'signatures', nargs='*',
         help='signatures to load into SBT'
     )
     subparser.add_argument(


### PR DESCRIPTION
Makes the signatures positional arg optional for `sourmash index`. This frees the user to only pass in signatures from a file or load a file as signatures.

This change means that the positional arguments need to be placed properly: first the index name, then zero or more signature files. To account for this, I changed the order of args in failing tests using `index`.

I also added an index test (`test_index_metagenome_fromfile_no_cmdline_sig`)that does not provide any command line sigs.


- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make coverage` Is the new code covered?
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.

fixes #1066