### PR TITLE
[WIP] SBT scaffold

### DIFF
--- a/include/sourmash.h
+++ b/include/sourmash.h
@@ -263,6 +263,8 @@ uintptr_t nodegraph_get_kmer(const SourmashNodegraph *ptr, const char *kmer);
 
 const uint64_t *nodegraph_hashsizes(const SourmashNodegraph *ptr, uintptr_t *size);
 
+uintptr_t nodegraph_intersection_count(const SourmashNodegraph *ptr, const SourmashNodegraph *optr);
+
 uintptr_t nodegraph_ksize(const SourmashNodegraph *ptr);
 
 uintptr_t nodegraph_matches(const SourmashNodegraph *ptr, const SourmashKmerMinHash *mh_ptr);

--- a/sourmash/cli/index.py
+++ b/sourmash/cli/index.py
@@ -55,7 +55,9 @@ def subparser(subparsers):
     )
     subparser.add_argument(
         '-x', '--bf-size', metavar='S', type=float, default=1e5,
-        help='Bloom filter size used for internal nodes'
+        help='Maximum Bloom filter size used for internal nodes. Set to 0 '
+             'to calculate an optimal size given the complexity of the datasets '
+             '(using a HyperLogLog to estimate the number of unique k-mers'
     )
     subparser.add_argument(
         '-f', '--force', action='store_true',

--- a/sourmash/commands.py
+++ b/sourmash/commands.py
@@ -12,7 +12,6 @@ from . import MinHash, load_sbt_index, create_sbt_index
 from . import signature as sig
 from . import sourmash_args
 from .logging import notify, error, print_results, set_quiet
-from .sbt import scaffold
 from .sbtmh import SearchMinHashesFindBest, SigLeaf
 
 from .sourmash_args import DEFAULT_LOAD_K, FileOutput
@@ -332,10 +331,13 @@ def index(args):
     if args.append:
         tree = load_sbt_index(args.sbt_name)
     else:
-        tree = create_sbt_index(args.bf_size, n_children=args.n_children)
+        bf_size = args.bf_size
+        if bf_size == 0:
+            bf_size = None
+
+        tree = create_sbt_index(bf_size, n_children=args.n_children)
         batch = True
         # TODO: set up storage here
-        # TODO: deal with factory and args.bf_size too?
 
     if args.sparseness < 0 or args.sparseness > 1.0:
         error('sparseness must be in range [0.0, 1.0].')

--- a/sourmash/commands.py
+++ b/sourmash/commands.py
@@ -337,7 +337,10 @@ def index(args):
 
         tree = create_sbt_index(bf_size, n_children=args.n_children)
         batch = True
+
         # TODO: set up storage here
+        storage_info = tree._setup_storage(args.sbt_name)
+        tree.storage = storage_info.storage
 
     if args.sparseness < 0 or args.sparseness > 1.0:
         error('sparseness must be in range [0.0, 1.0].')
@@ -415,6 +418,10 @@ def index(args):
         sys.exit(-1)
 
     notify('loaded {} sigs; saving SBT under "{}"', n, args.sbt_name)
+    # TODO: if all nodes are already saved (like in the scaffold/batch case)
+    # we can potentially set structure_only=True here. An alternative is to
+    # modify Node.save to verify if the data is already saved or still need to
+    # be saved (dirty flag?)
     tree.save(args.sbt_name, sparseness=args.sparseness)
 
 

--- a/sourmash/nodegraph.py
+++ b/sourmash/nodegraph.py
@@ -88,6 +88,14 @@ class Nodegraph(RustObject):
 
         return self._methodcall(lib.nodegraph_matches, mh._objptr)
 
+    def intersection_count(self, other):
+        if isinstance(other, Nodegraph):
+            return self._methodcall(lib.nodegraph_intersection_count, other._objptr)
+        else:
+            # FIXME: we could take MinHash and sets here too (or anything that can be
+            # converted to a list of ints...)
+            raise TypeError("Must be a Nodegraph")
+
     def to_khmer_nodegraph(self):
         import khmer
         try:

--- a/sourmash/sbt_storage.py
+++ b/sourmash/sbt_storage.py
@@ -72,6 +72,10 @@ class FSStorage(Storage):
                     newpath = "{}_{}".format(path, n)
 
         fullpath = os.path.join(self.location, self.subdir, newpath)
+        dirpath = os.path.dirname(fullpath)
+        if not os.path.exists(dirpath):
+            os.makedirs(dirpath)
+
         with open(fullpath, 'wb') as f:
             f.write(content)
 

--- a/sourmash/sbtmh.py
+++ b/sourmash/sbtmh.py
@@ -15,7 +15,10 @@ def load_sbt_index(filename, *, print_version_warning=True, cache_size=None):
 
 def create_sbt_index(bloom_filter_size=1e5, n_children=2):
     "Create an empty SBT index."
-    factory = GraphFactory(1, bloom_filter_size, 4)
+    if bloom_filter_size == 0:
+        factory = None
+    else:
+        factory = GraphFactory(1, bloom_filter_size, 4)
     tree = SBT(factory, d=n_children)
     return tree
 

--- a/src/core/src/ffi/nodegraph.rs
+++ b/src/core/src/ffi/nodegraph.rs
@@ -150,6 +150,18 @@ pub unsafe extern "C" fn nodegraph_update(
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn nodegraph_intersection_count(
+    ptr: *const SourmashNodegraph,
+    optr: *const SourmashNodegraph,
+) -> usize {
+    let ng = SourmashNodegraph::as_rust(ptr);
+    let ong = SourmashNodegraph::as_rust(optr);
+
+    // FIXME raise an exception properly
+    ng.intersection_count(ong)
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn nodegraph_update_mh(
     ptr: *mut SourmashNodegraph,
     optr: *const SourmashKmerMinHash,

--- a/src/core/src/sketch/hyperloglog/estimators.rs
+++ b/src/core/src/sketch/hyperloglog/estimators.rs
@@ -32,7 +32,7 @@ pub fn mle(counts: &[u16], p: usize, q: usize, relerr: f64) -> f64 {
 
     let mut z = 0.;
     for i in num_iter::range_step_inclusive(k_max_prime as i32, k_min_prime as i32, -1) {
-        z = 0.5 * z + counts[i as usize] as f64;
+        z = 0.5 * z + (counts[i as usize] as f64);
     }
 
     // ldexp(x, i) = x * (2 ** i)

--- a/src/core/src/sketch/nodegraph.rs
+++ b/src/core/src/sketch/nodegraph.rs
@@ -289,31 +289,29 @@ impl Nodegraph {
         self.unique_kmers
     }
 
-    pub fn similarity(&self, other: &Nodegraph) -> f64 {
-        let result: usize = self
-            .bs
+    pub fn intersection_count(&self, other: &Nodegraph) -> usize {
+        self.bs
             .iter()
             .zip(&other.bs)
             .map(|(bs, bs_other)| bs.intersection(bs_other).count())
-            .sum();
+            .sum()
+    }
+
+    pub fn similarity(&self, other: &Nodegraph) -> f64 {
+        let intersection = self.intersection_count(other);
         let size: usize = self
             .bs
             .iter()
             .zip(&other.bs)
             .map(|(bs, bs_other)| bs.union(bs_other).count())
             .sum();
-        result as f64 / size as f64
+        intersection as f64 / size as f64
     }
 
     pub fn containment(&self, other: &Nodegraph) -> f64 {
-        let result: usize = self
-            .bs
-            .iter()
-            .zip(&other.bs)
-            .map(|(bs, bs_other)| bs.intersection(bs_other).count())
-            .sum();
+        let intersection = self.intersection_count(other);
         let size: usize = self.bs.iter().map(|bs| bs.len()).sum();
-        result as f64 / size as f64
+        intersection as f64 / size as f64
     }
 }
 


### PR DESCRIPTION
Add a new function `scaffold` that takes a list of signatures and build an SBT clustered by shared hashes.

At the moment still uses the same amount of memory, but building by levels (from bottom up) allows saving each node as they are built, and then unload them as the next level is built.

This replaces the `tree.insert(sig)` approach in `sourmash index`, with a fallback to the regular insertion code if `--append` is set.

## TODO

- [x] set up storage properly, so we can start saving leaves (and later internal levels) as they are built
- [ ] more benchmarks
- [ ] Test more corner cases
- [ ] more comments about how it works (HowDe SBT does distances-with-maxheap too)
- [x] Use an HLL to count unique k-mers when loading sigs, and then set the `GraphFactory` with it

## Checklist

- [ ] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make coverage` Is the new code covered?
- [ ] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
