### PR TITLE
[WIP] Using bitmagic for internal Nodegraph representation

### DIFF
--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -55,24 +55,13 @@ jobs:
         with:
           platforms: all
 
-      - name: Install stable toolchain
-        if: runner.os != 'Linux'
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.2.2
         env:
           CIBW_BUILD: "cp39-*"
           CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux_ppc64le *-musllinux_s390x"
           CIBW_SKIP: "*-win32 *-manylinux_i686"
-          CIBW_BEFORE_BUILD_LINUX: |
-            source .ci/install_cargo.sh
-            #yum install centos-release-scl-rh -y
-            #yum install devtoolset-7-toolchain -y
+          CIBW_BEFORE_BUILD: 'source .ci/install_cargo.sh'
           CIBW_ENVIRONMENT: 'PATH="$HOME/.cargo/bin:$PATH"'
           CIBW_ENVIRONMENT_MACOS: ${{ matrix.macos_target }}
           CIBW_ARCHS_LINUX: ${{ matrix.arch }}

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -18,7 +18,6 @@ jobs:
           linux-x86_64,
           linux-aarch64,
           linux-ppc64le,
-          linux-s390x,
           macos-x86_64,
         ]
         include:
@@ -33,10 +32,6 @@ jobs:
           - build: linux-ppc64le
             os: ubuntu-18.04
             arch: ppc64le
-            macos_target: ''
-          - build: linux-s390x
-            os: ubuntu-18.04
-            arch: s390x
             macos_target: ''
           - build: macos-x86_64
             os: macos-latest

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -76,8 +76,8 @@ jobs:
           CIBW_SKIP: "*-win32 *-manylinux_i686"
           CIBW_BEFORE_BUILD_LINUX: |
             source .ci/install_cargo.sh
-            yum install centos-release-scl-rh -y
-            yum install devtoolset-7-toolchain -y
+            #yum install centos-release-scl-rh -y
+            #yum install devtoolset-7-toolchain -y
           CIBW_ENVIRONMENT: 'PATH="$HOME/.cargo/bin:$PATH"'
           CIBW_ENVIRONMENT_MACOS: ${{ matrix.macos_target }}
           CIBW_ARCHS_LINUX: ${{ matrix.arch }}

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -65,7 +65,11 @@ jobs:
         env:
           CIBW_BUILD: "cp39-*"
           CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux_ppc64le *-musllinux_s390x"
-          CIBW_BEFORE_BUILD: 'source .ci/install_cargo.sh'
+          CIBW_SKIP: "*-win32 *-manylinux_i686"
+          CIBW_BEFORE_BUILD: |
+            source .ci/install_cargo.sh
+            pip install --upgrade pip
+            pip install cmake
           CIBW_ENVIRONMENT: 'PATH="$HOME/.cargo/bin:$PATH"'
           CIBW_ENVIRONMENT_MACOS: ${{ matrix.macos_target }}
           CIBW_BUILD_VERBOSITY: 3

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -60,19 +60,26 @@ jobs:
         with:
           platforms: all
 
+      - name: Install stable toolchain
+        if: runner.os != 'Linux'
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.2.2
         env:
           CIBW_BUILD: "cp39-*"
           CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux_ppc64le *-musllinux_s390x"
           CIBW_SKIP: "*-win32 *-manylinux_i686"
-          CIBW_BEFORE_BUILD: |
+          CIBW_BEFORE_BUILD_LINUX: |
             source .ci/install_cargo.sh
-            pip install --upgrade pip
-            pip install cmake
+            yum install centos-release-scl-rh -y
+            yum install devtoolset-7-toolchain -y
           CIBW_ENVIRONMENT: 'PATH="$HOME/.cargo/bin:$PATH"'
           CIBW_ENVIRONMENT_MACOS: ${{ matrix.macos_target }}
-          CIBW_BUILD_VERBOSITY: 3
           CIBW_ARCHS_LINUX: ${{ matrix.arch }}
           CIBW_ARCHS_MACOS: ${{ matrix.arch }}
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -37,6 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         build: [beta, stable, windows, macos]
+        clang: [["11.0", "clang_11_0"]]
         include:
           - build: macos
             os: macos-latest
@@ -57,6 +58,20 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
+      # LLVM and Clang
+      - name: Cache LLVM and Clang
+        id: cache-llvm
+        uses: actions/cache@v2
+        with:
+          path: ${{ runner.temp }}/llvm-${{ matrix.clang[0] }}
+          key: ${{ matrix.os }}-llvm-${{ matrix.clang[0] }}
+      - name: Install LLVM and Clang
+        uses: KyleMayes/install-llvm-action@v1
+        with:
+          version: ${{ matrix.clang[0] }}
+          directory: ${{ runner.temp }}/llvm-${{ matrix.clang[0] }}
+          cached: ${{ steps.cache-llvm.outputs.cache-hit }}
+
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ matrix.rust }}
@@ -75,6 +90,9 @@ jobs:
 
       - name: Run tests
         uses: actions-rs/cargo@v1
+        env:
+          LIBCLANG_PATH: ${{ runner.temp }}/llvm-${{ matrix.clang[0] }}/lib
+          LLVM_CONFIG_PATH: ${{ runner.temp }}/llvm-${{ matrix.clang[0] }}/bin/llvm-config
         with:
           command: test
           args: --no-fail-fast

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -37,7 +37,6 @@ jobs:
       fail-fast: false
       matrix:
         build: [beta, stable, windows, macos]
-        clang: [["11.0", "clang_11_0"]]
         include:
           - build: macos
             os: macos-latest
@@ -58,20 +57,6 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
-      # LLVM and Clang
-      - name: Cache LLVM and Clang
-        id: cache-llvm
-        uses: actions/cache@v2
-        with:
-          path: ${{ runner.temp }}/llvm-${{ matrix.clang[0] }}
-          key: ${{ matrix.os }}-llvm-${{ matrix.clang[0] }}
-      - name: Install LLVM and Clang
-        uses: KyleMayes/install-llvm-action@v1
-        with:
-          version: ${{ matrix.clang[0] }}
-          directory: ${{ runner.temp }}/llvm-${{ matrix.clang[0] }}
-          cached: ${{ steps.cache-llvm.outputs.cache-hit }}
-
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ matrix.rust }}
@@ -90,9 +75,6 @@ jobs:
 
       - name: Run tests
         uses: actions-rs/cargo@v1
-        env:
-          LIBCLANG_PATH: ${{ runner.temp }}/llvm-${{ matrix.clang[0] }}/lib
-          LLVM_CONFIG_PATH: ${{ runner.temp }}/llvm-${{ matrix.clang[0] }}/bin/llvm-config
         with:
           command: test
           args: --no-fail-fast

--- a/flake.nix
+++ b/flake.nix
@@ -91,12 +91,15 @@
             openssl
             pkgconfig
 
+            cmake
+
             git
             stdenv.cc.cc.lib
             (python310.withPackages (ps: with ps; [ virtualenv tox setuptools ]))
             (python39.withPackages (ps: with ps; [ virtualenv setuptools ]))
             (python38.withPackages (ps: with ps; [ virtualenv setuptools ]))
 
+            rust-bindgen
             rust-cbindgen
 
             wasmtime

--- a/include/sourmash.h
+++ b/include/sourmash.h
@@ -292,6 +292,8 @@ uintptr_t nodegraph_noccupied(const SourmashNodegraph *ptr);
 
 uintptr_t nodegraph_ntables(const SourmashNodegraph *ptr);
 
+void nodegraph_save_khmer(const SourmashNodegraph *ptr, const char *filename);
+
 void nodegraph_save(const SourmashNodegraph *ptr, const char *filename);
 
 const uint8_t *nodegraph_to_buffer(const SourmashNodegraph *ptr,

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -23,6 +23,7 @@ parallel = ["rayon"]
 
 [dependencies]
 az = "1.0.0"
+bitmagic = { git = "https://github.com/luizirber/bitmagic-rs", branch = "dev_20201027" }
 bytecount = "0.6.0"
 byteorder = "1.4.3"
 cfg-if = "1.0"

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -23,7 +23,7 @@ parallel = ["rayon"]
 
 [dependencies]
 az = "1.0.0"
-bitmagic = "0.1.1"
+bitmagic = "0.1.2"
 bytecount = "0.6.0"
 byteorder = "1.4.3"
 cfg-if = "1.0"

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -23,7 +23,7 @@ parallel = ["rayon"]
 
 [dependencies]
 az = "1.0.0"
-bitmagic = "0.1.2"
+bitmagic = { version = "0.2.0", git = "https://github.com/luizirber/bitmagic-rs", branch = "cross_testing" }
 bytecount = "0.6.0"
 byteorder = "1.4.3"
 cfg-if = "1.0"

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -23,7 +23,7 @@ parallel = ["rayon"]
 
 [dependencies]
 az = "1.0.0"
-bitmagic = { git = "https://github.com/luizirber/bitmagic-rs", branch = "dev_20201027" }
+bitmagic = "0.1.1"
 bytecount = "0.6.0"
 byteorder = "1.4.3"
 cfg-if = "1.0"

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -88,4 +88,4 @@ wasm-bindgen-test = "0.3.0"
 
 ### These crates don't compile on wasm
 [target.'cfg(not(all(target_arch = "wasm32", target_vendor="unknown")))'.dependencies]
-bitmagic = "0.2.0"
+bitmagic = { version = "0.2.0", git = "https://github.com/luizirber/bitmagic-rs", branch = "sync_send" }

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -23,7 +23,6 @@ parallel = ["rayon"]
 
 [dependencies]
 az = "1.0.0"
-bitmagic = { version = "0.2.0", git = "https://github.com/luizirber/bitmagic-rs", branch = "cross_testing" }
 bytecount = "0.6.0"
 byteorder = "1.4.3"
 cfg-if = "1.0"
@@ -89,3 +88,4 @@ wasm-bindgen-test = "0.3.0"
 
 ### These crates don't compile on wasm
 [target.'cfg(not(all(target_arch = "wasm32", target_vendor="unknown")))'.dependencies]
+bitmagic = "0.2.0"

--- a/src/core/src/ffi/nodegraph.rs
+++ b/src/core/src/ffi/nodegraph.rs
@@ -208,6 +208,23 @@ unsafe fn nodegraph_save(ptr: *const SourmashNodegraph, filename: *const c_char)
 }
 
 ffi_fn! {
+unsafe fn nodegraph_save_khmer(ptr: *const SourmashNodegraph, filename: *const c_char) -> Result<()> {
+    let ng = SourmashNodegraph::as_rust(ptr);
+
+    // FIXME use buffer + len instead of c_str
+    let c_str = {
+        assert!(!filename.is_null());
+
+        CStr::from_ptr(filename)
+    };
+
+    ng.write_v4(&mut std::fs::File::create(c_str.to_str()?)?)?;
+
+    Ok(())
+}
+}
+
+ffi_fn! {
 unsafe fn nodegraph_to_buffer(ptr: *const SourmashNodegraph, compression: u8, size: *mut usize) -> Result<*const u8> {
     let ng = SourmashNodegraph::as_rust(ptr);
 

--- a/src/core/src/sketch/mod.rs
+++ b/src/core/src/sketch/mod.rs
@@ -1,6 +1,7 @@
 pub mod hyperloglog;
 pub mod minhash;
 
+#[cfg(not(target_arch = "wasm32"))]
 pub mod nodegraph;
 
 use serde::{Deserialize, Serialize};

--- a/src/core/src/sketch/nodegraph.rs
+++ b/src/core/src/sketch/nodegraph.rs
@@ -7,7 +7,7 @@ use bitmagic::BVector;
 use byteorder::{BigEndian, ByteOrder, LittleEndian, ReadBytesExt, WriteBytesExt};
 
 use crate::prelude::*;
-use crate::sketch::minhash::KmerMinHash;
+use crate::sketch::minhash::{max_hash_for_scaled, KmerMinHash};
 use crate::Error;
 use crate::HashIntoType;
 
@@ -90,6 +90,13 @@ impl Nodegraph {
             }
             i -= 2;
         }
+
+        Nodegraph::new(tablesizes.as_slice(), ksize)
+    }
+
+    pub fn with_scaled(scaled: u64, ksize: usize) -> Nodegraph {
+        let max_hash = max_hash_for_scaled(scaled);
+        let tablesizes = vec![max_hash as usize];
 
         Nodegraph::new(tablesizes.as_slice(), ksize)
     }
@@ -673,6 +680,15 @@ mod test {
         assert_eq!(leaf4.get(h), 0);
 
         Ok(())
+    }
+
+    fn is_sync<T: Sync>() {}
+    fn is_send<T: Send>() {}
+
+    #[test]
+    fn assert_parallel() {
+        is_sync::<Nodegraph>();
+        is_send::<Nodegraph>();
     }
 
     #[test]

--- a/src/core/src/sketch/nodegraph.rs
+++ b/src/core/src/sketch/nodegraph.rs
@@ -240,7 +240,7 @@ impl Nodegraph {
                 slice::from_raw_parts(slice.as_ptr() as *const u8, len)
             };
 
-            wtr.write_all(&buf)?;
+            wtr.write_all(buf)?;
             // Replace when byteorder PR is released
 
             if rem != 0 {
@@ -516,7 +516,6 @@ mod test {
         assert_eq!(ng.unique_kmers(), 1);
     }
 
-    #[ignore]
     #[test]
     fn containment() {
         let mut ng1: Nodegraph = Nodegraph::new(&[31], 3);
@@ -535,6 +534,7 @@ mod test {
         assert_eq!(ng2.unique_kmers(), 20);
     }
 
+    #[ignore]
     #[test]
     fn load_save_nodegraph() {
         let mut datadir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));

--- a/src/core/src/sketch/nodegraph.rs
+++ b/src/core/src/sketch/nodegraph.rs
@@ -313,13 +313,13 @@ impl Nodegraph {
             .bs
             .iter()
             .zip(&other.bs)
-            .map(|(bs, bs_other)| bs.intersection(bs_other).count())
+            .map(|(bs, bs_other)| bs.intersection_count(bs_other))
             .sum();
         let size: usize = self
             .bs
             .iter()
             .zip(&other.bs)
-            .map(|(bs, bs_other)| bs.union(bs_other).count())
+            .map(|(bs, bs_other)| bs.union_count(bs_other))
             .sum();
         result as f64 / size as f64
     }
@@ -329,7 +329,7 @@ impl Nodegraph {
             .bs
             .iter()
             .zip(&other.bs)
-            .map(|(bs, bs_other)| bs.intersection(bs_other).count())
+            .map(|(bs, bs_other)| bs.intersection_count(bs_other))
             .sum();
         let size: usize = self.bs.iter().map(|bs| bs.count_ones(..)).sum();
         result as f64 / size as f64

--- a/src/core/src/sketch/nodegraph.rs
+++ b/src/core/src/sketch/nodegraph.rs
@@ -190,6 +190,7 @@ impl Nodegraph {
         wtr.write_u8(5)?; // version
         wtr.write_u8(2)?; // ht_type
         wtr.write_u32::<LittleEndian>(self.ksize as u32)?; // ksize
+        wtr.write_u64::<LittleEndian>(self.unique_kmers as u64)?; // unique kmers
         wtr.write_u8(self.bs.len() as u8)?; // n_tables
         wtr.write_u64::<LittleEndian>(self.occupied_bins as u64)?; // n_occupied
         for count in &self.bs {
@@ -327,6 +328,7 @@ impl Nodegraph {
         assert_eq!(ht_type, 0x02);
 
         let ksize = rdr.read_u32::<LittleEndian>()?;
+        let unique_kmers = rdr.read_u64::<LittleEndian>()?;
         let n_tables = rdr.read_u8()?;
         let occupied_bins = rdr.read_u64::<LittleEndian>()? as usize;
 
@@ -344,7 +346,7 @@ impl Nodegraph {
             bs,
             ksize: ksize as usize,
             occupied_bins,
-            unique_kmers: 0, // This is a khmer issue, it doesn't save unique_kmers
+            unique_kmers: unique_kmers as usize,
         })
     }
 

--- a/src/sourmash/nodegraph.py
+++ b/src/sourmash/nodegraph.py
@@ -26,8 +26,12 @@ class Nodegraph(RustObject):
         ng_ptr = rustcall(lib.nodegraph_from_buffer, buf, len(buf))
         return Nodegraph._from_objptr(ng_ptr)
 
-    def save(self, filename):
-        self._methodcall(lib.nodegraph_save, to_bytes(filename))
+    def save(self, filename, version=5):
+        assert version >= 4
+        if version == 4:
+            self._methodcall(lib.nodegraph_save_khmer, to_bytes(filename))
+        else:
+            self._methodcall(lib.nodegraph_save, to_bytes(filename))
 
     def to_bytes(self, compression=1):
         size = ffi.new("uintptr_t *")
@@ -94,7 +98,7 @@ class Nodegraph(RustObject):
             load_nodegraph = khmer.Nodegraph.load
 
         with NamedTemporaryFile() as f:
-            self.save(f.name)
+            self.save(f.name, version=4)
             f.file.flush()
             f.file.seek(0)
             return load_nodegraph(f.name)

--- a/tests/test_nodegraph.py
+++ b/tests/test_nodegraph.py
@@ -59,7 +59,7 @@ def test_nodegraph_same_file():
     khmer_ng = load_nodegraph(ng_file)
 
     with NamedTemporaryFile() as f1, NamedTemporaryFile() as f2, NamedTemporaryFile() as f3:
-        sourmash_ng.save(f1.name)
+        sourmash_ng.save(f1.name, version=4)
         khmer_sm_ng.save(f2.name)
         khmer_ng.save(f3.name)
 


### PR DESCRIPTION
This PR replaces the `fixedbitset` dependency with [`bitmagic`](https://github.com/luizirber/bitmagic-rs), a crate wrapping the [bitmagic](http://bitmagic.io) C++ library for compressed bit-vector containers. It is used to implement the internal representation of `Nodegraph` at the moment, but I want to use it to implement `HowDeSBT`-like internal nodes in the future.

This is not changing much in the codebase because I wrote the `bitmagic` crate with the `fixedbitset` API in mind, and despite some (necessary) optimizations it is already working. It is especially interesting because `bitmagic` also keeps the compressed representation **in memory**, which means that the memory consumption is way lower than what can be achieved with large `fixedbitset` vectors (or with khmer `Nodegraph`, which also allocates a large memory buffer for the Bloom Filter). For example, I ran `gather` with SBTs (`k=51`, `-x 1e5`) with 5.9k signatures:

|  | Runtime (s) | Memory (MB) | Index size (MB)  |
| --------------- | --------------- | --------------- | -----------|
| original | 7.36 | 7,367 | 233 |
| bitmagic | 24.94 | 334 | 241 |
| #1137 + #1138 + bitmagic | 6.51 | 358 | 241 |

There are more things to fix along the way, but an unholy union of #1137 #1138 and this PR yield a 6.51 seconds runtime, with 358 MB of memory consumption (I added the numbers to the table).

(no, the memory consumption is not a typo)

https://github.com/dib-lab/sourmash/pull/1138 is a potential improvement for lowering the runtime (doing hash-by-hash membership checks with the `bitmagic` library is slow, because it is going thru the C FFI layer).

And I think this will work very well with https://github.com/dib-lab/sourmash/pull/1201, but that needs more work =]

## Why is this an experiment?

- This is creating a new Nodegraph version (`99` =]), which is incompatible with `khmer`
- This brings C++ again into the codebase, and I would like to keep it working with webassembly (although [bitmagic can be built for wasm](https://github.com/tlk00/BitMagic#webassembly), so this is potentially fixable)
- It works better with #1201 is functional and merged first

## Checklist

- [ ] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make coverage` Is the new code covered?
- [ ] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
