### PR TITLE
[MRG] Accept file list in `sourmash sig cat`

### DIFF
--- a/sourmash/sourmash_args.py
+++ b/sourmash/sourmash_args.py
@@ -402,6 +402,21 @@ def _load_database(filename, traverse_yield_all, *, cache_size=None):
     except Exception as exc:
         pass
 
+    if not loaded:   # try load signatures from single file (list of signature paths)
+        try:
+            db = []
+            with open(filename, 'rt') as fp:
+                for line in fp:
+                    line = line.strip()
+                    if line:
+                        sig = sourmash.load_signatures(line, quiet=True, do_raise=True)
+                        db += list(sig)
+
+            loaded = True
+            dbtype = DatabaseType.SIGLIST
+        except Exception as exc:
+            pass
+
     if not loaded:                    # try load as SBT
         try:
             db = load_sbt_index(filename, cache_size=cache_size)

--- a/sourmash/sourmash_args.py
+++ b/sourmash/sourmash_args.py
@@ -409,8 +409,8 @@ def _load_database(filename, traverse_yield_all, *, cache_size=None):
                 for line in fp:
                     line = line.strip()
                     if line:
-                        sig = sourmash.load_signatures(line, quiet=True, do_raise=True)
-                        db += list(sig)
+                        sigs = load_file_as_signatures(line)
+                        db += list(sigs)
 
             loaded = True
             dbtype = DatabaseType.SIGLIST

--- a/tests/test_cmd_signature.py
+++ b/tests/test_cmd_signature.py
@@ -763,6 +763,28 @@ def test_sig_cat_filelist(c):
     assert repr(siglist) == """[SourmashSignature('NC_009665.1 Shewanella baltica OS185, complete genome', 09a08691), SourmashSignature('NC_009665.1 Shewanella baltica OS185, complete genome', 09a08691), SourmashSignature('NC_009665.1 Shewanella baltica OS185, complete genome', 57e2b22f), SourmashSignature('NC_009661.1 Shewanella baltica OS185 plasmid pS18501, complete sequence', bde81a41), SourmashSignature('NC_011663.1 Shewanella baltica OS223, complete genome', f033bbd8), SourmashSignature('NC_011664.1 Shewanella baltica OS223 plasmid pS22301, complete sequence', 87a9aec4), SourmashSignature('NC_011668.1 Shewanella baltica OS223 plasmid pS22302, complete sequence', 837bf2a7), SourmashSignature('NC_011665.1 Shewanella baltica OS223 plasmid pS22303, complete sequence', 485c3377)]"""
 
 
+@utils.in_tempdir
+def test_sig_cat_filelist_with_dbs(c):
+    # cat using a file list as input
+    sig47 = utils.get_test_data('47.fa.sig')
+    sig47abund = utils.get_test_data('track_abund/47.fa.sig')
+    sbt = utils.get_test_data('v6.sbt.zip')
+
+    filelist = c.output("filelist")
+    with open(filelist, 'w') as f:
+        f.write("\n".join((sig47, sig47abund, sbt)))
+
+    c.run_sourmash('sig', 'cat', filelist,
+                   '-o', 'out.sig')
+
+    # stdout should be same signatures
+    out = c.output('out.sig')
+
+    siglist = list(sourmash.load_signatures(out))
+    print(len(siglist))
+
+    assert repr(siglist) == """[SourmashSignature('NC_009665.1 Shewanella baltica OS185, complete genome', 09a08691), SourmashSignature('NC_009665.1 Shewanella baltica OS185, complete genome', 09a08691), SourmashSignature('', 6d6e87e1), SourmashSignature('', 60f7e23c), SourmashSignature('', 0107d767), SourmashSignature('', f71e7817), SourmashSignature('', f0c834bc), SourmashSignature('', 4e94e602), SourmashSignature('', b59473c9)]"""
+
 
 @utils.in_tempdir
 def test_sig_split_1(c):

--- a/tests/test_cmd_signature.py
+++ b/tests/test_cmd_signature.py
@@ -741,6 +741,30 @@ def test_sig_cat_2_out_inplace(c):
 
 
 @utils.in_tempdir
+def test_sig_cat_filelist(c):
+    # cat using a file list as input
+    sig47 = utils.get_test_data('47.fa.sig')
+    sig47abund = utils.get_test_data('track_abund/47.fa.sig')
+    multisig = utils.get_test_data('47+63-multisig.sig')
+
+    filelist = c.output("filelist")
+    with open(filelist, 'w') as f:
+        f.write("\n".join((sig47, sig47abund, multisig)))
+
+    c.run_sourmash('sig', 'cat', filelist,
+                   '-o', 'out.sig')
+
+    # stdout should be same signatures
+    out = c.output('out.sig')
+
+    siglist = list(sourmash.load_signatures(out))
+    print(len(siglist))
+
+    assert repr(siglist) == """[SourmashSignature('NC_009665.1 Shewanella baltica OS185, complete genome', 09a08691), SourmashSignature('NC_009665.1 Shewanella baltica OS185, complete genome', 09a08691), SourmashSignature('NC_009665.1 Shewanella baltica OS185, complete genome', 57e2b22f), SourmashSignature('NC_009661.1 Shewanella baltica OS185 plasmid pS18501, complete sequence', bde81a41), SourmashSignature('NC_011663.1 Shewanella baltica OS223, complete genome', f033bbd8), SourmashSignature('NC_011664.1 Shewanella baltica OS223 plasmid pS22301, complete sequence', 87a9aec4), SourmashSignature('NC_011668.1 Shewanella baltica OS223 plasmid pS22302, complete sequence', 837bf2a7), SourmashSignature('NC_011665.1 Shewanella baltica OS223 plasmid pS22303, complete sequence', 485c3377)]"""
+
+
+
+@utils.in_tempdir
 def test_sig_split_1(c):
     # split 47 into 1 sig :)
     sig47 = utils.get_test_data('47.fa.sig')


### PR DESCRIPTION
Current behavior of `sourmash sig cat` doesn't support passing a file list as input. I would like to run `sourmash sig cat filelist.txt` and be able to load signatures from `filelist.txt` (one signature path per line).

I think `load_file_as_signatures` (called [here](https://github.com/dib-lab/sourmash/blob/a6c800ef689fcc8e146a605c6d1fba16b417faaa/sourmash/sig/__main__.py#L77)) is missing the call to [`load_file_list_of_signatures`](https://github.com/dib-lab/sourmash/blob/a6c800ef689fcc8e146a605c6d1fba16b417faaa/sourmash/sourmash_args.py#L510)?

## Checklist

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make coverage` Is the new code covered?
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
