### PR TITLE
[MRG] Move greyhound-core into sourmash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,8 @@ include/sourmash.h: src/core/src/lib.rs \
                     src/core/src/ffi/minhash.rs \
                     src/core/src/ffi/signature.rs \
                     src/core/src/ffi/nodegraph.rs \
+                    src/core/src/ffi/index/mod.rs \
+                    src/core/src/ffi/index/revindex.rs \
                     src/core/src/errors.rs
 	cd src/core && \
 	RUSTC_BOOTSTRAP=1 cbindgen -c cbindgen.toml . -o ../../$@

--- a/doc/developer.md
+++ b/doc/developer.md
@@ -275,13 +275,6 @@ Some installation issues can be solved by simply removing the intermediate build
 make clean
 ```
 
-## Notes on implementing a new `Index`
-
-- required method: `signatures`
-- after that (if there are more efficient impls):
-  * `find`
-  * `search`/`gather`
-
 ## Contents
 
 ```{toctree}

--- a/doc/developer.md
+++ b/doc/developer.md
@@ -275,6 +275,13 @@ Some installation issues can be solved by simply removing the intermediate build
 make clean
 ```
 
+## Notes on implementing a new `Index`
+
+- required method: `signatures`
+- after that (if there are more efficient impls):
+  * `find`
+  * `search`/`gather`
+
 ## Contents
 
 ```{toctree}

--- a/include/sourmash.h
+++ b/include/sourmash.h
@@ -315,6 +315,8 @@ const SourmashSearchResult *const *revindex_gather(const SourmashRevIndex *ptr,
                                                    bool _ignore_abundance,
                                                    uintptr_t *size);
 
+uint64_t revindex_len(const SourmashRevIndex *ptr);
+
 SourmashRevIndex *revindex_new_with_paths(const SourmashStr *const *search_sigs_ptr,
                                           uintptr_t insigs,
                                           const SourmashKmerMinHash *template_ptr,

--- a/include/sourmash.h
+++ b/include/sourmash.h
@@ -52,6 +52,10 @@ typedef struct SourmashKmerMinHash SourmashKmerMinHash;
 
 typedef struct SourmashNodegraph SourmashNodegraph;
 
+typedef struct SourmashRevIndex SourmashRevIndex;
+
+typedef struct SourmashSearchResult SourmashSearchResult;
+
 typedef struct SourmashSignature SourmashSignature;
 
 /**
@@ -301,6 +305,49 @@ void nodegraph_update_mh(SourmashNodegraph *ptr, const SourmashKmerMinHash *optr
 SourmashNodegraph *nodegraph_with_tables(uintptr_t ksize,
                                          uintptr_t starting_size,
                                          uintptr_t n_tables);
+
+void revindex_free(SourmashRevIndex *ptr);
+
+const SourmashSearchResult *const *revindex_gather(const SourmashRevIndex *ptr,
+                                                   const SourmashSignature *sig_ptr,
+                                                   double threshold,
+                                                   bool _do_containment,
+                                                   bool _ignore_abundance,
+                                                   uintptr_t *size);
+
+SourmashRevIndex *revindex_new_with_paths(const SourmashStr *const *search_sigs_ptr,
+                                          uintptr_t insigs,
+                                          const SourmashKmerMinHash *template_ptr,
+                                          uintptr_t threshold,
+                                          const SourmashKmerMinHash *const *queries_ptr,
+                                          uintptr_t inqueries,
+                                          bool keep_sigs);
+
+SourmashRevIndex *revindex_new_with_sigs(const SourmashSignature *const *search_sigs_ptr,
+                                         uintptr_t insigs,
+                                         const SourmashKmerMinHash *template_ptr,
+                                         uintptr_t threshold,
+                                         const SourmashKmerMinHash *const *queries_ptr,
+                                         uintptr_t inqueries);
+
+uint64_t revindex_scaled(const SourmashRevIndex *ptr);
+
+const SourmashSearchResult *const *revindex_search(const SourmashRevIndex *ptr,
+                                                   const SourmashSignature *sig_ptr,
+                                                   double threshold,
+                                                   bool do_containment,
+                                                   bool _ignore_abundance,
+                                                   uintptr_t *size);
+
+SourmashSignature **revindex_signatures(const SourmashRevIndex *ptr, uintptr_t *size);
+
+SourmashStr searchresult_filename(const SourmashSearchResult *ptr);
+
+void searchresult_free(SourmashSearchResult *ptr);
+
+double searchresult_score(const SourmashSearchResult *ptr);
+
+SourmashSignature *searchresult_signature(const SourmashSearchResult *ptr);
 
 void signature_add_protein(SourmashSignature *ptr, const char *sequence);
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ DEBUG_BUILD = os.environ.get("SOURMASH_DEBUG") == "1"
 def build_native(spec):
     cmd = ["cargo", "build",
            "--manifest-path", "src/core/Cargo.toml",
-           "--features", "experimental,parallel",
+           "--features", "parallel",
            "--lib"]
 
     target = "debug"

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ DEBUG_BUILD = os.environ.get("SOURMASH_DEBUG") == "1"
 def build_native(spec):
     cmd = ["cargo", "build",
            "--manifest-path", "src/core/Cargo.toml",
-           "--features", "parallel",
+            # "--features", "parallel",
            "--lib"]
 
     target = "debug"

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,10 @@ DEBUG_BUILD = os.environ.get("SOURMASH_DEBUG") == "1"
 
 
 def build_native(spec):
-    cmd = ["cargo", "build", "--manifest-path", "src/core/Cargo.toml", "--lib"]
+    cmd = ["cargo", "build",
+           "--manifest-path", "src/core/Cargo.toml",
+           "--features", "experimental,parallel",
+           "--lib"]
 
     target = "debug"
     if not DEBUG_BUILD:

--- a/src/core/CHANGELOG.md
+++ b/src/core/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+Added:
+
+- An inverted index, codename Greyhound (#1238)
+
 ## [0.11.0] - 2021-07-07
 
 Added:

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -20,12 +20,14 @@ bench = false
 [features]
 from-finch = ["finch"]
 parallel = ["rayon"]
+experimental = []
 
 [dependencies]
 az = "1.0.0"
 bytecount = "0.6.0"
 byteorder = "1.4.3"
 cfg-if = "1.0"
+counter = "0.5.2"
 finch = { version = "0.4.1", optional = true }
 fixedbitset = "0.4.0"
 getset = "0.1.1"
@@ -42,6 +44,8 @@ serde_json = "1.0.53"
 primal-check = "0.3.1"
 thiserror = "1.0"
 typed-builder = "0.9.0"
+twox-hash = "1.6.0"
+vec-collections = "0.3.4"
 
 [dev-dependencies]
 assert_matches = "1.3.0"

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -93,4 +93,3 @@ wasm-bindgen-test = "0.3.0"
 
 ### These crates don't compile on wasm
 [target.'cfg(not(all(target_arch = "wasm32", target_vendor="unknown")))'.dependencies]
-rocksdb = "0.17.0"

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -46,12 +46,8 @@ thiserror = "1.0"
 typed-builder = "0.9.0"
 twox-hash = "1.6.0"
 vec-collections = "0.3.4"
-#piz = { version = "0.4.0", git = "https://github.com/luizirber/piz-rs", branch = "clone" }
-#piz = { version = "0.4.0", path = "/home/luizirber/prj/piz-rs" }
 piz = "0.4.0"
 memmap2 = "0.5.0"
-zip = { version = "0.5.13", default-features = false }
-rkyv = "0.7.29"
 
 [dev-dependencies]
 assert_matches = "1.3.0"

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -20,7 +20,6 @@ bench = false
 [features]
 from-finch = ["finch"]
 parallel = ["rayon"]
-experimental = []
 
 [dependencies]
 az = "1.0.0"

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -46,6 +46,9 @@ thiserror = "1.0"
 typed-builder = "0.9.0"
 twox-hash = "1.6.0"
 vec-collections = "0.3.4"
+#piz = { version = "0.4.0", git = "https://github.com/luizirber/piz-rs", branch = "clone" }
+piz = "0.4.0"
+memmap2 = "0.5.0"
 
 [dev-dependencies]
 assert_matches = "1.3.0"

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -47,8 +47,11 @@ typed-builder = "0.9.0"
 twox-hash = "1.6.0"
 vec-collections = "0.3.4"
 #piz = { version = "0.4.0", git = "https://github.com/luizirber/piz-rs", branch = "clone" }
+#piz = { version = "0.4.0", path = "/home/luizirber/prj/piz-rs" }
 piz = "0.4.0"
 memmap2 = "0.5.0"
+zip = { version = "0.5.13", default-features = false }
+rkyv = "0.7.29"
 
 [dev-dependencies]
 assert_matches = "1.3.0"
@@ -90,3 +93,4 @@ wasm-bindgen-test = "0.3.0"
 
 ### These crates don't compile on wasm
 [target.'cfg(not(all(target_arch = "wasm32", target_vendor="unknown")))'.dependencies]
+rocksdb = "0.17.0"

--- a/src/core/cbindgen.toml
+++ b/src/core/cbindgen.toml
@@ -8,6 +8,7 @@ clean = true
 
 [parse.expand]
 crates = ["sourmash"]
+features = ["experimental"]
 
 [enum]
 rename_variants = "QualifiedScreamingSnakeCase"

--- a/src/core/cbindgen.toml
+++ b/src/core/cbindgen.toml
@@ -8,7 +8,7 @@ clean = true
 
 [parse.expand]
 crates = ["sourmash"]
-features = ["experimental"]
+features = []
 
 [enum]
 rename_variants = "QualifiedScreamingSnakeCase"

--- a/src/core/src/encodings.rs
+++ b/src/core/src/encodings.rs
@@ -1,11 +1,19 @@
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::convert::TryFrom;
+use std::hash::{BuildHasher, BuildHasherDefault, Hash, Hasher};
 use std::iter::Iterator;
 use std::str;
 
+use nohash_hasher::BuildNoHashHasher;
 use once_cell::sync::Lazy;
 
 use crate::Error;
+
+pub type Color = u64;
+pub type Idx = u64;
+type IdxTracker = (vec_collections::VecSet<[Idx; 4]>, u64);
+type ColorToIdx = HashMap<Color, IdxTracker, BuildNoHashHasher<Color>>;
 
 #[allow(non_camel_case_types)]
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -357,3 +365,202 @@ pub const VALID: [bool; 256] = {
     lookup[b'T' as usize] = true;
     lookup
 };
+
+#[derive(Serialize, Deserialize, Default)]
+pub struct Colors {
+    colors: ColorToIdx,
+}
+
+impl Colors {
+    pub fn new() -> Colors {
+        Default::default()
+    }
+
+    /// Given a color and a new idx, return an updated color
+    ///
+    /// This might create a new one, or find an already existing color
+    /// that contains the new_idx
+    ///
+    /// Future optimization: store a count for each color, so we can track
+    /// if there are extra colors that can be removed at the end.
+    /// (the count is decreased whenever a new color has to be created)
+    pub fn update<'a, I: IntoIterator<Item = &'a Idx>>(
+        &mut self,
+        current_color: Option<Color>,
+        new_idxs: I,
+    ) -> Result<Color, Error> {
+        if let Some(color) = current_color {
+            if let Some(idxs) = self.colors.get_mut(&color) {
+                let idx_to_add: Vec<_> = new_idxs
+                    .into_iter()
+                    .filter(|new_idx| !idxs.0.contains(&new_idx))
+                    .collect();
+
+                if idx_to_add.is_empty() {
+                    // Easy case, it already has all the new_idxs, so just return this color
+                    idxs.1 += 1;
+                    Ok(color)
+                } else {
+                    // We need to either create a new color,
+                    // or find an existing color that have the same idxs
+
+                    let mut idxs = idxs.clone();
+                    idxs.0.extend(idx_to_add.into_iter().cloned());
+                    let new_color = Colors::compute_color(&idxs);
+
+                    if new_color != color {
+                        self.colors.get_mut(&color).unwrap().1 -= 1;
+                        if self.colors[&color].1 == 0 {
+                            self.colors.remove(&color);
+                        };
+                    };
+
+                    self.colors
+                        .entry(new_color)
+                        .and_modify(|old_idxs| {
+                            assert_eq!(old_idxs.0, idxs.0);
+                            old_idxs.1 += 1;
+                        })
+                        .or_insert_with(|| (idxs.0, 1));
+                    Ok(new_color)
+                }
+            } else {
+                unimplemented!("throw error, current_color must exist in order to be updated. current_color: {:?}, colors: {:#?}", current_color, &self.colors);
+            }
+        } else {
+            let mut idxs = IdxTracker::default();
+            idxs.0.extend(new_idxs.into_iter().cloned());
+            idxs.1 = 1;
+            let new_color = Colors::compute_color(&idxs);
+            self.colors
+                .entry(new_color)
+                .and_modify(|old_idxs| {
+                    assert_eq!(old_idxs.0, idxs.0);
+                    old_idxs.1 += 1;
+                })
+                .or_insert_with(|| (idxs.0, 1));
+            Ok(new_color)
+        }
+    }
+
+    fn compute_color(idxs: &IdxTracker) -> Color {
+        let s = BuildHasherDefault::<twox_hash::Xxh3Hash128>::default();
+        let mut hasher = s.build_hasher();
+        idxs.0.hash(&mut hasher);
+        hasher.finish()
+    }
+
+    pub fn len(&self) -> usize {
+        self.colors.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.colors.is_empty()
+    }
+
+    pub fn contains(&self, color: Color, idx: Idx) -> bool {
+        if let Some(idxs) = self.colors.get(&color) {
+            idxs.0.contains(&idx)
+        } else {
+            false
+        }
+    }
+
+    pub fn indices(&self, color: &Color) -> Indices {
+        // TODO: what if color is not present?
+        Indices {
+            iter: self.colors.get(&color).unwrap().0.iter(),
+        }
+    }
+
+    pub fn retain<F>(&mut self, f: F)
+    where
+        F: FnMut(&Color, &mut IdxTracker) -> bool,
+    {
+        self.colors.retain(f)
+    }
+}
+
+pub struct Indices<'a> {
+    iter: vec_collections::VecSetIter<core::slice::Iter<'a, Idx>>,
+}
+
+impl<'a> Iterator for Indices<'a> {
+    type Item = &'a Idx;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn colors_update() {
+        let mut colors = Colors::new();
+
+        let color = colors.update(None, &[1_u64]).unwrap();
+        assert_eq!(colors.len(), 1);
+
+        dbg!("update");
+        let new_color = colors.update(Some(color), &[1_u64]).unwrap();
+        assert_eq!(colors.len(), 1);
+        assert_eq!(color, new_color);
+
+        dbg!("upgrade");
+        let new_color = colors.update(Some(color), &[2_u64]).unwrap();
+        assert_eq!(colors.len(), 2);
+        assert_ne!(color, new_color);
+    }
+
+    #[test]
+    fn colors_retain() {
+        let mut colors = Colors::new();
+
+        let color1 = colors.update(None, &[1_u64]).unwrap();
+        assert_eq!(colors.len(), 1);
+        // used_colors:
+        //   color1: 1
+
+        dbg!("update");
+        let same_color = colors.update(Some(color1), &[1_u64]).unwrap();
+        assert_eq!(colors.len(), 1);
+        assert_eq!(color1, same_color);
+        // used_colors:
+        //   color1: 2
+
+        dbg!("upgrade");
+        let color2 = colors.update(Some(color1), &[2_u64]).unwrap();
+        assert_eq!(colors.len(), 2);
+        assert_ne!(color1, color2);
+        // used_colors:
+        //   color1: 1
+        //   color2: 1
+
+        dbg!("update");
+        let same_color = colors.update(Some(color2), &[2_u64]).unwrap();
+        assert_eq!(colors.len(), 2);
+        assert_eq!(color2, same_color);
+        // used_colors:
+        //   color1: 1
+        //   color1: 2
+
+        dbg!("upgrade");
+        let color3 = colors.update(Some(color1), &[3_u64]).unwrap();
+        assert_ne!(color1, color3);
+        assert_ne!(color2, color3);
+        // used_colors:
+        //   color1: 0
+        //   color2: 2
+        //   color3: 1
+
+        // This is the pre color-count tracker, where it is needed
+        // to call retain to maintain colors
+        //assert_eq!(colors.len(), 3);
+        //colors.retain(|c, _| [color2, color3].contains(c));
+
+        assert_eq!(colors.len(), 2);
+    }
+}

--- a/src/core/src/encodings.rs
+++ b/src/core/src/encodings.rs
@@ -399,7 +399,7 @@ impl Colors {
             if let Some(idxs) = self.colors.get_mut(&color) {
                 let idx_to_add: Vec<_> = new_idxs
                     .into_iter()
-                    .filter(|new_idx| !idxs.0.contains(&new_idx))
+                    .filter(|new_idx| !idxs.0.contains(new_idx))
                     .collect();
 
                 if idx_to_add.is_empty() {
@@ -475,7 +475,7 @@ impl Colors {
     pub fn indices(&self, color: &Color) -> Indices {
         // TODO: what if color is not present?
         Indices {
-            iter: self.colors.get(&color).unwrap().0.iter(),
+            iter: self.colors.get(color).unwrap().0.iter(),
         }
     }
 

--- a/src/core/src/encodings.rs
+++ b/src/core/src/encodings.rs
@@ -10,6 +10,12 @@ use once_cell::sync::Lazy;
 
 use crate::Error;
 
+// To consider there: use a slab allocator for IdxTracker
+// https://twitter.com/tomaka17/status/1391052081272967170
+//   Pro-tip: you might be able to save a lot of hashmap lookups
+//   if you replace a `HashMap<K, V>` with a `HashMap<K, usize>`
+//   and a `Slab<V>`. This might be very useful if K is something
+//   heavy such as a `String`.
 pub type Color = u64;
 pub type Idx = u64;
 type IdxTracker = (vec_collections::VecSet<[Idx; 4]>, u64);

--- a/src/core/src/ffi/index/mod.rs
+++ b/src/core/src/ffi/index/mod.rs
@@ -1,0 +1,38 @@
+#[cfg(feature = "experimental")]
+pub mod revindex;
+
+use crate::signature::Signature;
+
+use crate::ffi::signature::SourmashSignature;
+use crate::ffi::utils::{ForeignObject, SourmashStr};
+
+pub struct SourmashSearchResult;
+
+impl ForeignObject for SourmashSearchResult {
+    type RustObject = (f64, Signature, String);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn searchresult_free(ptr: *mut SourmashSearchResult) {
+    SourmashSearchResult::drop(ptr);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn searchresult_score(ptr: *const SourmashSearchResult) -> f64 {
+    let result = SourmashSearchResult::as_rust(ptr);
+    result.0
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn searchresult_filename(ptr: *const SourmashSearchResult) -> SourmashStr {
+    let result = SourmashSearchResult::as_rust(ptr);
+    (result.2).clone().into()
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn searchresult_signature(
+    ptr: *const SourmashSearchResult,
+) -> *mut SourmashSignature {
+    let result = SourmashSearchResult::as_rust(ptr);
+    SourmashSignature::from_rust((result.1).clone())
+}

--- a/src/core/src/ffi/index/mod.rs
+++ b/src/core/src/ffi/index/mod.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "experimental")]
 pub mod revindex;
 
 use crate::signature::Signature;

--- a/src/core/src/ffi/index/revindex.rs
+++ b/src/core/src/ffi/index/revindex.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 use std::slice;
 
-use crate::index::greyhound::RevIndex;
+use crate::index::revindex::RevIndex;
 use crate::index::Index;
 use crate::signature::{Signature, SigsTrait};
 use crate::sketch::minhash::KmerMinHash;

--- a/src/core/src/ffi/index/revindex.rs
+++ b/src/core/src/ffi/index/revindex.rs
@@ -1,0 +1,236 @@
+use std::path::PathBuf;
+use std::slice;
+
+use crate::index::greyhound::RevIndex;
+use crate::index::Index;
+use crate::signature::{Signature, SigsTrait};
+use crate::sketch::minhash::KmerMinHash;
+use crate::sketch::Sketch;
+
+use crate::ffi::index::SourmashSearchResult;
+use crate::ffi::minhash::SourmashKmerMinHash;
+use crate::ffi::signature::SourmashSignature;
+use crate::ffi::utils::{ForeignObject, SourmashStr};
+
+pub struct SourmashRevIndex;
+
+impl ForeignObject for SourmashRevIndex {
+    type RustObject = RevIndex;
+}
+
+ffi_fn! {
+  unsafe fn revindex_new_with_paths(
+      search_sigs_ptr: *const *const SourmashStr,
+      insigs: usize,
+      template_ptr: *const SourmashKmerMinHash,
+      threshold: usize,
+      queries_ptr: *const *const SourmashKmerMinHash,
+      inqueries: usize,
+      keep_sigs: bool,
+  ) -> Result<*mut SourmashRevIndex> {
+    let search_sigs: Vec<PathBuf> = {
+      assert!(!search_sigs_ptr.is_null());
+        slice::from_raw_parts(search_sigs_ptr, insigs).iter().map(|path| {
+          let mut new_path = PathBuf::new();
+          new_path.push(SourmashStr::as_rust(*path).as_str());
+          new_path}
+          ).collect()
+    };
+
+    let template = {
+      assert!(!template_ptr.is_null());
+      //TODO: avoid clone here
+      Sketch::MinHash(SourmashKmerMinHash::as_rust(template_ptr).clone())
+    };
+
+    let queries_vec: Vec<KmerMinHash>;
+    let queries: Option<&[KmerMinHash]> = if queries_ptr.is_null() {
+      None
+    } else {
+        queries_vec =
+          slice::from_raw_parts(queries_ptr, inqueries).iter().map(|mh_ptr|
+            // TODO: avoid this clone
+          SourmashKmerMinHash::as_rust(*mh_ptr).clone()).collect();
+        Some(queries_vec.as_ref())
+    };
+      let revindex = RevIndex::new(
+        search_sigs.as_ref(),
+        &template,
+        threshold,
+        queries,
+        keep_sigs
+      );
+      Ok(SourmashRevIndex::from_rust(revindex))
+  }
+}
+
+ffi_fn! {
+  unsafe fn revindex_new_with_sigs(
+      search_sigs_ptr: *const *const SourmashSignature,
+      insigs: usize,
+      template_ptr: *const SourmashKmerMinHash,
+      threshold: usize,
+      queries_ptr: *const *const SourmashKmerMinHash,
+      inqueries: usize,
+  ) -> Result<*mut SourmashRevIndex> {
+    let search_sigs: Vec<Signature> = {
+      assert!(!search_sigs_ptr.is_null());
+        slice::from_raw_parts(search_sigs_ptr, insigs).iter().map(|sig|
+          SourmashSignature::as_rust(*sig)
+          ).cloned().collect()
+    };
+
+    let template = {
+      assert!(!template_ptr.is_null());
+      //TODO: avoid clone here
+      Sketch::MinHash(SourmashKmerMinHash::as_rust(template_ptr).clone())
+    };
+
+    let queries_vec: Vec<KmerMinHash>;
+    let queries: Option<&[KmerMinHash]> = if queries_ptr.is_null() {
+      None
+    } else {
+        queries_vec =
+          slice::from_raw_parts(queries_ptr, inqueries).iter().map(|mh_ptr|
+            // TODO: avoid this clone
+          SourmashKmerMinHash::as_rust(*mh_ptr).clone()).collect();
+        Some(queries_vec.as_ref())
+    };
+      let revindex = RevIndex::new_with_sigs(
+        search_sigs,
+        &template,
+        threshold,
+        queries,
+      );
+      Ok(SourmashRevIndex::from_rust(revindex))
+  }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn revindex_free(ptr: *mut SourmashRevIndex) {
+    SourmashRevIndex::drop(ptr);
+}
+
+ffi_fn! {
+unsafe fn revindex_search(
+    ptr: *const SourmashRevIndex,
+    sig_ptr: *const SourmashSignature,
+    threshold: f64,
+    do_containment: bool,
+    _ignore_abundance: bool,
+    size: *mut usize
+) -> Result<*const *const SourmashSearchResult> {
+    let revindex = SourmashRevIndex::as_rust(ptr);
+    let sig = SourmashSignature::as_rust(sig_ptr);
+
+    if sig.signatures.is_empty() {
+        *size = 0;
+        return Ok(std::ptr::null::<*const SourmashSearchResult>());
+    }
+
+    let mh = if let Sketch::MinHash(mh) = &sig.signatures[0] {
+        mh
+    } else {
+        // TODO: what if it is not a mh?
+        unimplemented!()
+    };
+
+    let results: Vec<(f64, Signature, String)> = revindex
+        .find_signatures(mh, threshold, do_containment, true)?
+        .into_iter()
+        .collect();
+
+    // FIXME: use the ForeignObject trait, maybe define new method there...
+    let ptr_sigs: Vec<*const SourmashSearchResult> = results.into_iter().map(|x| {
+      Box::into_raw(Box::new(x)) as *const SourmashSearchResult
+    }).collect();
+
+    let b = ptr_sigs.into_boxed_slice();
+    *size = b.len();
+
+    Ok(Box::into_raw(b) as *const *const SourmashSearchResult)
+}
+}
+
+ffi_fn! {
+unsafe fn revindex_gather(
+    ptr: *const SourmashRevIndex,
+    sig_ptr: *const SourmashSignature,
+    threshold: f64,
+    _do_containment: bool,
+    _ignore_abundance: bool,
+    size: *mut usize
+) -> Result<*const *const SourmashSearchResult> {
+    let revindex = SourmashRevIndex::as_rust(ptr);
+    let sig = SourmashSignature::as_rust(sig_ptr);
+
+    if sig.signatures.is_empty() {
+        *size = 0;
+        return Ok(std::ptr::null::<*const SourmashSearchResult>());
+    }
+
+    let mh = if let Sketch::MinHash(mh) = &sig.signatures[0] {
+        mh
+    } else {
+        // TODO: what if it is not a mh?
+        unimplemented!()
+    };
+
+    // TODO: proper threshold calculation
+    let threshold: usize = (threshold * (mh.size() as f64)) as _;
+
+    let counter = revindex.counter_for_query(&mh);
+        dbg!(&counter);
+
+    let results: Vec<(f64, Signature, String)> = revindex
+        .gather(counter, threshold, mh)
+        .unwrap() // TODO: proper error handling
+        .into_iter()
+        .map(|r| {
+            let filename = r.filename().to_owned();
+            let sig = r.get_match();
+            (r.f_match(), sig, filename)
+        })
+        .collect();
+
+
+    // FIXME: use the ForeignObject trait, maybe define new method there...
+    let ptr_sigs: Vec<*const SourmashSearchResult> = results.into_iter().map(|x| {
+      Box::into_raw(Box::new(x)) as *const SourmashSearchResult
+    }).collect();
+
+    let b = ptr_sigs.into_boxed_slice();
+    *size = b.len();
+
+    Ok(Box::into_raw(b) as *const *const SourmashSearchResult)
+}
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn revindex_scaled(ptr: *const SourmashRevIndex) -> u64 {
+    let revindex = SourmashRevIndex::as_rust(ptr);
+    if let Sketch::MinHash(mh) = revindex.template() {
+        mh.scaled()
+    } else {
+        unimplemented!()
+    }
+}
+
+ffi_fn! {
+unsafe fn revindex_signatures(ptr: *const SourmashRevIndex,
+                              size: *mut usize) -> Result<*mut *mut SourmashSignature> {
+    let revindex = SourmashRevIndex::as_rust(ptr);
+
+    let sigs = revindex.signatures();
+
+    // FIXME: use the ForeignObject trait, maybe define new method there...
+    let ptr_sigs: Vec<*mut SourmashSignature> = sigs.into_iter().map(|x| {
+      Box::into_raw(Box::new(x)) as *mut SourmashSignature
+    }).collect();
+
+    let b = ptr_sigs.into_boxed_slice();
+    *size = b.len();
+
+    Ok(Box::into_raw(b) as *mut *mut SourmashSignature)
+}
+}

--- a/src/core/src/ffi/index/revindex.rs
+++ b/src/core/src/ffi/index/revindex.rs
@@ -221,6 +221,12 @@ pub unsafe extern "C" fn revindex_scaled(ptr: *const SourmashRevIndex) -> u64 {
     }
 }
 
+#[no_mangle]
+pub unsafe extern "C" fn revindex_len(ptr: *const SourmashRevIndex) -> u64 {
+    let revindex = SourmashRevIndex::as_rust(ptr);
+    revindex.len() as u64
+}
+
 ffi_fn! {
 unsafe fn revindex_signatures(
     ptr: *const SourmashRevIndex,

--- a/src/core/src/ffi/mod.rs
+++ b/src/core/src/ffi/mod.rs
@@ -8,6 +8,7 @@ pub mod utils;
 
 pub mod cmd;
 pub mod hyperloglog;
+pub mod index;
 pub mod minhash;
 pub mod nodegraph;
 pub mod signature;

--- a/src/core/src/ffi/utils.rs
+++ b/src/core/src/ffi/utils.rs
@@ -314,3 +314,7 @@ pub unsafe extern "C" fn sourmash_str_free(s: *mut SourmashStr) {
         (*s).free()
     }
 }
+
+impl ForeignObject for SourmashStr {
+    type RustObject = SourmashStr;
+}

--- a/src/core/src/index/greyhound.rs
+++ b/src/core/src/index/greyhound.rs
@@ -23,6 +23,8 @@ use crate::HashIntoType;
 type HashToColor = HashMap<HashIntoType, Color, BuildNoHashHasher<HashIntoType>>;
 type SigCounter = counter::Counter<Idx>;
 
+// Use rkyv for serialization?
+// https://davidkoloski.me/rkyv/
 #[derive(Serialize, Deserialize)]
 pub struct RevIndex {
     hash_to_color: HashToColor,

--- a/src/core/src/index/greyhound.rs
+++ b/src/core/src/index/greyhound.rs
@@ -16,7 +16,6 @@ use crate::index::Index;
 use crate::signature::{Signature, SigsTrait};
 use crate::sketch::minhash::KmerMinHash;
 use crate::sketch::Sketch;
-//use crate::storage::{InnerStorage, MemStorage};
 use crate::Error;
 use crate::HashIntoType;
 

--- a/src/core/src/index/greyhound.rs
+++ b/src/core/src/index/greyhound.rs
@@ -1,0 +1,754 @@
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use cfg_if::cfg_if;
+use getset::{CopyGetters, Getters, Setters};
+use log::{debug, info};
+use nohash_hasher::BuildNoHashHasher;
+use serde::{Deserialize, Serialize};
+
+#[cfg(feature = "parallel")]
+use rayon::prelude::*;
+
+use crate::encodings::{Color, Colors, Idx};
+use crate::index::Index;
+use crate::signature::{Signature, SigsTrait};
+use crate::sketch::minhash::KmerMinHash;
+use crate::sketch::Sketch;
+//use crate::storage::{InnerStorage, MemStorage};
+use crate::Error;
+use crate::HashIntoType;
+
+type HashToColor = HashMap<HashIntoType, Color, BuildNoHashHasher<HashIntoType>>;
+type SigCounter = counter::Counter<Idx>;
+
+#[derive(Serialize, Deserialize)]
+pub struct RevIndex {
+    hash_to_color: HashToColor,
+
+    sig_files: Vec<PathBuf>,
+
+    #[serde(skip)]
+    ref_sigs: Option<Vec<Signature>>,
+
+    template: Sketch,
+    colors: Colors,
+    //#[serde(skip)]
+    //storage: Option<InnerStorage>,
+}
+
+impl RevIndex {
+    pub fn load<P: AsRef<Path>>(
+        index_path: P,
+        queries: Option<&[KmerMinHash]>,
+    ) -> Result<RevIndex, Box<dyn std::error::Error>> {
+        let (rdr, _) = niffler::from_path(index_path)?;
+        let revindex = if let Some(qs) = queries {
+            // TODO: avoid loading full revindex if query != None
+            /*
+            struct PartialRevIndex<T> {
+                hashes_to_keep: Option<HashSet<HashIntoType>>,
+                marker: PhantomData<fn() -> T>,
+            }
+
+            impl<T> PartialRevIndex<T> {
+                pub fn new(hashes_to_keep: HashSet<u64>) -> Self {
+                    PartialRevIndex {
+                        hashes_to_keep: Some(hashes_to_keep),
+                        marker: PhantomData,
+                    }
+                }
+            }
+            */
+
+            let mut hashes: HashSet<u64> = HashSet::new();
+            for q in qs {
+                hashes.extend(q.iter_mins());
+            }
+
+            //let mut revindex: RevIndex = PartialRevIndex::new(hashes).deserialize(&rdr).unwrap();
+
+            let mut revindex: RevIndex = serde_json::from_reader(rdr)?;
+            revindex
+                .hash_to_color
+                .retain(|hash, _| hashes.contains(hash));
+            revindex
+        } else {
+            // Load the full revindex
+            serde_json::from_reader(rdr)?
+        };
+
+        Ok(revindex)
+    }
+
+    pub fn new(
+        search_sigs: &[PathBuf],
+        template: &Sketch,
+        threshold: usize,
+        queries: Option<&[KmerMinHash]>,
+        keep_sigs: bool,
+    ) -> RevIndex {
+        // If threshold is zero, let's merge all queries and save time later
+        let merged_query = if let Some(qs) = queries {
+            if threshold == 0 {
+                let mut merged = qs[0].clone();
+                for query in &qs[1..] {
+                    merged.merge(query).unwrap();
+                }
+                Some(merged)
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
+        let processed_sigs = AtomicUsize::new(0);
+
+        cfg_if! {
+          if #[cfg(feature = "parallel")] {
+            let (hash_to_color, colors) = search_sigs
+                .par_iter()
+                .enumerate()
+                .filter_map(|(dataset_id, filename)| {
+                    let i = processed_sigs.fetch_add(1, Ordering::SeqCst);
+                    if i % 1000 == 0 {
+                        info!("Processed {} reference sigs", i);
+                    }
+
+                    RevIndex::map_hashes_colors(
+                        dataset_id,
+                        filename,
+                        queries,
+                        &merged_query,
+                        threshold,
+                        template,
+                    )
+                })
+                .reduce(
+                    || {
+                        (
+                            HashToColor::with_hasher(BuildNoHashHasher::default()),
+                            Colors::default(),
+                        )
+                    },
+                    RevIndex::reduce_hashes_colors,
+                );
+          } else {
+            let (hash_to_color, colors) = search_sigs
+                .iter()
+                .enumerate()
+                .filter_map(|(dataset_id, filename)| {
+                    let i = processed_sigs.fetch_add(1, Ordering::SeqCst);
+                    if i % 1000 == 0 {
+                        info!("Processed {} reference sigs", i);
+                    }
+                    RevIndex::map_hashes_colors(
+                        dataset_id,
+                        filename,
+                        queries,
+                        &merged_query,
+                        threshold,
+                        template,
+                    )
+                })
+                .fold(
+                    (
+                        HashToColor::with_hasher(BuildNoHashHasher::default()),
+                        Colors::default(),
+                    ),
+                    RevIndex::reduce_hashes_colors,
+                );
+          }
+        }
+
+        // TODO: build this together with hash_to_idx?
+        // TODO: do a parallel (par_iter) and sequential (iter) version
+        let ref_sigs = if keep_sigs {
+            cfg_if! {
+              if #[cfg(feature = "parallel")] {
+                Some(
+                    search_sigs
+                        .par_iter()
+                        .map(|ref_path| {
+                            Signature::from_path(&ref_path)
+                                .unwrap_or_else(|_| panic!("Error processing {:?}", ref_path))
+                                .swap_remove(0)
+                        })
+                        .collect(),
+                )
+              } else {
+                Some(
+                    search_sigs
+                        .iter()
+                        .map(|ref_path| {
+                            Signature::from_path(&ref_path)
+                                .unwrap_or_else(|_| panic!("Error processing {:?}", ref_path))
+                                .swap_remove(0)
+                        })
+                        .collect(),
+                )
+              }
+            }
+        } else {
+            None
+        };
+
+        RevIndex {
+            hash_to_color,
+            sig_files: search_sigs.into(),
+            ref_sigs,
+            template: template.clone(),
+            colors,
+            //            storage: Some(InnerStorage::new(MemStorage::default())),
+        }
+    }
+
+    pub fn new_with_sigs(
+        search_sigs: Vec<Signature>,
+        template: &Sketch,
+        threshold: usize,
+        queries: Option<&[KmerMinHash]>,
+    ) -> RevIndex {
+        // If threshold is zero, let's merge all queries and save time later
+        let merged_query = if let Some(qs) = queries {
+            if threshold == 0 {
+                let mut merged = qs[0].clone();
+                for query in &qs[1..] {
+                    merged.merge(query).unwrap();
+                }
+                Some(merged)
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
+        let processed_sigs = AtomicUsize::new(0);
+
+        cfg_if! {
+          if #[cfg(feature = "parallel")] {
+            let (hash_to_color, colors) = search_sigs
+                .par_iter()
+                .enumerate()
+                .filter_map(|(dataset_id, sig)| {
+                    let i = processed_sigs.fetch_add(1, Ordering::SeqCst);
+                    if i % 1000 == 0 {
+                        info!("Processed {} reference sigs", i);
+                    }
+
+                    RevIndex::map_hashes_colors_sigs(
+                        dataset_id,
+                        sig,
+                        queries,
+                        &merged_query,
+                        threshold,
+                        template,
+                    )
+                })
+                .reduce(
+                    || {
+                        (
+                            HashToColor::with_hasher(BuildNoHashHasher::default()),
+                            Colors::default(),
+                        )
+                    },
+                    RevIndex::reduce_hashes_colors,
+                );
+          } else {
+            let (hash_to_color, colors) = search_sigs
+                .iter()
+                .enumerate()
+                .filter_map(|(dataset_id, filename)| {
+                    let i = processed_sigs.fetch_add(1, Ordering::SeqCst);
+                    if i % 1000 == 0 {
+                        info!("Processed {} reference sigs", i);
+                    }
+                    RevIndex::map_hashes_colors_sigs(
+                        dataset_id,
+                        filename,
+                        queries,
+                        &merged_query,
+                        threshold,
+                        template,
+                    )
+                })
+                .fold(
+                    (
+                        HashToColor::with_hasher(BuildNoHashHasher::default()),
+                        Colors::default(),
+                    ),
+                    RevIndex::reduce_hashes_colors,
+                );
+          }
+        }
+
+        RevIndex {
+            hash_to_color,
+            sig_files: vec![],
+            ref_sigs: search_sigs.into(),
+            template: template.clone(),
+            colors,
+            //storage: None,
+        }
+    }
+
+    fn map_hashes_colors_sigs(
+        dataset_id: usize,
+        search_sig: &Signature,
+        queries: Option<&[KmerMinHash]>,
+        merged_query: &Option<KmerMinHash>,
+        threshold: usize,
+        template: &Sketch,
+    ) -> Option<(HashToColor, Colors)> {
+        let mut search_mh = None;
+        if let Some(Sketch::MinHash(mh)) = search_sig.select_sketch(&template) {
+            search_mh = Some(mh);
+        }
+
+        let search_mh = search_mh.expect("Couldn't find a compatible MinHash");
+        let mut hash_to_color = HashToColor::with_hasher(BuildNoHashHasher::default());
+        let mut colors = Colors::default();
+        let mut color = None;
+
+        let mut add_to = |matched_hashes: Vec<u64>, intersection| {
+            if !matched_hashes.is_empty() || intersection > threshold as u64 {
+                matched_hashes.into_iter().for_each(|hash| {
+                    color = Some(colors.update(color, &[dataset_id as Idx]).unwrap());
+                    hash_to_color.insert(hash, color.unwrap());
+                });
+            }
+        };
+
+        if let Some(qs) = queries {
+            if let Some(ref merged) = merged_query {
+                let (matched_hashes, intersection) = merged.intersection(search_mh).unwrap();
+                add_to(matched_hashes, intersection);
+            } else {
+                for query in qs {
+                    let (matched_hashes, intersection) = query.intersection(search_mh).unwrap();
+                    add_to(matched_hashes, intersection);
+                }
+            }
+        } else {
+            let matched = search_mh.mins();
+            let size = matched.len() as u64;
+            add_to(matched, size);
+        };
+
+        if hash_to_color.is_empty() {
+            None
+        } else {
+            Some((hash_to_color, colors))
+        }
+    }
+
+    fn map_hashes_colors(
+        dataset_id: usize,
+        filename: &Path,
+        queries: Option<&[KmerMinHash]>,
+        merged_query: &Option<KmerMinHash>,
+        threshold: usize,
+        template: &Sketch,
+    ) -> Option<(HashToColor, Colors)> {
+        let search_sig = Signature::from_path(&filename)
+            .unwrap_or_else(|_| panic!("Error processing {:?}", filename))
+            .swap_remove(0);
+
+        RevIndex::map_hashes_colors_sigs(
+            dataset_id,
+            &search_sig,
+            queries,
+            merged_query,
+            threshold,
+            template,
+        )
+    }
+
+    fn reduce_hashes_colors(
+        a: (HashToColor, Colors),
+        b: (HashToColor, Colors),
+    ) -> (HashToColor, Colors) {
+        let ((small_hashes, small_colors), (mut large_hashes, mut large_colors)) =
+            if a.0.len() > b.0.len() {
+                (b, a)
+            } else {
+                (a, b)
+            };
+
+        small_hashes.into_iter().for_each(|(hash, color)| {
+            large_hashes
+                .entry(hash)
+                .and_modify(|entry| {
+                    // Hash is already present.
+                    // Update the current color by adding the indices from
+                    // small_colors.
+                    let ids = small_colors.indices(&color);
+                    let new_color = large_colors.update(Some(*entry), ids).unwrap();
+                    *entry = new_color;
+                })
+                .or_insert_with(|| {
+                    // In this case, the hash was not present yet.
+                    // we need to create the same color from small_colors
+                    // into large_colors.
+                    let ids = small_colors.indices(&color);
+                    let new_color = large_colors.update(None, ids).unwrap();
+                    assert_eq!(new_color, color);
+                    new_color
+                });
+        });
+
+        (large_hashes, large_colors)
+    }
+
+    pub fn search(
+        &self,
+        counter: SigCounter,
+        similarity: bool,
+        threshold: usize,
+    ) -> Result<Vec<String>, Box<dyn std::error::Error>> {
+        let mut matches = vec![];
+        if similarity {
+            unimplemented!("TODO: threshold correction")
+        }
+
+        for (dataset_id, size) in counter.most_common() {
+            if size >= threshold {
+                matches.push(self.sig_files[dataset_id as usize].to_str().unwrap().into());
+            } else {
+                break;
+            };
+        }
+        Ok(matches)
+    }
+
+    pub fn gather(
+        &self,
+        mut counter: SigCounter,
+        threshold: usize,
+        query: &KmerMinHash,
+    ) -> Result<Vec<GatherResult>, Box<dyn std::error::Error>> {
+        let mut match_size = usize::max_value();
+        let mut matches = vec![];
+
+        while match_size > threshold && !counter.is_empty() {
+            let (dataset_id, size) = counter.most_common()[0];
+            match_size = if size >= threshold { size } else { break };
+
+            let p;
+            let match_path = if self.sig_files.is_empty() {
+                p = PathBuf::new(); // TODO: Fix somehow?
+                &p
+            } else {
+                &self.sig_files[dataset_id as usize]
+            };
+
+            let ref_match;
+            let match_sig = if let Some(refsigs) = &self.ref_sigs {
+                &refsigs[dataset_id as usize]
+            } else {
+                // TODO: remove swap_remove
+                ref_match = Signature::from_path(&match_path)?.swap_remove(0);
+                &ref_match
+            };
+
+            let mut match_mh = None;
+            if let Some(Sketch::MinHash(mh)) = match_sig.select_sketch(&self.template) {
+                match_mh = Some(mh);
+            }
+            let match_mh = match_mh.expect("Couldn't find a compatible MinHash");
+
+            // Calculate stats
+            let f_orig_query = match_size as f64 / query.size() as f64;
+            let f_match = match_size as f64 / match_mh.size() as f64;
+            let filename = match_path.to_str().unwrap().into();
+            let name = match_sig.name();
+            let unique_intersect_bp = match_mh.scaled() as usize * match_size;
+            let gather_result_rank = matches.len();
+
+            let (intersect_orig, _) = match_mh.intersection_size(query)?;
+            let intersect_bp = (match_mh.scaled() as u64 * intersect_orig) as usize;
+
+            let f_unique_to_query = intersect_orig as f64 / query.size() as f64;
+            let match_ = match_sig.clone();
+
+            // TODO: all of these
+            let f_unique_weighted = 0.;
+            let average_abund = 0;
+            let median_abund = 0;
+            let std_abund = 0;
+            let md5 = "".into();
+            let f_match_orig = 0.;
+            let remaining_bp = 0;
+
+            let result = GatherResult {
+                intersect_bp,
+                f_orig_query,
+                f_match,
+                f_unique_to_query,
+                f_unique_weighted,
+                average_abund,
+                median_abund,
+                std_abund,
+                filename,
+                name,
+                md5,
+                match_,
+                f_match_orig,
+                unique_intersect_bp,
+                gather_result_rank,
+                remaining_bp,
+            };
+            matches.push(result);
+
+            // Prepare counter for finding the next match by decrementing
+            // all hashes found in the current match in other datasets
+            for hash in match_mh.iter_mins() {
+                if let Some(color) = self.hash_to_color.get(hash) {
+                    for dataset in self.colors.indices(color) {
+                        counter.entry(*dataset).and_modify(|e| {
+                            if *e > 0 {
+                                *e -= 1
+                            }
+                        });
+                    }
+                }
+            }
+            counter.remove(&dataset_id);
+        }
+        Ok(matches)
+    }
+
+    pub fn counter_for_query(&self, query: &KmerMinHash) -> SigCounter {
+        query
+            .iter_mins()
+            .filter_map(|hash| self.hash_to_color.get(hash))
+            .flat_map(|color| self.colors.indices(color))
+            .cloned()
+            .collect()
+    }
+
+    pub fn counter(&self) -> SigCounter {
+        self.hash_to_color
+            .iter()
+            .flat_map(|(_, color)| self.colors.indices(color))
+            .cloned()
+            .collect()
+    }
+
+    pub fn template(&self) -> Sketch {
+        self.template.clone()
+    }
+    // TODO: mh should be a sketch, or even a sig...
+    pub(crate) fn find_signatures(
+        &self,
+        mh: &KmerMinHash,
+        threshold: f64,
+        containment: bool,
+        _ignore_scaled: bool,
+    ) -> Result<Vec<(f64, Signature, String)>, Error> {
+        /*
+        let template_mh = None;
+        if let Sketch::MinHash(mh) = self.template {
+            template_mh = Some(mh);
+        };
+        // TODO: throw error
+        let template_mh = template_mh.unwrap();
+
+        let tmp_mh;
+        let mh = if template_mh.scaled() > mh.scaled() {
+            // TODO: proper error here
+            tmp_mh = mh.downsample_scaled(self.scaled)?;
+            &tmp_mh
+        } else {
+            mh
+        };
+
+                if self.scaled < mh.scaled() && !ignore_scaled {
+                        return Err(LcaDBError::ScaledMismatchError {
+                                db: self.scaled,
+                                query: mh.scaled(),
+                        }
+                        .into());
+                }
+        */
+
+        // TODO: proper threshold calculation
+        let threshold: usize = (threshold * (mh.size() as f64)) as _;
+
+        let counter = self.counter_for_query(&mh);
+
+        debug!(
+            "number of matching signatures for hashes: {}",
+            counter.len()
+        );
+
+        let mut results = vec![];
+        for (dataset_id, size) in counter.most_common() {
+            let match_size = if size >= threshold { size } else { break };
+
+            let p;
+            let match_path = if self.sig_files.is_empty() {
+                p = PathBuf::new(); // TODO: Fix somehow?
+                &p
+            } else {
+                &self.sig_files[dataset_id as usize]
+            };
+
+            let ref_match;
+            let match_sig = if let Some(refsigs) = &self.ref_sigs {
+                &refsigs[dataset_id as usize]
+            } else {
+                // TODO: remove swap_remove
+                ref_match = Signature::from_path(&match_path)?.swap_remove(0);
+                &ref_match
+            };
+
+            let mut match_mh = None;
+            if let Some(Sketch::MinHash(mh)) = match_sig.select_sketch(&self.template) {
+                match_mh = Some(mh);
+            }
+            let match_mh = match_mh.unwrap();
+
+            if size >= threshold {
+                let score = if containment {
+                    size as f64 / mh.size() as f64
+                } else {
+                    size as f64 / (mh.size() + match_size - size) as f64
+                };
+                let filename = match_path.to_str().unwrap().into();
+                let mut sig = match_sig.clone();
+                sig.reset_sketches();
+                sig.push(Sketch::MinHash(match_mh.clone()));
+                results.push((score, sig, filename));
+            } else {
+                break;
+            };
+        }
+        Ok(results)
+    }
+}
+
+#[derive(CopyGetters, Getters, Setters, Serialize, Deserialize, Debug)]
+pub struct GatherResult {
+    #[getset(get_copy = "pub")]
+    intersect_bp: usize,
+
+    #[getset(get_copy = "pub")]
+    f_orig_query: f64,
+
+    #[getset(get_copy = "pub")]
+    f_match: f64,
+
+    f_unique_to_query: f64,
+    f_unique_weighted: f64,
+    average_abund: usize,
+    median_abund: usize,
+    std_abund: usize,
+
+    #[getset(get = "pub")]
+    filename: String,
+
+    #[getset(get = "pub")]
+    name: String,
+
+    md5: String,
+    match_: Signature,
+    f_match_orig: f64,
+    unique_intersect_bp: usize,
+    gather_result_rank: usize,
+    remaining_bp: usize,
+}
+
+impl GatherResult {
+    pub fn get_match(&self) -> Signature {
+        self.match_.clone()
+    }
+}
+
+impl<'a> Index<'a> for RevIndex {
+    type Item = Signature;
+
+    fn insert(&mut self, _node: Self::Item) -> Result<(), Error> {
+        unimplemented!()
+    }
+
+    fn save<P: AsRef<Path>>(&self, _path: P) -> Result<(), Error> {
+        unimplemented!()
+    }
+
+    fn load<P: AsRef<Path>>(_path: P) -> Result<(), Error> {
+        unimplemented!()
+    }
+
+    fn signatures(&self) -> Vec<Self::Item> {
+        if let Some(ref sigs) = self.ref_sigs {
+            sigs.iter().map(|x| x.clone()).collect()
+        } else {
+            unimplemented!()
+        }
+    }
+
+    fn signature_refs(&self) -> Vec<&Self::Item> {
+        unimplemented!()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    use crate::sketch::minhash::max_hash_for_scaled;
+
+    #[test]
+    fn greyhound_new() {
+        let max_hash = max_hash_for_scaled(10000);
+        let template = Sketch::MinHash(
+            KmerMinHash::builder()
+                .num(0u32)
+                .ksize(31)
+                .max_hash(max_hash)
+                .build(),
+        );
+        let search_sigs = [
+            "../../tests/test-data/gather/GCF_000006945.2_ASM694v2_genomic.fna.gz.sig".into(),
+            "../../tests/test-data/gather/GCF_000007545.1_ASM754v1_genomic.fna.gz.sig".into(),
+        ];
+        let index = RevIndex::new(&search_sigs, &template, 0, None, false);
+        assert_eq!(index.colors.len(), 3);
+    }
+
+    #[test]
+    fn greyhound_many() {
+        let max_hash = max_hash_for_scaled(10000);
+        let template = Sketch::MinHash(
+            KmerMinHash::builder()
+                .num(0u32)
+                .ksize(31)
+                .max_hash(max_hash)
+                .build(),
+        );
+        let search_sigs = [
+            "../../tests/test-data/gather/GCF_000006945.2_ASM694v2_genomic.fna.gz.sig".into(),
+            "../../tests/test-data/gather/GCF_000007545.1_ASM754v1_genomic.fna.gz.sig".into(),
+            "../../tests/test-data/gather/GCF_000008105.1_ASM810v1_genomic.fna.gz.sig".into(),
+        ];
+
+        let index = RevIndex::new(&search_sigs, &template, 0, None, false);
+        /*
+         dbg!(&index.colors.colors);
+         0: 86
+         1: 132
+         2: 91
+         (0, 1): 53
+         (0, 2): 90
+         (1, 2): 26
+         (0, 1, 2): 261
+         union: 739
+        */
+        //assert_eq!(index.colors.len(), 3);
+        assert_eq!(index.colors.len(), 7);
+    }
+}

--- a/src/core/src/index/greyhound.rs
+++ b/src/core/src/index/greyhound.rs
@@ -709,6 +709,14 @@ impl<'a> Index<'a> for RevIndex {
         unimplemented!()
     }
 
+    fn len(&self) -> usize {
+        if let Some(refs) = &self.ref_sigs {
+            refs.len()
+        } else {
+            self.sig_files.len()
+        }
+    }
+
     fn signatures(&self) -> Vec<Self::Item> {
         if let Some(ref sigs) = self.ref_sigs {
             sigs.to_vec()

--- a/src/core/src/index/greyhound.rs
+++ b/src/core/src/index/greyhound.rs
@@ -377,7 +377,7 @@ impl RevIndex {
         template: &Sketch,
     ) -> Option<(HashToColor, Colors)> {
         let mut search_mh = None;
-        if let Some(Sketch::MinHash(mh)) = search_sig.select_sketch(&template) {
+        if let Some(Sketch::MinHash(mh)) = search_sig.select_sketch(template) {
             search_mh = Some(mh);
         }
 
@@ -604,7 +604,7 @@ impl RevIndex {
         // TODO: proper threshold calculation
         let threshold: usize = (threshold * (mh.size() as f64)) as _;
 
-        let counter = self.counter_for_query(&mh);
+        let counter = self.counter_for_query(mh);
 
         debug!(
             "number of matching signatures for hashes: {}",
@@ -711,7 +711,7 @@ impl<'a> Index<'a> for RevIndex {
 
     fn signatures(&self) -> Vec<Self::Item> {
         if let Some(ref sigs) = self.ref_sigs {
-            sigs.iter().map(|x| x.clone()).collect()
+            sigs.to_vec()
         } else {
             unimplemented!()
         }

--- a/src/core/src/index/linear.rs
+++ b/src/core/src/index/linear.rs
@@ -2,20 +2,19 @@ use std::fs::File;
 use std::io::{BufReader, Read};
 use std::path::Path;
 use std::path::PathBuf;
-use std::rc::Rc;
 
 use serde::{Deserialize, Serialize};
 use typed_builder::TypedBuilder;
 
 use crate::index::{Comparable, DatasetInfo, Index, SigStore};
 use crate::prelude::*;
-use crate::storage::{FSStorage, Storage, StorageInfo};
+use crate::storage::{FSStorage, InnerStorage, Storage, StorageInfo};
 use crate::Error;
 
 #[derive(TypedBuilder)]
 pub struct LinearIndex<L> {
     #[builder(default)]
-    storage: Option<Rc<dyn Storage>>,
+    storage: Option<InnerStorage>,
 
     #[builder(default)]
     datasets: Vec<SigStore<L>>,
@@ -85,7 +84,7 @@ where
     pub fn save_file<P: AsRef<Path>>(
         &mut self,
         path: P,
-        storage: Option<Rc<dyn Storage>>,
+        storage: Option<InnerStorage>,
     ) -> Result<(), Error> {
         let ref_path = path.as_ref();
         let mut basename = ref_path.file_name().unwrap().to_str().unwrap().to_owned();
@@ -98,7 +97,7 @@ where
             Some(s) => s,
             None => {
                 let subdir = format!(".linear.{}", basename);
-                Rc::new(FSStorage::new(location.to_str().unwrap(), &subdir))
+                InnerStorage::new(FSStorage::new(location.to_str().unwrap(), &subdir))
             }
         };
 
@@ -119,7 +118,7 @@ where
                     let _: &L = (*l).data().unwrap();
 
                     // set storage to new one
-                    l.storage = Some(Rc::clone(&storage));
+                    l.storage = Some(storage.clone());
 
                     let filename = (*l).save(&l.filename).unwrap();
 
@@ -164,23 +163,23 @@ where
         // TODO: support other storages
         let mut st: FSStorage = (&linear.storage.args).into();
         st.set_base(path.as_ref().to_str().unwrap());
-        let storage: Rc<dyn Storage> = Rc::new(st);
+        let storage = InnerStorage::new(st);
 
         Ok(LinearIndex {
-            storage: Some(Rc::clone(&storage)),
+            storage: Some(storage.clone()),
             datasets: linear
                 .leaves
                 .into_iter()
                 .map(|l| {
                     let mut v: SigStore<L> = l.into();
-                    v.storage = Some(Rc::clone(&storage));
+                    v.storage = Some(storage.clone());
                     v
                 })
                 .collect(),
         })
     }
 
-    pub fn storage(&self) -> Option<Rc<dyn Storage>> {
+    pub fn storage(&self) -> Option<InnerStorage> {
         self.storage.clone()
     }
 }

--- a/src/core/src/index/mod.rs
+++ b/src/core/src/index/mod.rs
@@ -4,8 +4,8 @@
 //! Some indices also support containment searches.
 
 pub mod bigsi;
-pub mod greyhound;
 pub mod linear;
+pub mod revindex;
 pub mod sbt;
 
 pub mod search;

--- a/src/core/src/index/mod.rs
+++ b/src/core/src/index/mod.rs
@@ -104,6 +104,10 @@ pub trait Index<'a> {
         self.signature_refs().len()
     }
 
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     /*
     fn iter_signatures(&self) -> Self::SignatureIterator;
     */

--- a/src/core/src/index/mod.rs
+++ b/src/core/src/index/mod.rs
@@ -7,11 +7,13 @@ pub mod bigsi;
 pub mod linear;
 pub mod sbt;
 
+#[cfg(feature = "experimental")]
+pub mod greyhound;
+
 pub mod search;
 
 use std::ops::Deref;
 use std::path::Path;
-use std::rc::Rc;
 
 use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
@@ -24,7 +26,7 @@ use crate::prelude::*;
 use crate::signature::SigsTrait;
 use crate::sketch::nodegraph::Nodegraph;
 use crate::sketch::Sketch;
-use crate::storage::Storage;
+use crate::storage::{InnerStorage, Storage};
 use crate::Error;
 
 pub type MHBT = SBT<Node<Nodegraph>, Signature>;
@@ -134,7 +136,7 @@ pub struct SigStore<T> {
     #[builder(setter(into))]
     metadata: String,
 
-    storage: Option<Rc<dyn Storage>>,
+    storage: Option<InnerStorage>,
 
     #[builder(setter(into), default)]
     data: OnceCell<T>,

--- a/src/core/src/index/mod.rs
+++ b/src/core/src/index/mod.rs
@@ -4,11 +4,9 @@
 //! Some indices also support containment searches.
 
 pub mod bigsi;
+pub mod greyhound;
 pub mod linear;
 pub mod sbt;
-
-#[cfg(feature = "experimental")]
-pub mod greyhound;
 
 pub mod search;
 

--- a/src/core/src/index/mod.rs
+++ b/src/core/src/index/mod.rs
@@ -100,6 +100,10 @@ pub trait Index<'a> {
 
     fn signature_refs(&self) -> Vec<&Self::Item>;
 
+    fn len(&self) -> usize {
+        self.signature_refs().len()
+    }
+
     /*
     fn iter_signatures(&self) -> Self::SignatureIterator;
     */

--- a/src/core/src/index/revindex.rs
+++ b/src/core/src/index/revindex.rs
@@ -737,7 +737,7 @@ mod test {
     use crate::sketch::minhash::max_hash_for_scaled;
 
     #[test]
-    fn greyhound_new() {
+    fn revindex_new() {
         let max_hash = max_hash_for_scaled(10000);
         let template = Sketch::MinHash(
             KmerMinHash::builder()
@@ -755,7 +755,7 @@ mod test {
     }
 
     #[test]
-    fn greyhound_many() {
+    fn revindex_many() {
         let max_hash = max_hash_for_scaled(10000);
         let template = Sketch::MinHash(
             KmerMinHash::builder()

--- a/src/core/src/index/sbt/mhbt.rs
+++ b/src/core/src/index/sbt/mhbt.rs
@@ -7,6 +7,7 @@ use crate::prelude::*;
 use crate::signature::SigsTrait;
 use crate::sketch::nodegraph::Nodegraph;
 use crate::sketch::Sketch;
+use crate::storage::Storage;
 use crate::Error;
 
 impl ToWriter for Nodegraph {

--- a/src/core/src/index/sbt/mod.rs
+++ b/src/core/src/index/sbt/mod.rs
@@ -16,7 +16,6 @@ use std::fs::File;
 use std::hash::BuildHasherDefault;
 use std::io::{BufReader, Read};
 use std::path::{Path, PathBuf};
-use std::rc::Rc;
 
 use log::info;
 use nohash_hasher::NoHashHasher;
@@ -26,7 +25,7 @@ use typed_builder::TypedBuilder;
 
 use crate::index::{Comparable, DatasetInfo, Index, SigStore};
 use crate::prelude::*;
-use crate::storage::{FSStorage, StorageInfo};
+use crate::storage::{FSStorage, InnerStorage, StorageInfo};
 use crate::Error;
 
 #[derive(TypedBuilder)]
@@ -35,7 +34,7 @@ pub struct SBT<N, L> {
     d: u32,
 
     #[builder(default, setter(into))]
-    storage: Option<Rc<dyn Storage>>,
+    storage: Option<InnerStorage>,
 
     #[builder(default = Factory::GraphFactory { args: (1, 100000.0, 4) })]
     factory: Factory,
@@ -79,7 +78,7 @@ where
         (0..u64::from(self.d)).map(|c| self.child(pos, c)).collect()
     }
 
-    pub fn storage(&self) -> Option<Rc<dyn Storage>> {
+    pub fn storage(&self) -> Option<InnerStorage> {
         self.storage.clone()
     }
 
@@ -148,7 +147,7 @@ where
             SBTInfo::V6(ref sbt) => (&sbt.storage.args).into(),
         };
         st.set_base(path.as_ref().to_str().unwrap());
-        let storage: Rc<dyn Storage> = Rc::new(st);
+        let storage = InnerStorage::new(st);
 
         let d = match sinfo {
             SBTInfo::V4(ref sbt) => sbt.d,
@@ -174,7 +173,7 @@ where
                                 .filename(l.filename)
                                 .name(l.name)
                                 .metadata(l.metadata)
-                                .storage(Some(Rc::clone(&storage)))
+                                .storage(Some(storage.clone()))
                                 .build(),
                         )
                     })
@@ -189,7 +188,7 @@ where
                                 .filename(l.filename)
                                 .name(l.name)
                                 .metadata(l.metadata)
-                                .storage(Some(Rc::clone(&storage)))
+                                .storage(Some(storage.clone()))
                                 .build(),
                         )
                     })
@@ -207,7 +206,7 @@ where
                                 .filename(l.filename)
                                 .name(l.name)
                                 .metadata(l.metadata)
-                                .storage(Some(Rc::clone(&storage)))
+                                .storage(Some(storage.clone()))
                                 .build(),
                         )
                     })
@@ -222,7 +221,7 @@ where
                                 .filename(l.filename)
                                 .name(l.name)
                                 .metadata(l.metadata)
-                                .storage(Some(Rc::clone(&storage)))
+                                .storage(Some(storage.clone()))
                                 .build(),
                         )
                     })
@@ -240,7 +239,7 @@ where
                                 .filename(l.filename.clone())
                                 .name(l.name.clone())
                                 .metadata(l.metadata.clone())
-                                .storage(Some(Rc::clone(&storage)))
+                                .storage(Some(storage.clone()))
                                 .build(),
                         )),
                         NodeInfoV4::Leaf(_) => None,
@@ -258,7 +257,7 @@ where
                                 .filename(l.filename)
                                 .name(l.name)
                                 .metadata(l.metadata)
-                                .storage(Some(Rc::clone(&storage)))
+                                .storage(Some(storage.clone()))
                                 .build(),
                         )),
                     })
@@ -271,7 +270,7 @@ where
         Ok(SBT {
             d,
             factory,
-            storage: Some(Rc::clone(&storage)),
+            storage: Some(storage),
             nodes,
             leaves,
         })
@@ -295,7 +294,7 @@ where
     pub fn save_file<P: AsRef<Path>>(
         &mut self,
         path: P,
-        storage: Option<Rc<dyn Storage>>,
+        storage: Option<InnerStorage>,
     ) -> Result<(), Error> {
         let ref_path = path.as_ref();
         let mut basename = ref_path.file_name().unwrap().to_str().unwrap().to_owned();
@@ -308,7 +307,7 @@ where
             Some(s) => s,
             None => {
                 let subdir = format!(".sbt.{}", basename);
-                Rc::new(FSStorage::new(location.to_str().unwrap(), &subdir))
+                InnerStorage::new(FSStorage::new(location.to_str().unwrap(), &subdir))
             }
         };
 
@@ -331,7 +330,7 @@ where
                     let _: &U = (*l).data().expect("Couldn't load data");
 
                     // set storage to new one
-                    l.storage = Some(Rc::clone(&storage));
+                    l.storage = Some(storage.clone());
 
                     let filename = (*l).save(&l.filename).unwrap();
                     let new_node = NodeInfo {
@@ -350,7 +349,7 @@ where
                     let _: &T = (*l).data().unwrap();
 
                     // set storage to new one
-                    l.storage = Some(Rc::clone(&storage));
+                    l.storage = Some(storage.clone());
 
                     // TODO: this should be l.md5sum(), not l.filename
                     let filename = (*l).save(&l.filename).unwrap();
@@ -558,7 +557,7 @@ pub struct Node<T> {
     metadata: HashMap<String, u64>,
 
     #[builder(default)]
-    storage: Option<Rc<dyn Storage>>,
+    storage: Option<InnerStorage>,
 
     #[builder(setter(into), default)]
     data: OnceCell<T>,
@@ -696,7 +695,7 @@ struct TreeNode<T> {
 
 pub fn scaffold<N>(
     mut datasets: Vec<SigStore<Signature>>,
-    storage: Option<Rc<dyn Storage>>,
+    storage: Option<InnerStorage>,
 ) -> SBT<Node<N>, Signature>
 where
     N: Clone + Default,

--- a/src/core/src/signature.rs
+++ b/src/core/src/signature.rs
@@ -608,9 +608,9 @@ impl Signature {
         if #[cfg(feature = "parallel")] {
             self.signatures
                 .par_iter_mut()
-                .for_each(|sketch| {
-                    sketch.add_sequence(seq, force).unwrap(); }
-                );
+                .try_for_each(|sketch| {
+                    sketch.add_sequence(seq, force) }
+                )?;
         } else {
             for sketch in self.signatures.iter_mut(){
                 sketch.add_sequence(seq, force)?;

--- a/src/core/src/sketch/minhash.rs
+++ b/src/core/src/sketch/minhash.rs
@@ -774,6 +774,26 @@ impl KmerMinHash {
 
         hll
     }
+
+    // create a downsampled copy of self
+    pub fn downsample_scaled(&self, scaled: u64) -> Result<KmerMinHash, Error> {
+        let max_hash = max_hash_for_scaled(scaled);
+
+        let mut new_mh = KmerMinHash::new(
+            max_hash, // old max_hash => max_hash arg
+            self.ksize,
+            self.hash_function,
+            self.seed,
+            self.abunds.is_some(),
+            self.num,
+        );
+        if self.abunds.is_some() {
+            new_mh.add_many_with_abund(&self.to_vec_abunds())?;
+        } else {
+            new_mh.add_many(&self.mins)?;
+        }
+        Ok(new_mh)
+    }
 }
 
 impl SigsTrait for KmerMinHash {

--- a/src/core/src/storage.rs
+++ b/src/core/src/storage.rs
@@ -190,7 +190,7 @@ impl<'a> Storage for ZipStorage<'a> {
 
     fn load(&self, path: &str) -> Result<Vec<u8>, Error> {
         if let Some(archive) = &self.archive {
-            load_from_archive(&archive, path)
+            load_from_archive(archive, path)
         } else {
             //FIXME
             let archive = piz::ZipArchive::new((&self.mapping.as_ref()).unwrap())

--- a/src/core/src/storage.rs
+++ b/src/core/src/storage.rs
@@ -193,7 +193,7 @@ impl<'a> Storage for ZipStorage<'a> {
             load_from_archive(&archive, path)
         } else {
             //FIXME
-            let archive = piz::ZipArchive::new(&(&self.mapping.as_ref()).unwrap())
+            let archive = piz::ZipArchive::new((&self.mapping.as_ref()).unwrap())
                 .map_err(|_| StorageError::EmptyPathError)?;
             load_from_archive(&archive, path)
         }
@@ -225,7 +225,7 @@ impl<'a> ZipStorage<'a> {
 
     pub fn from_slice(mapping: &'a [u8]) -> Result<Self, Error> {
         //FIXME
-        let archive = piz::ZipArchive::new(&mapping).map_err(|_| StorageError::EmptyPathError)?;
+        let archive = piz::ZipArchive::new(mapping).map_err(|_| StorageError::EmptyPathError)?;
 
         //FIXME
         //let entries: Vec<_> = archive.entries().iter().map(|x| x.to_owned()).collect();

--- a/src/core/src/storage.rs
+++ b/src/core/src/storage.rs
@@ -1,12 +1,34 @@
 use std::fs::{DirBuilder, File};
 use std::io::{BufReader, BufWriter, Read, Write};
 use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
 
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use typed_builder::TypedBuilder;
 
 use crate::Error;
+
+#[derive(Clone)]
+pub struct InnerStorage(Arc<Mutex<dyn Storage>>);
+
+impl InnerStorage {
+    pub fn new(inner: impl Storage + 'static) -> InnerStorage {
+        InnerStorage(Arc::new(Mutex::new(inner)))
+    }
+}
+
+impl Storage for InnerStorage {
+    fn save(&self, path: &str, content: &[u8]) -> Result<String, Error> {
+        self.0.save(path, content)
+    }
+    fn load(&self, path: &str) -> Result<Vec<u8>, Error> {
+        self.0.load(path)
+    }
+    fn args(&self) -> StorageArgs {
+        self.0.args()
+    }
+}
 
 #[derive(Debug, Error)]
 pub enum StorageError {
@@ -53,6 +75,23 @@ pub trait Storage {
 
     /// Args for initializing a new Storage
     fn args(&self) -> StorageArgs;
+}
+
+impl<L> Storage for Mutex<L>
+where
+    L: ?Sized + Storage,
+{
+    fn save(&self, path: &str, content: &[u8]) -> Result<String, Error> {
+        self.lock().unwrap().save(path, content)
+    }
+
+    fn load(&self, path: &str) -> Result<Vec<u8>, Error> {
+        self.lock().unwrap().load(path)
+    }
+
+    fn args(&self) -> StorageArgs {
+        self.lock().unwrap().args()
+    }
 }
 
 /// Store files locally into a directory

--- a/src/core/tests/storage.rs
+++ b/src/core/tests/storage.rs
@@ -4,11 +4,18 @@ use std::path::PathBuf;
 use sourmash::storage::{Storage, ZipStorage};
 
 #[test]
-fn zipstorage_load_file() {
+fn zipstorage_load_file() -> Result<(), Box<dyn std::error::Error>> {
     let mut filename = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     filename.push("../../tests/test-data/v6.sbt.zip");
 
-    //let zs = ZipStorage::new(filename.as_str())?;
+    let zs = ZipStorage::new(filename.to_str().unwrap())?;
+
+    let data = zs.load("v6.sbt.json")?;
+
+    let description: serde_json::Value = serde_json::from_slice(&data[..])?;
+    assert_eq!(description["version"], 6);
+
+    Ok(())
 }
 
 #[test]

--- a/src/core/tests/storage.rs
+++ b/src/core/tests/storage.rs
@@ -1,0 +1,30 @@
+use std::fs::File;
+use std::path::PathBuf;
+
+use sourmash::storage::{Storage, ZipStorage};
+
+#[test]
+fn zipstorage_load_file() {
+    let mut filename = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    filename.push("../../tests/test-data/v6.sbt.zip");
+
+    //let zs = ZipStorage::new(filename.as_str())?;
+}
+
+#[test]
+fn zipstorage_load_slice() -> Result<(), Box<dyn std::error::Error>> {
+    let mut filename = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    filename.push("../../tests/test-data/v6.sbt.zip");
+
+    let zip_file = File::open(filename)?;
+    let mapping = unsafe { memmap2::Mmap::map(&zip_file)? };
+
+    let zs = ZipStorage::from_slice(&mapping)?;
+
+    let data = zs.load("v6.sbt.json")?;
+
+    let description: serde_json::Value = serde_json::from_slice(&data[..])?;
+    assert_eq!(description["version"], 6);
+
+    Ok(())
+}

--- a/src/sourmash/index/__init__.py
+++ b/src/sourmash/index/__init__.py
@@ -575,7 +575,7 @@ class ZipFileLinearIndex(Index):
     @classmethod
     def load(cls, location, traverse_yield_all=False, use_manifest=True):
         "Class method to load a zipfile."
-        from .sbt_storage import ZipStorage
+        from ..sbt_storage import ZipStorage
 
         # we can only load from existing zipfiles in this method.
         if not os.path.exists(location):
@@ -916,7 +916,7 @@ class MultiIndex(Index):
         load all files ending in .sig or .sig.gz, by default; if 'force' is
         True, will attempt to load _all_ files, ignoring errors.
         """
-        from .sourmash_args import traverse_find_sigs
+        from ..sourmash_args import traverse_find_sigs
 
         if not os.path.isdir(pathname):
             raise ValueError(f"'{pathname}' must be a directory.")

--- a/src/sourmash/index/__init__.py
+++ b/src/sourmash/index/__init__.py
@@ -40,10 +40,10 @@ from collections import namedtuple, Counter
 import csv
 from io import TextIOWrapper
 
-from .search import make_jaccard_search_query, make_gather_query
-from .manifest import CollectionManifest
-from .logging import debug_literal
-from .signature import load_signatures, save_signatures
+from ..search import make_jaccard_search_query, make_gather_query
+from ..manifest import CollectionManifest
+from ..logging import debug_literal
+from ..signature import load_signatures, save_signatures
 
 # generic return tuple for Index.search and Index.gather
 IndexSearchResult = namedtuple('Result', 'score, signature, location')
@@ -979,7 +979,7 @@ class MultiIndex(Index):
         if they are listed in the text file; it uses 'load_file_as_index'
         underneath.
         """
-        from .sourmash_args import (load_pathlist_from_file,
+        from ..sourmash_args import (load_pathlist_from_file,
                                     load_file_as_index)
         idx_list = []
         src_list = []

--- a/src/sourmash/index/revindex.py
+++ b/src/sourmash/index/revindex.py
@@ -125,7 +125,10 @@ class RevIndex(RustObject, Index):
         #    raise NotImplementedError("Call into Rust and retrieve sigs")
 
     def __len__(self):
-        pass
+        if self._objptr:
+            return self._methodcall(lib.revindex_len)
+        else:
+            return len(self._signatures)
 
     def insert(self, node):
         if self._signatures is None:

--- a/src/sourmash/index/revindex.py
+++ b/src/sourmash/index/revindex.py
@@ -1,0 +1,250 @@
+import weakref
+
+from sourmash.index import Index, IndexSearchResult
+from sourmash.minhash import MinHash
+from sourmash.signature import SourmashSignature
+from sourmash._lowlevel import ffi, lib
+from sourmash.utils import RustObject, rustcall, decode_str, encode_str
+
+
+class RevIndex(RustObject, Index):
+    __dealloc_func__ = lib.revindex_free
+
+    def __init__(
+        self,
+        *,
+        signatures=None,
+        signature_paths=None,
+        template=None,
+        threshold=0,
+        queries=None,
+        keep_sigs=False,
+    ):
+        self.template = template
+        self.threshold = threshold
+        self.queries = queries
+        self.keep_sigs = keep_sigs
+        self.signature_paths = signature_paths
+        self._signatures = signatures
+
+        if signature_paths is None or signatures is None:
+            # delay initialization
+            self._objptr = ffi.NULL
+        else:
+            self._init_inner()
+
+    def _init_inner(self):
+        if self._objptr != ffi.NULL:
+            # Already initialized
+            return
+
+        if (
+            self.signature_paths is None
+            and not self._signatures
+            and self._objptr == ffi.NULL
+        ):
+            raise ValueError("No signatures provided")
+        elif (self.signature_paths or self._signatures) and self._objptr != ffi.NULL:
+            raise NotImplementedError("Need to update RevIndex")
+
+        attached_refs = weakref.WeakKeyDictionary()
+
+        queries_ptr = ffi.NULL
+        queries_size = 0
+        if self.queries:
+            # get list of rust objects
+            collected = []
+            for obj in queries:
+                rv = obj._get_objptr()
+                attached_refs[rv] = obj
+                collected.append(rv)
+            queries_ptr = ffi.new("SourmashSignature*[]", collected)
+            queries_size = len(queries)
+
+        template_ptr = ffi.NULL
+        if self.template:
+            if isinstance(self.template, MinHash):
+                template_ptr = self.template._get_objptr()
+            else:
+                raise ValueError("Template must be a MinHash")
+
+        search_sigs_ptr = ffi.NULL
+        sigs_size = 0
+        collected = []
+        if self.signature_paths:
+            for path in self.signature_paths:
+                collected.append(encode_str(path))
+            search_sigs_ptr = ffi.new("SourmashStr*[]", collected)
+            sigs_size = len(signature_paths)
+
+            self._objptr = rustcall(
+                lib.revindex_new_with_paths,
+                search_sigs_ptr,
+                sigs_size,
+                template_ptr,
+                self.threshold,
+                queries_ptr,
+                queries_size,
+                self.keep_sigs,
+            )
+        elif self._signatures:
+            # force keep_sigs=True, and pass SourmashSignature directly to RevIndex.
+            for sig in self._signatures:
+                collected.append(sig._get_objptr())
+            search_sigs_ptr = ffi.new("SourmashSignature*[]", collected)
+            sigs_size = len(self._signatures)
+
+            self._objptr = rustcall(
+                lib.revindex_new_with_sigs,
+                search_sigs_ptr,
+                sigs_size,
+                template_ptr,
+                self.threshold,
+                queries_ptr,
+                queries_size,
+            )
+
+    def signatures(self):
+        self._init_inner()
+
+        size = ffi.new("uintptr_t *")
+        sigs_ptr = self._methodcall(lib.revindex_signatures, size)
+        size = size[0]
+
+        sigs = []
+        for i in range(size):
+            sig = SourmashSignature._from_objptr(sigs_ptr[i])
+            sigs.append(sig)
+
+        for sig in sigs:
+            yield sig
+
+        #if self._signatures:
+        #    yield from self._signatures
+        #else:
+        #    raise NotImplementedError("Call into Rust and retrieve sigs")
+
+    def __len__(self):
+        pass
+
+    def insert(self, node):
+        if self._signatures is None:
+            self._signatures = []
+        self._signatures.append(node)
+
+    def save(self, path):
+        pass
+
+    @classmethod
+    def load(cls, location):
+        pass
+
+    def select(self, ksize=None, moltype=None):
+        if self.template:
+            if ksize:
+                self.template.ksize = ksize
+            if moltype:
+                self.template.moltype = moltype
+        else:
+            # TODO: deal with None/default values
+            self.template = MinHash(ksize=ksize, moltype=moltype)
+
+#    def search(self, query, *args, **kwargs):
+#        """Return set of matches with similarity above 'threshold'.
+#
+#        Results will be sorted by similarity, highest to lowest.
+#
+#        Optional arguments:
+#          * do_containment: default False. If True, use Jaccard containment.
+#          * ignore_abundance: default False. If True, and query signature
+#            and database support k-mer abundances, ignore those abundances.
+#
+#        Note, the "best only" hint is ignored by LCA_Database
+#        """
+#        if not query.minhash:
+#            return []
+#
+#        # check arguments
+#        if "threshold" not in kwargs:
+#            raise TypeError("'search' requires 'threshold'")
+#        threshold = kwargs["threshold"]
+#        do_containment = kwargs.get("do_containment", False)
+#        ignore_abundance = kwargs.get("ignore_abundance", False)
+#
+#        self._init_inner()
+#
+#        size = ffi.new("uintptr_t *")
+#        results_ptr = self._methodcall(
+#            lib.revindex_search,
+#            query._get_objptr(),
+#            threshold,
+#            do_containment,
+#            ignore_abundance,
+#            size,
+#        )
+#
+#        size = size[0]
+#        if size == 0:
+#            return []
+#
+#        results = []
+#        for i in range(size):
+#            match = SearchResult._from_objptr(results_ptr[i])
+#            if match.score >= threshold:
+#                results.append(IndexSearchResult(match.score, match.signature, match.filename))
+#
+#        return results
+#
+#    def gather(self, query, *args, **kwargs):
+#        "Return the match with the best Jaccard containment in the database."
+#        if not query.minhash:
+#            return []
+#
+#        self._init_inner()
+#
+#        threshold_bp = kwargs.get("threshold_bp", 0.0)
+#        threshold = threshold_bp / (len(query.minhash) * self.scaled)
+#
+#        results = []
+#        size = ffi.new("uintptr_t *")
+#        results_ptr = self._methodcall(
+#            lib.revindex_gather, query._get_objptr(), threshold, True, True, size
+#        )
+#        size = size[0]
+#        if size == 0:
+#            return []
+#
+#        results = []
+#        for i in range(size):
+#            match = SearchResult._from_objptr(results_ptr[i])
+#            if match.score >= threshold:
+#                results.append(IndexSearchResult(match.score, match.signature, match.filename))
+#
+#        results.sort(reverse=True,
+#                     key=lambda x: (x.score, x.signature.md5sum()))
+#
+#        return results[:1]
+
+    @property
+    def scaled(self):
+        return self._methodcall(lib.revindex_scaled)
+
+
+class SearchResult(RustObject):
+    __dealloc_func__ = lib.searchresult_free
+
+    @property
+    def score(self):
+        return self._methodcall(lib.searchresult_score)
+
+    @property
+    def signature(self):
+        sig_ptr = self._methodcall(lib.searchresult_signature)
+        return SourmashSignature._from_objptr(sig_ptr)
+
+    @property
+    def filename(self):
+        result = decode_str(self._methodcall(lib.searchresult_filename))
+        if result == "":
+            return None
+        return result

--- a/src/sourmash/utils.py
+++ b/src/sourmash/utils.py
@@ -52,7 +52,7 @@ def decode_str(s):
 def encode_str(s):
     """Encodes a SourmashStr"""
     rv = ffi.new("SourmashStr *")
-    if isinstance(s, text_type):
+    if isinstance(s, str):
         s = s.encode("utf-8")
     rv.data = ffi.from_buffer(s)
     rv.len = len(s)

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -2424,7 +2424,7 @@ def test_revindex_gather_ignore():
     search_fn = JaccardSearchBestOnly_ButIgnore([ss47])
 
     results = list(lidx.find(search_fn, ss47))
-    results = [ ss for (ss, score) in results ]
+    results = [ ss.signature for ss in results ]
 
     def is_found(ss, xx):
         for q in xx:

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -14,6 +14,7 @@ from sourmash import load_one_signature, SourmashSignature
 from sourmash.index import (LinearIndex, ZipFileLinearIndex,
                             make_jaccard_search_query, CounterGather,
                             LazyLinearIndex, MultiIndex)
+from sourmash.index.revindex import RevIndex
 from sourmash.sbt import SBT, GraphFactory, Leaf
 from sourmash.sbtmh import SigLeaf
 from sourmash import sourmash_args
@@ -2260,7 +2261,6 @@ def test_lazy_index_wraps_multi_index_location():
                                      lazy2.signatures_with_location()):
         assert ss_tup == ss_lazy_tup
 
-
 def test_lazy_loaded_index_1(runtmp):
     # some basic tests for LazyLoadedIndex
     lcafile = utils.get_test_data('prot/protein.lca.json.gz')
@@ -2338,3 +2338,101 @@ def test_lazy_loaded_index_3_find(runtmp):
     x = db.search(query, threshold=0.0)
     x = list(x)
     assert len(x) == 0
+
+def test_revindex_index_search():
+    sig2 = utils.get_test_data("2.fa.sig")
+    sig47 = utils.get_test_data("47.fa.sig")
+    sig63 = utils.get_test_data("63.fa.sig")
+
+    ss2 = sourmash.load_one_signature(sig2, ksize=31)
+    ss47 = sourmash.load_one_signature(sig47)
+    ss63 = sourmash.load_one_signature(sig63)
+
+    lidx = RevIndex(template=ss2.minhash)
+    lidx.insert(ss2)
+    lidx.insert(ss47)
+    lidx.insert(ss63)
+
+    # now, search for sig2
+    sr = lidx.search(ss2, threshold=1.0)
+    print([s[1].name for s in sr])
+    assert len(sr) == 1
+    assert sr[0][1] == ss2
+
+    # search for sig47 with lower threshold; search order not guaranteed.
+    sr = lidx.search(ss47, threshold=0.1)
+    print([s[1].name for s in sr])
+    assert len(sr) == 2
+    sr.sort(key=lambda x: -x[0])
+    assert sr[0][1] == ss47
+    assert sr[1][1] == ss63
+
+    # search for sig63 with lower threshold; search order not guaranteed.
+    sr = lidx.search(ss63, threshold=0.1)
+    print([s[1].name for s in sr])
+    assert len(sr) == 2
+    sr.sort(key=lambda x: -x[0])
+    assert sr[0][1] == ss63
+    assert sr[1][1] == ss47
+
+    # search for sig63 with high threshold => 1 match
+    sr = lidx.search(ss63, threshold=0.8)
+    print([s[1].name for s in sr])
+    assert len(sr) == 1
+    sr.sort(key=lambda x: -x[0])
+    assert sr[0][1] == ss63
+
+
+def test_revindex_gather():
+    sig2 = utils.get_test_data("2.fa.sig")
+    sig47 = utils.get_test_data("47.fa.sig")
+    sig63 = utils.get_test_data("63.fa.sig")
+
+    ss2 = sourmash.load_one_signature(sig2, ksize=31)
+    ss47 = sourmash.load_one_signature(sig47)
+    ss63 = sourmash.load_one_signature(sig63)
+
+    lidx = RevIndex(template=ss2.minhash)
+    lidx.insert(ss2)
+    lidx.insert(ss47)
+    lidx.insert(ss63)
+
+    matches = lidx.gather(ss2)
+    assert len(matches) == 1
+    assert matches[0][0] == 1.0
+    assert matches[0][1] == ss2
+
+    matches = lidx.gather(ss47)
+    assert len(matches) == 1
+    assert matches[0][0] == 1.0
+    assert matches[0][1] == ss47
+
+
+def test_revindex_gather_ignore():
+    sig2 = utils.get_test_data('2.fa.sig')
+    sig47 = utils.get_test_data('47.fa.sig')
+    sig63 = utils.get_test_data('63.fa.sig')
+
+    ss2 = sourmash.load_one_signature(sig2, ksize=31)
+    ss47 = sourmash.load_one_signature(sig47, ksize=31)
+    ss63 = sourmash.load_one_signature(sig63, ksize=31)
+
+    # construct an index...
+    lidx = RevIndex(template=ss2.minhash, signatures=[ss2, ss47, ss63])
+
+    # ...now search with something that should ignore sig47, the exact match.
+    search_fn = JaccardSearchBestOnly_ButIgnore([ss47])
+
+    results = list(lidx.find(search_fn, ss47))
+    results = [ ss for (ss, score) in results ]
+
+    def is_found(ss, xx):
+        for q in xx:
+            print(ss, ss.similarity(q))
+            if ss.similarity(q) == 1.0:
+                return True
+        return False
+
+    assert not is_found(ss47, results)
+    assert not is_found(ss2, results)
+    assert is_found(ss63, results)


### PR DESCRIPTION
This PR moves the `greyhound-core` (`RevIndex` and `gather`) into sourmash. It doesn't bring the CLI, web server or browser frontend.
(The CLI should probably be exposed here at some point, the web server and frontend should go into `wort`).

I created a new feature on the Rust side, "experimental". The idea is to allow experimentation without making stability guarantees, including passing all checks required for merging (like wasm support). #1221 is another example of an "experimental" feature.
In order to avoid piling up experimental features, I also propose a requirement that sourmash-Python CAN'T use the "experimental" feature. This keeps us honest, and force stabilization in the Rust side =]
This is sort of equivalent to the `nightly` features in the Rust compiler.

Lots left to do, but a small list:

- [ ] properly use the `parallel` feature to expose rayon
- [ ] fix wasm compilation
