### PR TITLE
CI: Fix releases in GitHub Actions

### DIFF
--- a/.github/workflows/asv.yml
+++ b/.github/workflows/asv.yml
@@ -2,6 +2,9 @@ name: asv benchmarks
 
 on:
   push:
+    branches: [latest]
+  pull_request:
+    branches: [latest]
   schedule:
     - cron: "0 0 * * *" # daily
 

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -48,11 +48,23 @@ jobs:
         with:
           path: './dist/sourmash*.whl'
 
+  release:
+    name: Publish wheels
+    runs-on: ubuntu-18.04
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: build_wheels
+
+    steps:
+      - name: Fetch wheels from artifacts
+        id: fetch_artifacts
+        uses: actions/download-artifact@v2
+        with:
+          path: 'wheels/'
+
       # if it matches a Python release tag, upload to github releases
-      # TODO: check https://github.com/actions/upload-release-asset
+      # TODO: In the future, use the create-release and upload-release-assets actions
       - name: Release
         uses: fnkr/github-action-ghr@v1
-        if: startsWith(github.ref, 'refs/tags/v')
         env:
-          GHR_PATH: dist/
+          GHR_PATH: ${{steps.fetch_artifacts.outputs.download-path}}/artifact
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -16,6 +16,7 @@ jobs:
     strategy:
       matrix:
          os: [ubuntu-18.04, macos-latest]
+      fail-fast: false
 
     steps:
       - uses: actions/checkout@v2
@@ -53,5 +54,5 @@ jobs:
         uses: fnkr/github-action-ghr@v1
         if: startsWith(github.ref, 'refs/tags/v')
         env:
-            GHR_PATH: ./dist/
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHR_PATH: dist/
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -3,7 +3,6 @@ name: Python tests
 on:
   push:
     branches: [latest]
-    tags: v*
   pull_request:
     branches: [latest]
   schedule:


### PR DESCRIPTION
Reorganized the build_wheel workflow to
1) build wheels for Linux and MacOS
2) upload to artifacts
3) if it is a new release, download the artifacts and upload to github releases

Because step 3 waits for 1 and 2 to be done, it doesn't hit the problem of running docker on MacOS.

Example release on my fork: https://github.com/luizirber/sourmash/releases/tag/v4.0.0a3
And the workflow that released it: https://github.com/luizirber/sourmash/actions/runs/408870105

## Checklist

- [ ] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make coverage` Is the new code covered?
- [ ] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
