### PR TITLE
CI: small build fixes

### DIFF
--- a/.github/workflows/asv.yml
+++ b/.github/workflows/asv.yml
@@ -15,14 +15,22 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
+
     - name: Set up Python 3.7
       uses: actions/setup-python@v1
       with:
         python-version: 3.7
+
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        override: true
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install asv virtualenv==16.7.9
+
     - name: Runs benchmarks against latest
       run: |
         asv machine --yes

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Set up IPFS
         if: startsWith(runner.os, 'Linux') && (matrix.py == '3.9')
-        uses: luizirber/setup-ipfs@fix_add_path
+        uses: ibnesayeed/setup-ipfs@master
         with:
           ipfs_version: 0.6
           run_daemon: true

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -201,7 +201,7 @@ jobs:
       - name: Install wasmtime
         run: "curl https://wasmtime.dev/install.sh -sSf | bash"
       - name: Add wasmtime to PATH
-        run: echo "::add-path::$HOME/.wasmtime/bin"
+        run: echo "$HOME/.wasmtime/bin" >> $GITHUB_PATH
       - name: Install cargo-wasi command
         uses: actions-rs/cargo@v1
         with:

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -12,7 +12,8 @@
     "html_dir": ".asv/html",
     "build_cache_size": 8,
     "build_command": [
-      "python -m pip install build",
-      "python -m build --sdist --wheel --outdir {build_cache_dir} {build_dir}"
+      "python -m pip install 'setuptools_scm[toml]<5' milksnake",
+      "python setup.py build",
+      "PIP_NO_BUILD_ISOLATION=false python -mpip wheel --no-deps --no-index -w {build_cache_dir} {build_dir}"
     ]
 }

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -3,12 +3,16 @@
     "project": "sourmash",
     "project_url": "https://github.com/dib-lab/sourmash",
     "repo": ".",
-    "branches": ["latest"], // for git
+    "branches": ["latest"],
     "dvcs": "git",
     "environment_type": "virtualenv",
     "pythons": ["3.7"],
     "env_dir": ".asv/env",
     "results_dir": ".asv/results",
     "html_dir": ".asv/html",
-    "build_cache_size": 8
+    "build_cache_size": 8,
+    "build_command": [
+      "python -m pip install build",
+      "python -m build --sdist --wheel --outdir {build_cache_dir} {build_dir}"
+    ]
 }

--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -48,11 +48,11 @@ class TimeMinHashSuite:
         mh = self.mh
         mh.add_many(list(range(1000)))
 
-    def time_compare(self):
+    def time_similarity(self):
         mh = self.mh
         other_mh = self.populated_mh
         for i in range(500):
-            mh.compare(other_mh)
+            mh.similarity(other_mh)
 
     def time_count_common(self):
         mh = self.mh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,9 @@
+[build-system]
+requires = [
+    "setuptools >= 48",
+    "setuptools_scm[toml] >= 4, <5",
+    "setuptools_scm_git_archive",
+    "milksnake",
+    "wheel >= 0.29.0",
+]
+build-backend = 'setuptools.build_meta'

--- a/setup.py
+++ b/setup.py
@@ -64,10 +64,11 @@ SETUP_METADATA = {
                          'matplotlib', 'scipy', 'deprecation>=2.0.6',
                          'cachetools >=4,<5'],
     "setup_requires": [
-        "setuptools>=38.6.0",
+        "setuptools>=48",
         "milksnake",
-        "setuptools_scm>=3.2.0",
+        "setuptools_scm[toml] >= 4, <5",
         "setuptools_scm_git_archive",
+        "wheel >= 0.29.0",
     ],
     "use_scm_version": {
         "write_to": "sourmash/version.py",

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -33,7 +33,7 @@ getset = "0.1.1"
 log = "0.4.8"
 md5 = "0.7.0"
 murmurhash3 = "0.0.5"
-niffler = { version = "2.2.0", default-features = false, features = [ "gz" ] }
+niffler = { version = "2.3.1", default-features = false, features = [ "gz" ] }
 nohash-hasher = "0.2.0"
 num-iter = "0.1.41"
 once_cell = "1.3.1"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,9 @@ import os
 from hypothesis import settings, Verbosity
 import pytest
 
+import matplotlib.pyplot as plt
+plt.rcParams.update({'figure.max_open_warning': 0})
+
 
 @pytest.fixture(params=[True, False])
 def track_abundance(request):


### PR DESCRIPTION
Small build fixes in preparation for #696 (and also fixing assorted paper cuts)

- fix rust checks for WASI (wasmtime installation)
- fix benchmarks (`mh.compare` was removed, and use [`build`](https://pypi.org/project/build) to generate wheels and sdist for `asv`)
- add a `pyproject.toml` to make sourmash pep517-compliant.
- update niffler to 2.3.1
- avoid mpl warnings on tests

## Checklist

- [ ] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make coverage` Is the new code covered?
- [ ] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
