### PR TITLE
[WIP] Index.gather is not doing gather?

### DIFF
--- a/src/sourmash/index.py
+++ b/src/sourmash/index.py
@@ -108,10 +108,12 @@ class Index(ABC):
 
         # actually do search!
         results = []
+        query_mh = query.minhash
         for ss in self.signatures():
-            cont = query.minhash.contained_by(ss.minhash, True)
+            cont = query_mh.contained_by(ss.minhash, True)
             if cont and cont >= threshold:
                 results.append((cont, ss, self.filename))
+                query_mh.remove_many(ss.minhash.hashes)
 
         results.sort(reverse=True, key=lambda x: (x[0], x[1].md5sum()))
 

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -132,11 +132,9 @@ def test_linear_index_gather():
     assert matches[0][1] == ss2
 
     matches = lidx.gather(ss47)
-    assert len(matches) == 2
+    assert len(matches) == 1
     assert matches[0][0] == 1.0
     assert matches[0][1] == ss47
-    assert round(matches[1][0], 2) == 0.49
-    assert matches[1][1] == ss63
 
 
 def test_linear_index_save():


### PR DESCRIPTION
The default implementation of `Index.gather` returns all signatures with a containment above a threshold, which... is not what gather is supposed to do =]

SBT and LCA reimplement the method, but `LinearIndex` reuses it and generate the wrong results.

There is also a discussion about the proper intended behavior of `Index.gather`. Sometimes it returns the best match (only), sometimes it returns a list of matches. I think we should have a separate method for the first use case (`best_match`?), and another with a simple `gather` based on linear scans over the signatures.

cc @ctb 

## Checklist

- [ ] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make coverage` Is the new code covered?
- [ ] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
