### PR TITLE
[MRG] Fix new clippy warnings from Rust 1.49

### DIFF
--- a/src/core/src/index/sbt/mod.rs
+++ b/src/core/src/index/sbt/mod.rs
@@ -15,7 +15,6 @@ use std::fmt::Debug;
 use std::fs::File;
 use std::hash::BuildHasherDefault;
 use std::io::{BufReader, Read};
-use std::iter::FromIterator;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
 
@@ -722,12 +721,7 @@ where
         let next_leaf = datasets.pop().unwrap();
 
         let (simleaf_tree, in_common) = if datasets.is_empty() {
-            (
-                BinaryTree::Empty,
-                HashSet::<u64, BuildHasherDefault<NoHashHasher<u64>>>::from_iter(
-                    next_leaf.mins().into_iter(),
-                ),
-            )
+            (BinaryTree::Empty, next_leaf.mins().into_iter().collect())
         } else {
             let mut similar_leaf_pos = 0;
             let mut current_max = 0;
@@ -741,16 +735,13 @@ where
 
             let similar_leaf = datasets.remove(similar_leaf_pos);
 
-            let in_common = HashSet::<u64, BuildHasherDefault<NoHashHasher<u64>>>::from_iter(
-                next_leaf.mins().into_iter(),
-            )
-            .union(
-                &HashSet::<u64, BuildHasherDefault<NoHashHasher<u64>>>::from_iter(
-                    similar_leaf.mins().into_iter(),
-                ),
-            )
-            .cloned()
-            .collect();
+            let in_common = next_leaf
+                .mins()
+                .into_iter()
+                .collect::<HashSet<u64, BuildHasherDefault<NoHashHasher<u64>>>>()
+                .union(&similar_leaf.mins().into_iter().collect())
+                .cloned()
+                .collect();
 
             let simleaf_tree = BinaryTree::Leaf(Box::new(TreeNode {
                 element: similar_leaf,

--- a/src/core/src/sketch/hyperloglog/mod.rs
+++ b/src/core/src/sketch/hyperloglog/mod.rs
@@ -40,11 +40,11 @@ impl HyperLogLog {
     }
 
     pub fn new(p: usize, ksize: usize) -> Result<HyperLogLog, Error> {
-        if p < 4 || p > 18 {
+        if !(4..=18).contains(&p) {
             return Err(Error::HLLPrecisionBounds);
         }
 
-        let size = (1 as usize) << p;
+        let size = (1_usize) << p;
         let registers = vec![0; size];
 
         Ok(HyperLogLog {


### PR DESCRIPTION
CI started failing after Rust 1.49 was released, since 5 new clippy warnings showed up. This PR fixes them.

## Checklist

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make coverage` Is the new code covered?
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
