### PR TITLE
[WIP] Ertl estimators for scaled minhash

### DIFF
--- a/src/core/src/signature.rs
+++ b/src/core/src/signature.rs
@@ -364,8 +364,14 @@ impl Signature {
                     if mh.check_compatible(template).is_ok() {
                         return Some(sk);
                     }
-                } else {
-                    unimplemented!()
+                }
+            }
+        } else if let Sketch::HyperLogLog(template) = sketch {
+            for sk in &self.signatures {
+                if let Sketch::HyperLogLog(mh) = sk {
+                    if mh.check_compatible(template).is_ok() {
+                        return Some(sk);
+                    }
                 }
             }
         } else {

--- a/src/core/src/signature.rs
+++ b/src/core/src/signature.rs
@@ -229,7 +229,7 @@ impl SigsTrait for Sketch {
         match *self {
             Sketch::MinHash(ref mut mh) => mh.add_sequence(seq, force),
             Sketch::LargeMinHash(ref mut mh) => mh.add_sequence(seq, force),
-            Sketch::HyperLogLog(_) => unimplemented!(),
+            Sketch::HyperLogLog(ref mut hll) => hll.add_sequence(seq, force),
         }
     }
 
@@ -237,7 +237,7 @@ impl SigsTrait for Sketch {
         match *self {
             Sketch::MinHash(ref mut mh) => mh.add_protein(seq),
             Sketch::LargeMinHash(ref mut mh) => mh.add_protein(seq),
-            Sketch::HyperLogLog(_) => unimplemented!(),
+            Sketch::HyperLogLog(ref mut hll) => hll.add_protein(seq),
         }
     }
 }


### PR DESCRIPTION
The idea of this PR is to estimate the cardinality of the original dataset using the scaled minhash as a proxy
(the scaled minhash has a reduced resolution HLL equivalent to full resolution HLL from the original dataset), keeping it backwards-compatible with existing sigs (since we can build the reduced HLL from the scaled minhash).

(Surfacing this after talking with @bluegenes)

## TODO

- [ ] finish impl
- [ ] validate with experiments

## Checklist

- [ ] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make coverage` Is the new code covered?
- [ ] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
