### PR TITLE
[CI] update rand for test, and activate "js" feature for getrandom

### DIFF
--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -63,7 +63,8 @@ criterion = "0.3.2"
 needletail = { version = "0.4.0", default-features = false }
 predicates = "1.0.4"
 proptest = { version = "0.9.6", default-features = false, features = ["std"]}  # Upgrade to 0.10 requires rust 1.39
-rand = "0.7.3"
+rand = "0.8.2"
+getrandom = { version = "0.2", features = ["js"] }
 tempfile = "3.1.0"
 
 [[bench]]


### PR DESCRIPTION
WASM tests started failing because `getrandom` was missing the "js" feature. This also closes #1274 

## Checklist

- [ ] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make coverage` Is the new code covered?
- [ ] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
