### PR TITLE
add deprecation warning to `sourmash info` in support of `sourmash -v`.

### DIFF
--- a/src/sourmash/cli/info.py
+++ b/src/sourmash/cli/info.py
@@ -15,6 +15,10 @@ def subparser(subparsers):
 
 def info(verbose=False):
     "Report sourmash version + version of installed dependencies."
+    notify("** WARNING: 'info' is deprecated as of sourmash 4.0, and will")
+    notify("**    be removed in sourmash 5.0; use 'sourmash -v -d' instead.")
+    notify('')
+
     notify('sourmash version {}', sourmash.VERSION)
     notify('- loaded from path: {}', os.path.dirname(__file__))
     notify('')


### PR DESCRIPTION
Would fix https://github.com/dib-lab/sourmash/issues/818 but I'm not actually going to request merge; leaving code here because I wrote it, that's all :).

## Checklist

- [ ] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make coverage` Is the new code covered?
- [ ] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
