### PR TITLE
[MRG] Switch use of `load_signatures` over to `load_file_as_signatures` throughout.

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -4,13 +4,15 @@ import sourmash
 import sourmash_tst_utils as utils
 
 
-def test_sourmash_signature_api():
+@utils.in_tempdir
+def test_sourmash_signature_api(c):
     e = sourmash.MinHash(n=1, ksize=20)
     sig = sourmash.SourmashSignature(e)
 
-    s = sourmash.save_signatures([sig])
-    sig_x1 = sourmash.load_one_signature(s)
-    sig_x2 = list(sourmash.load_signatures(s))[0]
+    with open(c.output('xxx.sig'), 'wt') as fp:
+        sourmash.save_signatures([sig], fp)
+    sig_x1 = sourmash.load_one_signature(c.output('xxx.sig'))
+    sig_x2 = list(sourmash.load_file_as_signatures(c.output('xxx.sig')))[0]
 
     assert sig_x1 == sig
     assert sig_x2 == sig

--- a/tests/test_cmd_signature.py
+++ b/tests/test_cmd_signature.py
@@ -9,6 +9,7 @@ import pytest
 
 import sourmash_tst_utils as utils
 import sourmash
+from sourmash.signature import load_signatures
 
 ## command line tests
 
@@ -185,7 +186,7 @@ def test_sig_filter_1(c):
     # stdout should be new signature
     out = c.last_result.out
 
-    filtered_sigs = list(sourmash.load_signatures(out))
+    filtered_sigs = list(load_signatures(out))
     filtered_sigs.sort(key=lambda x: str(x))
 
     assert len(filtered_sigs) == 2
@@ -578,7 +579,7 @@ def test_sig_rename_1_multisig(c):
     out = c.last_result.out
 
     n = 0
-    for sig in sourmash.load_signatures(out):
+    for sig in load_signatures(out):
         assert sig.name == 'fiz bar'
         n += 1
 
@@ -596,7 +597,7 @@ def test_sig_rename_1_multisig_ksize(c):
     out = c.last_result.out
 
     n = 0
-    for sig in sourmash.load_signatures(out):
+    for sig in load_signatures(out):
         assert sig.name == 'fiz bar'
         n += 1
 
@@ -652,7 +653,7 @@ def test_sig_cat_1_no_unique(c):
     out = c.last_result.out
 
     test_cat_sig = sourmash.load_one_signature(sig47)
-    actual_cat_sigs = sourmash.load_signatures(out)
+    actual_cat_sigs = load_signatures(out)
 
     for n, sig in enumerate(actual_cat_sigs):
         assert sig == test_cat_sig
@@ -672,7 +673,7 @@ def test_sig_cat_1_unique(c):
     err = c.last_result.err
 
     test_cat_sig = sourmash.load_one_signature(sig47)
-    actual_cat_sigs = sourmash.load_signatures(out)
+    actual_cat_sigs = load_signatures(out)
 
     for n, sig in enumerate(actual_cat_sigs):
         assert sig == test_cat_sig
@@ -693,7 +694,7 @@ def test_sig_cat_2(c):
     # stdout should be same signatures
     out = c.last_result.out
 
-    siglist = list(sourmash.load_signatures(out))
+    siglist = list(load_signatures(out))
     print(len(siglist))
 
     assert repr(siglist) == """[SourmashSignature('NC_009665.1 Shewanella baltica OS185, complete genome', 09a08691), SourmashSignature('NC_009665.1 Shewanella baltica OS185, complete genome', 09a08691), SourmashSignature('NC_009665.1 Shewanella baltica OS185, complete genome', 57e2b22f), SourmashSignature('NC_009661.1 Shewanella baltica OS185 plasmid pS18501, complete sequence', bde81a41), SourmashSignature('NC_011663.1 Shewanella baltica OS223, complete genome', f033bbd8), SourmashSignature('NC_011664.1 Shewanella baltica OS223 plasmid pS22301, complete sequence', 87a9aec4), SourmashSignature('NC_011668.1 Shewanella baltica OS223 plasmid pS22302, complete sequence', 837bf2a7), SourmashSignature('NC_011665.1 Shewanella baltica OS223 plasmid pS22303, complete sequence', 485c3377)]"""
@@ -711,7 +712,7 @@ def test_sig_cat_2_out(c):
     # stdout should be same signatures
     out = c.output('out.sig')
 
-    siglist = list(sourmash.load_signatures(out))
+    siglist = list(load_signatures(out))
     print(len(siglist))
 
     assert repr(siglist) == """[SourmashSignature('NC_009665.1 Shewanella baltica OS185, complete genome', 09a08691), SourmashSignature('NC_009665.1 Shewanella baltica OS185, complete genome', 09a08691), SourmashSignature('NC_009665.1 Shewanella baltica OS185, complete genome', 57e2b22f), SourmashSignature('NC_009661.1 Shewanella baltica OS185 plasmid pS18501, complete sequence', bde81a41), SourmashSignature('NC_011663.1 Shewanella baltica OS223, complete genome', f033bbd8), SourmashSignature('NC_011664.1 Shewanella baltica OS223 plasmid pS22301, complete sequence', 87a9aec4), SourmashSignature('NC_011668.1 Shewanella baltica OS223 plasmid pS22302, complete sequence', 837bf2a7), SourmashSignature('NC_011665.1 Shewanella baltica OS223 plasmid pS22303, complete sequence', 485c3377)]"""
@@ -734,7 +735,7 @@ def test_sig_cat_2_out_inplace(c):
     # stdout should be same signatures
     out = input_sig
 
-    siglist = list(sourmash.load_signatures(out))
+    siglist = list(load_signatures(out))
     print(len(siglist))
 
     assert repr(siglist) == """[SourmashSignature('NC_009665.1 Shewanella baltica OS185, complete genome', 09a08691), SourmashSignature('NC_009665.1 Shewanella baltica OS185, complete genome', 09a08691), SourmashSignature('NC_009665.1 Shewanella baltica OS185, complete genome', 57e2b22f), SourmashSignature('NC_009661.1 Shewanella baltica OS185 plasmid pS18501, complete sequence', bde81a41), SourmashSignature('NC_011663.1 Shewanella baltica OS223, complete genome', f033bbd8), SourmashSignature('NC_011664.1 Shewanella baltica OS223 plasmid pS22301, complete sequence', 87a9aec4), SourmashSignature('NC_011668.1 Shewanella baltica OS223 plasmid pS22302, complete sequence', 837bf2a7), SourmashSignature('NC_011665.1 Shewanella baltica OS223 plasmid pS22303, complete sequence', 485c3377)]"""
@@ -757,7 +758,7 @@ def test_sig_cat_filelist(c):
     # stdout should be same signatures
     out = c.output('out.sig')
 
-    siglist = list(sourmash.load_signatures(out))
+    siglist = list(load_signatures(out))
     print(len(siglist))
 
     assert repr(siglist) == """[SourmashSignature('NC_009665.1 Shewanella baltica OS185, complete genome', 09a08691), SourmashSignature('NC_009665.1 Shewanella baltica OS185, complete genome', 09a08691), SourmashSignature('NC_009665.1 Shewanella baltica OS185, complete genome', 57e2b22f), SourmashSignature('NC_009661.1 Shewanella baltica OS185 plasmid pS18501, complete sequence', bde81a41), SourmashSignature('NC_011663.1 Shewanella baltica OS223, complete genome', f033bbd8), SourmashSignature('NC_011664.1 Shewanella baltica OS223 plasmid pS22301, complete sequence', 87a9aec4), SourmashSignature('NC_011668.1 Shewanella baltica OS223 plasmid pS22302, complete sequence', 837bf2a7), SourmashSignature('NC_011665.1 Shewanella baltica OS223 plasmid pS22303, complete sequence', 485c3377)]"""
@@ -780,7 +781,7 @@ def test_sig_cat_filelist_with_dbs(c):
     # stdout should be same signatures
     out = c.output('out.sig')
 
-    siglist = list(sourmash.load_signatures(out))
+    siglist = list(load_signatures(out))
     print(len(siglist))
 
     assert repr(siglist) == """[SourmashSignature('NC_009665.1 Shewanella baltica OS185, complete genome', 09a08691), SourmashSignature('NC_009665.1 Shewanella baltica OS185, complete genome', 09a08691), SourmashSignature('', 6d6e87e1), SourmashSignature('', 60f7e23c), SourmashSignature('', 0107d767), SourmashSignature('', f71e7817), SourmashSignature('', f0c834bc), SourmashSignature('', 4e94e602), SourmashSignature('', b59473c9)]"""
@@ -1003,7 +1004,7 @@ def test_sig_extract_6(c):
     # stdout should be new signature
     out = c.last_result.out
 
-    siglist = sourmash.load_signatures(out)
+    siglist = load_signatures(out)
     siglist = list(siglist)
 
     assert len(siglist) == 2
@@ -1018,7 +1019,7 @@ def test_sig_extract_7(c):
     # stdout should be new signature
     out = c.last_result.out
 
-    siglist = sourmash.load_signatures(out)
+    siglist = load_signatures(out)
     siglist = list(siglist)
 
     assert len(siglist) == 1
@@ -1033,7 +1034,7 @@ def test_sig_extract_7_no_ksize(c):
     # stdout should be new signature
     out = c.last_result.out
 
-    siglist = sourmash.load_signatures(out)
+    siglist = load_signatures(out)
     siglist = list(siglist)
 
     assert len(siglist) == 3
@@ -1049,7 +1050,7 @@ def test_sig_flatten_1(c):
     # stdout should be new signature
     out = c.last_result.out
 
-    siglist = sourmash.load_signatures(out)
+    siglist = load_signatures(out)
     siglist = list(siglist)
 
     assert len(siglist) == 1
@@ -1067,7 +1068,7 @@ def test_sig_flatten_2_ksize(c):
     # stdout should be new signature
     out = c.last_result.out
 
-    siglist = sourmash.load_signatures(out)
+    siglist = load_signatures(out)
     siglist = list(siglist)
 
     assert len(siglist) == 1
@@ -1099,7 +1100,7 @@ def test_sig_downsample_1_scaled_downsample_multisig(c):
     # stdout should be new signatures
     out = c.last_result.out
 
-    for sig in sourmash.load_signatures(out):
+    for sig in load_signatures(out):
         assert sig.minhash.scaled == 10000
 
 

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -5,7 +5,8 @@ import numpy as np
 import pytest
 
 import sourmash
-from sourmash.compare import compare_all_pairs, compare_parallel, compare_serial
+from sourmash.compare import (compare_all_pairs, compare_parallel,
+                              compare_serial)
 import sourmash_tst_utils as utils
 
 
@@ -15,7 +16,7 @@ def siglist():
     filenames = sorted(glob.glob(os.path.join(demo_path, "*.sig")))
     sigs = []
     for filename in filenames:
-        sigs.extend(sourmash.load_signatures(filename))
+        sigs.extend(sourmash.load_file_as_signatures(filename))
     return sigs
 
 

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -157,8 +157,7 @@ def test_linear_index_save():
         filename = os.path.join(location, 'foo')
         linear.save(filename)
 
-        from sourmash import load_signatures
-        si = set(load_signatures(filename))
+        si = set(sourmash.load_file_as_signatures(filename))
 
     x = {ss2, ss47, ss63}
 
@@ -321,7 +320,7 @@ def test_linear_gather_threshold_5():
 def test_linear_index_multik_select():
     # this loads three ksizes, 21/31/51
     sig2 = utils.get_test_data('2.fa.sig')
-    siglist = sourmash.load_signatures(sig2)
+    siglist = sourmash.load_file_as_signatures(sig2)
 
     linear = LinearIndex()
     for ss in siglist:
@@ -339,7 +338,7 @@ def test_linear_index_multik_select():
 def test_linear_index_moltype_select():
     # this loads two ksizes(21, 10), and two moltypes (DNA and protein)
     filename = utils.get_test_data('genome-s10+s11.sig')
-    siglist = sourmash.load_signatures(filename)
+    siglist = sourmash.load_file_as_signatures(filename)
 
     linear = LinearIndex()
     for ss in siglist:

--- a/tests/test_sbt.py
+++ b/tests/test_sbt.py
@@ -5,7 +5,8 @@ import os
 import pytest
 
 import sourmash
-from sourmash import load_one_signature, SourmashSignature, load_signatures
+from sourmash import (load_one_signature, SourmashSignature,
+                      load_file_as_signatures)
 from sourmash.exceptions import IndexNotSupported
 from sourmash.sbt import SBT, GraphFactory, Leaf, Node
 from sourmash.sbtmh import (SigLeaf, search_minhashes,
@@ -340,7 +341,7 @@ def test_sbt_zipstorage(tmpdir):
     tree = SBT(factory)
 
     for f in utils.SIG_FILES:
-        sig = next(load_signatures(utils.get_test_data(f)))
+        sig = next(load_file_as_signatures(utils.get_test_data(f)))
         leaf = SigLeaf(os.path.basename(f), sig)
         tree.add_node(leaf)
         to_search = leaf


### PR DESCRIPTION
Per https://github.com/dib-lab/sourmash/issues/1296#issuecomment-773701424

This fixes deprecation warnings caused by merge of https://github.com/dib-lab/sourmash/pull/1279.

Note that, viz `tests/test_api.py`, we no longer provide a top-level / public API for loading signatures from strings.

## Checklist

- [ ] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make coverage` Is the new code covered?
- [ ] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
