### PR TITLE
[MRG] Deprecations for next 3.5.x release, in support of 4.0 release.

### DIFF
--- a/sourmash/cli/compute.py
+++ b/sourmash/cli/compute.py
@@ -30,6 +30,7 @@ from argparse import FileType
 
 from sourmash.minhash import get_minhash_default_seed
 from sourmash.cli.utils import add_construct_moltype_args
+from sourmash.logging import notify
 
 
 def ksize_parser(ksizes):
@@ -167,4 +168,8 @@ def subparser(subparsers):
 
 def main(args):
     from sourmash.command_compute import compute
+    if args.input_is_10x:
+        notify("** WARNING: 10x support is deprecated as of sourmash 3.5.x, and will")
+        notify("**    be removed in sourmash 4.0; use kmermaid instead.")
+        notify('')
     return compute(args)

--- a/sourmash/cli/lca/summarize.py
+++ b/sourmash/cli/lca/summarize.py
@@ -40,4 +40,10 @@ def subparser(subparsers):
 
 def main(args):
     import sourmash
+
+    notify("** WARNING: lca summarize behavior is changing in sourmash 4.0")
+    notify("**   As of 4.0, lca summarize will always apply --singleton.")
+    notify("**   In addition, --with-abundance is on by default;")
+    notify("**   please use --ignore-abundance to ignore abundances.")
+
     return sourmash.lca.command_summarize.summarize_main(args)

--- a/sourmash/minhash.py
+++ b/sourmash/minhash.py
@@ -4,12 +4,13 @@ from __future__ import unicode_literals, division
 import math
 import copy
 import collections
+import warnings
+from deprecation import deprecated
 
 from . import VERSION
 from ._lowlevel import ffi, lib
 from .utils import RustObject, rustcall, decode_str
 from .exceptions import SourmashError
-from deprecation import deprecated
 
 # default MurmurHash seed
 MINHASH_DEFAULT_SEED = 42
@@ -625,7 +626,9 @@ class MinHash(RustObject):
         self._methodcall(lib.kmerminhash_merge, other._get_objptr())
         return self
 
-    merge = __iadd__
+    def merge(self, other):
+        warnings.warn("Warning, MinHash.merge(...) will return None in sourmash 4.0; use '+' operator for old behavior.")
+        return self.__iadd__(other)
 
     def set_abundances(self, values, clear=True):
         """Set abundances for hashes from ``values``, where


### PR DESCRIPTION
Fixes https://github.com/dib-lab/sourmash/issues/1288, by deprecating 10x support.
Fixes https://github.com/dib-lab/sourmash/issues/1176, by providing warnings about new `lca summarize` behavior.
Fixes https://github.com/dib-lab/sourmash/issues/1306, by warning about new `MinHash.merge` behavior.

## Checklist

- [ ] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make coverage` Is the new code covered?
- [ ] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
