### PR TITLE
[WIP] Convert warnings to errors when running Pytest

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -97,3 +97,5 @@ python_files =
 testpaths =
     tests
     doc
+filterwarnings =
+    error


### PR DESCRIPTION
Controlling warnings and errors was mentioned in https://github.com/dib-lab/sourmash/issues/1296#issuecomment-774498515

And today there is a [gigantic discussion][0] about communicating these issues to users, and a suggestion is to enable [`filterwarnings = error`][1] in pytest.

[0]: https://github.com/pyca/cryptography/issues/5771
[1]: https://github.com/pyca/cryptography/issues/5771#issuecomment-775251831

But, as we discussed in #1296, this is very aggressive and confusing. But probably worth activating from time to time and clean up our warnings...

## Checklist

- [ ] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make coverage` Is the new code covered?
- [ ] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
