### PR TITLE
[MRG] Reapply 3.5.x deprecations in support of 4.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ SETUP_METADATA = {
         'doc' : ['sphinx', 'myst-parser[sphinx]', 'alabaster',
                  "sphinxcontrib-napoleon", "nbsphinx",
                  "ipython"],
-        '10x': ['bam2fasta==1.0.4'],
+        '10x': ['bam2fasta==1.0.8'],
         'storage': ["ipfshttpclient>=0.4.13", "redis"]
     },
     "include_package_data": True,

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ SETUP_METADATA = {
         'doc' : ['sphinx', 'myst-parser[sphinx]', 'alabaster',
                  "sphinxcontrib-napoleon", "nbsphinx",
                  "ipython"],
-        '10x': ['bam2fasta==1.0.8'],
+        '10x': ['bam2fasta==1.0.4'],
         'storage': ["ipfshttpclient>=0.4.13", "redis"]
     },
     "include_package_data": True,

--- a/sourmash/cli/compute.py
+++ b/sourmash/cli/compute.py
@@ -30,7 +30,6 @@ from argparse import FileType
 
 from sourmash.minhash import get_minhash_default_seed
 from sourmash.cli.utils import add_construct_moltype_args
-from sourmash.logging import notify
 
 
 def ksize_parser(ksizes):
@@ -168,8 +167,4 @@ def subparser(subparsers):
 
 def main(args):
     from sourmash.command_compute import compute
-    if args.input_is_10x:
-        notify("** WARNING: 10x support is deprecated as of sourmash 3.5.x, and will")
-        notify("**    be removed in sourmash 4.0; use kmermaid instead.")
-        notify('')
     return compute(args)

--- a/sourmash/cli/compute.py
+++ b/sourmash/cli/compute.py
@@ -30,6 +30,7 @@ from argparse import FileType
 
 from sourmash.minhash import get_minhash_default_seed
 from sourmash.cli.utils import add_construct_moltype_args
+from sourmash.logging import notify
 
 
 def ksize_parser(ksizes):
@@ -167,4 +168,8 @@ def subparser(subparsers):
 
 def main(args):
     from sourmash.command_compute import compute
+    if args.input_is_10x:
+        notify("** WARNING: 10x support is deprecated as of sourmash 3.5.x, and will")
+        notify("**    be removed in sourmash 4.0; use kmermaid instead.")
+        notify('')
     return compute(args)

--- a/sourmash/cli/lca/summarize.py
+++ b/sourmash/cli/lca/summarize.py
@@ -40,4 +40,10 @@ def subparser(subparsers):
 
 def main(args):
     import sourmash
+
+    notify("** WARNING: lca summarize behavior is changing in sourmash 4.0")
+    notify("**   As of 4.0, lca summarize will always apply --singleton.")
+    notify("**   In addition, --with-abundance is on by default;")
+    notify("**   please use --ignore-abundance to ignore abundances.")
+
     return sourmash.lca.command_summarize.summarize_main(args)

--- a/sourmash/cli/lca/summarize.py
+++ b/sourmash/cli/lca/summarize.py
@@ -40,10 +40,4 @@ def subparser(subparsers):
 
 def main(args):
     import sourmash
-
-    notify("** WARNING: lca summarize behavior is changing in sourmash 4.0")
-    notify("**   As of 4.0, lca summarize will always apply --singleton.")
-    notify("**   In addition, --with-abundance is on by default;")
-    notify("**   please use --ignore-abundance to ignore abundances.")
-
     return sourmash.lca.command_summarize.summarize_main(args)

--- a/sourmash/minhash.py
+++ b/sourmash/minhash.py
@@ -4,13 +4,12 @@ from __future__ import unicode_literals, division
 import math
 import copy
 import collections
-import warnings
-from deprecation import deprecated
 
 from . import VERSION
 from ._lowlevel import ffi, lib
 from .utils import RustObject, rustcall, decode_str
 from .exceptions import SourmashError
+from deprecation import deprecated
 
 # default MurmurHash seed
 MINHASH_DEFAULT_SEED = 42
@@ -626,9 +625,7 @@ class MinHash(RustObject):
         self._methodcall(lib.kmerminhash_merge, other._get_objptr())
         return self
 
-    def merge(self, other):
-        warnings.warn("Warning, MinHash.merge(...) will return None in sourmash 4.0; use '+' operator for old behavior.")
-        return self.__iadd__(other)
+    merge = __iadd__
 
     def set_abundances(self, values, clear=True):
         """Set abundances for hashes from ``values``, where

--- a/sourmash/minhash.py
+++ b/sourmash/minhash.py
@@ -4,12 +4,13 @@ from __future__ import unicode_literals, division
 import math
 import copy
 import collections
+import warnings
+from deprecation import deprecated
 
 from . import VERSION
 from ._lowlevel import ffi, lib
 from .utils import RustObject, rustcall, decode_str
 from .exceptions import SourmashError
-from deprecation import deprecated
 
 # default MurmurHash seed
 MINHASH_DEFAULT_SEED = 42
@@ -625,7 +626,9 @@ class MinHash(RustObject):
         self._methodcall(lib.kmerminhash_merge, other._get_objptr())
         return self
 
-    merge = __iadd__
+    def merge(self, other):
+        warnings.warn("Warning, MinHash.merge(...) will return None in sourmash 4.0; use '+' operator for old behavior.")
+        return self.__iadd__(other)
 
     def set_abundances(self, values, clear=True):
         """Set abundances for hashes from ``values``, where

--- a/sourmash/sbt_storage.py
+++ b/sourmash/sbt_storage.py
@@ -8,6 +8,10 @@ from tempfile import NamedTemporaryFile
 import zipfile
 from abc import ABC
 
+from deprecation import deprecated
+
+from . import VERSION
+
 
 class Storage(ABC):
 
@@ -87,6 +91,9 @@ class FSStorage(Storage):
 
 class TarStorage(Storage):
 
+    @deprecated(deprecated_in="3.5", removed_in="4.0",
+                current_version=VERSION,
+                details='Use ZipStorage instead')
     def __init__(self, path=None):
         # TODO: leave it open, or close/open every time?
 

--- a/sourmash/sbt_storage.py
+++ b/sourmash/sbt_storage.py
@@ -8,10 +8,6 @@ from tempfile import NamedTemporaryFile
 import zipfile
 from abc import ABC
 
-from deprecation import deprecated
-
-from . import VERSION
-
 
 class Storage(ABC):
 
@@ -91,9 +87,6 @@ class FSStorage(Storage):
 
 class TarStorage(Storage):
 
-    @deprecated(deprecated_in="3.5", removed_in="4.0",
-                current_version=VERSION,
-                details='Use ZipStorage instead')
     def __init__(self, path=None):
         # TODO: leave it open, or close/open every time?
 

--- a/tests/test_sourmash_compute.py
+++ b/tests/test_sourmash_compute.py
@@ -274,15 +274,14 @@ def test_do_sourmash_compute_10x_filter_umis():
         barcodes = [filename.replace(".fasta", "") for filename in fasta_files]
         assert len(barcodes) == 1
         assert len(fasta_files) == 1
-        print((barcodes[0],))
-        assert barcodes[0].startswith('lung_epithelial_cell_AAATGCCCAAACTGCT-1')
+        assert barcodes[0] == 'lung_epithelial_cell|AAATGCCCAAACTGCT-1'
         count = 0
         fasta_file_name = os.path.join(fastas_dir, fasta_files[0])
         for record in screed.open(fasta_file_name):
             name = record.name
             sequence = record.sequence
             count += 1
-            assert name.startswith('lung_epithelial_cell_AAATGCCCAAACTGCT-1')
+            assert name.startswith('lung_epithelial_cell|AAATGCCCAAACTGCT-1')
             assert sequence.count(">") == 0
             assert sequence.count("X") == 0
 

--- a/tests/test_sourmash_compute.py
+++ b/tests/test_sourmash_compute.py
@@ -274,14 +274,15 @@ def test_do_sourmash_compute_10x_filter_umis():
         barcodes = [filename.replace(".fasta", "") for filename in fasta_files]
         assert len(barcodes) == 1
         assert len(fasta_files) == 1
-        assert barcodes[0] == 'lung_epithelial_cell|AAATGCCCAAACTGCT-1'
+        print((barcodes[0],))
+        assert barcodes[0].startswith('lung_epithelial_cell_AAATGCCCAAACTGCT-1')
         count = 0
         fasta_file_name = os.path.join(fastas_dir, fasta_files[0])
         for record in screed.open(fasta_file_name):
             name = record.name
             sequence = record.sequence
             count += 1
-            assert name.startswith('lung_epithelial_cell|AAATGCCCAAACTGCT-1')
+            assert name.startswith('lung_epithelial_cell_AAATGCCCAAACTGCT-1')
             assert sequence.count(">") == 0
             assert sequence.count("X") == 0
 


### PR DESCRIPTION
https://github.com/dib-lab/sourmash/pull/1322 reverts a mistaken merge/push of #1308.

This reapplies #1308 after #1322.

Fixes https://github.com/dib-lab/sourmash/issues/1288, by deprecating 10x support; also updates bam2fasta.
Fixes https://github.com/dib-lab/sourmash/issues/1176, by providing warnings about new `lca summarize` behavior.
Fixes https://github.com/dib-lab/sourmash/issues/1306, by warning about new `MinHash.merge` behavior.

Merge #1322 first ;)

## Checklist

- [ ] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make coverage` Is the new code covered?
- [ ] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
