### PR TITLE
[MRG] add `--from-file` option to `sourmash sketch` commands

### DIFF
--- a/doc/sourmash-sketch.md
+++ b/doc/sourmash-sketch.md
@@ -75,7 +75,11 @@ will be left empty, and `sourmash sig describe` will output `** no name **`.
 
 ### Input contents and output signatures
 
-By default, `sourmash sketch` will produce signatures for each input *file*. If the file contains multiple FASTA/FASTQ records, these records will be merged into the output signature.
+By default, `sourmash sketch` will produce signatures for each input
+*file*. If the file contains multiple FASTA/FASTQ records, these
+records will be merged into the output signature.  You can provide a
+*list of FASTA files* in a text file to `sourmash sketch` by passing
+the text file path in via `--from-file`.
 
 If you specify `--singleton`, `sourmash sketch` will produce signatures for each *record*.
 

--- a/src/sourmash/cli/compare.py
+++ b/src/sourmash/cli/compare.py
@@ -29,7 +29,7 @@ def subparser(subparsers):
     )
     subparser.add_argument(
         '--from-file',
-        help='a file containing a list of signatures file to compare'
+        help='a text file containing a list of files to load signatures from'
     )
     subparser.add_argument(
         '-f', '--force', action='store_true',

--- a/src/sourmash/cli/index.py
+++ b/src/sourmash/cli/index.py
@@ -38,7 +38,7 @@ def subparser(subparsers):
     )
     subparser.add_argument(
         '--from-file',
-        help='a file containing a list of signatures file to load'
+        help='a text file containing a list of files to load signatures from'
     )
     subparser.add_argument(
         '-q', '--quiet', action='store_true',

--- a/src/sourmash/cli/lca/index.py
+++ b/src/sourmash/cli/lca/index.py
@@ -13,7 +13,7 @@ def subparser(subparsers):
     )
     subparser.add_argument(
         '--from-file',
-        help='a file containing a list of signatures file to load'
+        help='a text file containing a list of files to load signatures from'
     )
     subparser.add_argument(
         '--scaled', metavar='S', default=10000, type=float

--- a/src/sourmash/cli/sketch/dna.py
+++ b/src/sourmash/cli/sketch/dna.py
@@ -22,12 +22,16 @@ def subparser(subparsers):
     )
     
     subparser.add_argument(
-        'filenames', nargs='+', help='file(s) of sequences'
+        'filenames', nargs='*', help='file(s) of sequences'
     )
     file_args = subparser.add_argument_group('File handling options')
     file_args.add_argument(
         '-f', '--force', action='store_true',
         help='recompute signatures even if the file exists'
+    )
+    subparser.add_argument(
+        '--from-file',
+        help='a text file containing a list of sequence files to load'
     )
     file_args.add_argument(
         '-o', '--output',

--- a/src/sourmash/cli/sketch/protein.py
+++ b/src/sourmash/cli/sketch/protein.py
@@ -22,7 +22,7 @@ def subparser(subparsers):
     )
     
     subparser.add_argument(
-        'filenames', nargs='+', help='file(s) of sequences'
+        'filenames', nargs='*', help='file(s) of sequences'
     )
     file_args = subparser.add_argument_group('File handling options')
     file_args.add_argument(
@@ -32,6 +32,10 @@ def subparser(subparsers):
     file_args.add_argument(
         '-o', '--output',
         help='output computed signatures to this file'
+    )
+    subparser.add_argument(
+        '--from-file',
+        help='a text file containing a list of sequence files to load'
     )
     file_args.add_argument(
         '--merge', '--name', type=str, default='', metavar="FILE",

--- a/src/sourmash/cli/sketch/translate.py
+++ b/src/sourmash/cli/sketch/translate.py
@@ -22,7 +22,7 @@ def subparser(subparsers):
     )
     
     subparser.add_argument(
-        'filenames', nargs='+', help='file(s) of sequences'
+        'filenames', nargs='*', help='file(s) of sequences'
     )
     file_args = subparser.add_argument_group('File handling options')
     file_args.add_argument(
@@ -32,6 +32,10 @@ def subparser(subparsers):
     file_args.add_argument(
         '-o', '--output',
         help='output computed signatures to this file'
+    )
+    subparser.add_argument(
+        '--from-file',
+        help='a text file containing a list of sequence files to load'
     )
     file_args.add_argument(
         '--merge', '--name', type=str, default='', metavar="FILE",

--- a/src/sourmash/command_sketch.py
+++ b/src/sourmash/command_sketch.py
@@ -152,6 +152,14 @@ class _signatures_for_sketch_factory(object):
         return sigs
 
 
+def _add_from_file_to_filenames(args):
+    "Add filenames from --from-file to args.filenames"
+    from .sourmash_args import load_file_list_of_signatures
+    if args.from_file:
+        file_list = load_file_list_of_signatures(args.from_file)
+        args.filenames.extend(file_list)
+
+
 def _execute_sketch(args, signatures_factory):
     "Once configured, run 'sketch' the same way underneath."
     set_quiet(args.quiet)
@@ -200,6 +208,7 @@ def dna(args):
         error(f"Error creating signatures: {str(e)}")
         sys.exit(-1)
 
+    _add_from_file_to_filenames(args)
     _execute_sketch(args, signatures_factory)
 
 
@@ -229,6 +238,7 @@ def protein(args):
         error(f"Error creating signatures: {str(e)}")
         sys.exit(-1)
 
+    _add_from_file_to_filenames(args)
     _execute_sketch(args, signatures_factory)
 
 
@@ -258,4 +268,5 @@ def translate(args):
         error(f"Error creating signatures: {str(e)}")
         sys.exit(-1)
 
+    _add_from_file_to_filenames(args)
     _execute_sketch(args, signatures_factory)

--- a/tests/test_sourmash_sketch.py
+++ b/tests/test_sourmash_sketch.py
@@ -240,6 +240,26 @@ def test_do_sourmash_sketchdna():
         assert str(sig).endswith('short.fa')
 
 
+def test_do_sourmash_sketchdna_from_file():
+    with utils.TempDirectory() as location:
+        testdata1 = utils.get_test_data('short.fa')
+
+        file_list = os.path.join(location, "filelist.txt")
+        with open(file_list, 'wt') as fp:
+            print(testdata1, file=fp)
+
+        status, out, err = utils.runscript('sourmash',
+                                           ['sketch', 'dna',
+                                            '--from-file', file_list],
+                                           in_directory=location)
+
+        sigfile = os.path.join(location, 'short.fa.sig')
+        assert os.path.exists(sigfile)
+
+        sig = next(signature.load_signatures(sigfile))
+        assert str(sig).endswith('short.fa')
+
+
 @utils.in_tempdir
 def test_do_sourmash_sketchdna_noinput(c):
     data = ""
@@ -534,6 +554,31 @@ def test_do_sketch_translate_multik_with_protein():
             assert 10 in ksizes
 
 
+def test_do_sketch_translate_multik_with_protein_from_file():
+    with utils.TempDirectory() as location:
+        testdata1 = utils.get_test_data('short.fa')
+
+        file_list = os.path.join(location, "filelist.txt")
+        with open(file_list, 'wt') as fp:
+            print(testdata1, file=fp)
+
+        status, out, err = utils.runscript('sourmash',
+                                           ['sketch', 'translate',
+                                            '-p', 'k=7,k=10,num=500',
+                                            '--from-file', file_list],
+                                           in_directory=location)
+        outfile = os.path.join(location, 'short.fa.sig')
+        assert os.path.exists(outfile)
+
+        with open(outfile, 'rt') as fp:
+            sigdata = fp.read()
+            siglist = list(signature.load_signatures(sigdata))
+            assert len(siglist) == 2
+            ksizes = set([ x.minhash.ksize for x in siglist ])
+            assert 7 in ksizes
+            assert 10 in ksizes
+
+
 def test_do_sketch_translate_multik_with_dayhoff():
     with utils.TempDirectory() as location:
         testdata1 = utils.get_test_data('short.fa')
@@ -624,6 +669,36 @@ def test_do_sketch_protein_multik_input():
                                            ['sketch', 'protein',
                                             '-p', 'k=7,k=10,num=500',
                                             testdata1],
+                                           in_directory=location)
+        outfile = os.path.join(location, 'ecoli.faa.sig')
+        assert os.path.exists(outfile)
+
+        with open(outfile, 'rt') as fp:
+            sigdata = fp.read()
+            siglist = list(signature.load_signatures(sigdata))
+            assert len(siglist) == 2
+            ksizes = set([ x.minhash.ksize for x in siglist ])
+            assert 7 in ksizes
+            assert 10 in ksizes
+
+            moltype = set([ x.minhash.moltype == 'protein'
+                            for x in siglist ])
+            assert len(moltype) == 1
+            assert True in moltype
+
+
+def test_do_sketch_protein_multik_input_from_file():
+    with utils.TempDirectory() as location:
+        testdata1 = utils.get_test_data('ecoli.faa')
+
+        file_list = os.path.join(location, "filelist.txt")
+        with open(file_list, 'wt') as fp:
+            print(testdata1, file=fp)
+
+        status, out, err = utils.runscript('sourmash',
+                                           ['sketch', 'protein',
+                                            '-p', 'k=7,k=10,num=500',
+                                            '--from-file', file_list],
                                            in_directory=location)
         outfile = os.path.join(location, 'ecoli.faa.sig')
         assert os.path.exists(outfile)


### PR DESCRIPTION
This PR adds `sourmash sketch dna|protein|translate --from-file list_of_files.txt`.

Per @klamens request here, https://github.com/dib-lab/sourmash/issues/1338#issuecomment-781244639

## Checklist

- [ ] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make coverage` Is the new code covered?
- [ ] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
