### PR TITLE
[MRG] require scaled signatures for containment

### DIFF
--- a/src/sourmash/index.py
+++ b/src/sourmash/index.py
@@ -109,7 +109,7 @@ class Index(ABC):
         # actually do search!
         results = []
         for ss in self.signatures():
-            print('looking at:', ss.minhash.scaled)
+            print('CTB looking at:', ss.minhash.scaled)
             cont = query.minhash.contained_by(ss.minhash, True)
             if cont and cont >= threshold:
                 results.append((cont, ss, self.filename))

--- a/src/sourmash/index.py
+++ b/src/sourmash/index.py
@@ -109,6 +109,7 @@ class Index(ABC):
         # actually do search!
         results = []
         for ss in self.signatures():
+            print('looking at:', ss.minhash.scaled)
             cont = query.minhash.contained_by(ss.minhash, True)
             if cont and cont >= threshold:
                 results.append((cont, ss, self.filename))

--- a/src/sourmash/index.py
+++ b/src/sourmash/index.py
@@ -109,7 +109,6 @@ class Index(ABC):
         # actually do search!
         results = []
         for ss in self.signatures():
-            print('CTB looking at:', ss.minhash.scaled)
             cont = query.minhash.contained_by(ss.minhash, True)
             if cont and cont >= threshold:
                 results.append((cont, ss, self.filename))

--- a/src/sourmash/minhash.py
+++ b/src/sourmash/minhash.py
@@ -536,6 +536,7 @@ class MinHash(RustObject):
         """\
         Calculate how much of self is contained by other.
         """
+        assert self.scaled and other.scaled
         if not len(self):
             return 0.0
 

--- a/src/sourmash/minhash.py
+++ b/src/sourmash/minhash.py
@@ -536,7 +536,7 @@ class MinHash(RustObject):
         """\
         Calculate how much of self is contained by other.
         """
-        assert self.scaled and other.scaled
+        assert self.is_compatible(other)
         if not len(self):
             return 0.0
 

--- a/src/sourmash/minhash.py
+++ b/src/sourmash/minhash.py
@@ -536,7 +536,8 @@ class MinHash(RustObject):
         """\
         Calculate how much of self is contained by other.
         """
-        assert self.is_compatible(other)
+        if not (self.scaled and other.scaled):
+            raise TypeError("can only calculate containment for scaled MinHashes")
         if not len(self):
             return 0.0
 

--- a/src/sourmash/sourmash_args.py
+++ b/src/sourmash/sourmash_args.py
@@ -281,7 +281,7 @@ def load_dbs_and_sigs(filenames, query, is_similarity_query, *, cache_size=None)
             assert dbtype == DatabaseType.SIGLIST
 
             siglist = _select_sigs(db, moltype=query_moltype, ksize=query_ksize)
-            siglist = filter_compatible_signatures(query, siglist, 1)
+            siglist = filter_compatible_signatures(query, siglist, True)
             linear = LinearIndex(siglist, filename=filename)
             databases.append(linear)
 
@@ -311,8 +311,15 @@ def load_dbs_and_sigs(filenames, query, is_similarity_query, *, cache_size=None)
         # signature file
         elif dbtype == DatabaseType.SIGLIST:
             siglist = _select_sigs(db, moltype=query_moltype, ksize=query_ksize)
-            siglist = filter_compatible_signatures(query, siglist, False)
-            siglist = list(siglist)
+            try:
+                # CTB: it's not clear to me that filter_compatible_signatures
+                # should fail here, on incompatible signatures; but that's
+                # what we have it doing currently. Revisit.
+                siglist = filter_compatible_signatures(query, siglist, False)
+                siglist = list(siglist)
+            except ValueError:
+                siglist = []
+
             if not siglist:
                 notify("no compatible signatures found in '{}'", filename)
                 sys.exit(-1)

--- a/tests/test__minhash.py
+++ b/tests/test__minhash.py
@@ -101,6 +101,21 @@ def test_div_zero_contained(track_abundance):
     assert mh2.contained_by(mh) == 0
 
 
+def test_contained_requires_scaled(track_abundance):
+    # verify that MHs of size 1 stay size 1, & act properly as bottom sketches.
+    mh = MinHash(1, 4, track_abundance=track_abundance)
+    assert mh.moltype == 'DNA'
+
+    mh.add_sequence('ATGC')
+    a = mh.hashes
+
+    mh.add_sequence('GCAT')             # this will not get added; hash > ATGC
+    b = mh.hashes
+
+    with pytest.raises(TypeError):
+        mh.contained_by(mh)
+
+
 def test_bytes_dna(track_abundance):
     mh = MinHash(1, 4, track_abundance=track_abundance)
     mh.add_sequence('ATGC')

--- a/tests/test__minhash.py
+++ b/tests/test__minhash.py
@@ -93,7 +93,7 @@ def test_div_zero(track_abundance):
 
 def test_div_zero_contained(track_abundance):
     # verify that empty MHs do not yield divide by zero errors for contained_by
-    mh = MinHash(1, 4, track_abundance=track_abundance)
+    mh = MinHash(0, 4, scaled=1, track_abundance=track_abundance)
     mh2 = mh.copy_and_clear()
 
     mh.add_sequence('ATGC')

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -859,8 +859,8 @@ def test_compare_no_matching_sigs(c):
     query = utils.get_test_data('lca/TARA_ASE_MAG_00031.sig')
 
     with pytest.raises(ValueError) as exc:
-        c.last_result.status, c.last_result.out, c.last_result.err = c.run_sourmash('compare', '-k', '100', query,
-                                                                                    fail_ok=True)
+        c.last_result.status, c.last_result.out, c.last_result.err = \
+            c.run_sourmash('compare', '-k', '100', query, fail_ok=True)
 
     print(c.last_result.out)
     print(c.last_result.err)
@@ -1570,6 +1570,37 @@ def test_search_metagenome_traverse():
 
         assert ' 33.2%       NC_003198.1 Salmonella enterica subsp. enterica serovar T...' in out
         assert '13 matches; showing first 3:' in out
+
+
+@utils.in_thisdir
+def test_search_incompatible(c):
+    num_sig = utils.get_test_data('num/47.fa.sig')
+    scaled_sig = utils.get_test_data('47.fa.sig')
+
+    with pytest.raises(ValueError) as exc:
+        c.run_sourmash("search", scaled_sig, num_sig, fail_ok=True)
+    assert c.last_result.status != 0
+    print(c.last_result.out)
+    print(c.last_result.err)
+    assert 'incompatible - cannot compare.' in c.last_result.err
+    assert 'was calculated with --scaled,' in c.last_result.err
+
+
+@utils.in_tempdir
+def test_search_traverse_incompatible(c):
+    searchdir = c.output('searchme')
+    os.mkdir(searchdir)
+
+    num_sig = utils.get_test_data('num/47.fa.sig')
+    scaled_sig = utils.get_test_data('47.fa.sig')
+    shutil.copyfile(num_sig, c.output('searchme/num.sig'))
+    shutil.copyfile(scaled_sig, c.output('searchme/scaled.sig'))
+
+    c.run_sourmash("search", scaled_sig, c.output('searchme'))
+    print(c.last_result.out)
+    print(c.last_result.err)
+    assert 'incompatible - cannot compare.' in c.last_result.err
+    assert 'was calculated with --scaled,' in c.last_result.err
 
 
 # explanation: you cannot downsample a scaled SBT to match a scaled
@@ -3246,6 +3277,23 @@ def test_gather_metagenome_traverse():
                     'NC_003198.1 Salmonella enterica subsp...' in out))
         assert all(('4.7 Mbp        0.5%    1.5%' in out,
                     'NC_011294.1 Salmonella enterica subsp...' in out))
+
+
+@utils.in_tempdir
+def test_gather_traverse_incompatible(c):
+    searchdir = c.output('searchme')
+    os.mkdir(searchdir)
+
+    num_sig = utils.get_test_data('num/47.fa.sig')
+    scaled_sig = utils.get_test_data('47.fa.sig')
+    shutil.copyfile(num_sig, c.output('searchme/num.sig'))
+    shutil.copyfile(scaled_sig, c.output('searchme/scaled.sig'))
+
+    c.run_sourmash("gather", scaled_sig, c.output('searchme'))
+    print(c.last_result.out)
+    print(c.last_result.err)
+    assert 'incompatible - cannot compare.' in c.last_result.err
+    assert 'was calculated with --scaled,' in c.last_result.err
 
 
 def test_gather_metagenome_output_unassigned():

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -1345,7 +1345,8 @@ def test_search_containment():
         testdata1 = utils.get_test_data('short.fa')
         testdata2 = utils.get_test_data('short2.fa')
         status, out, err = utils.runscript('sourmash',
-                                           ['compute', testdata1, testdata2],
+                                           ['compute', testdata1, testdata2,
+                                            '--scaled', '1'],
                                            in_directory=location)
 
         status, out, err = utils.runscript('sourmash',
@@ -1354,7 +1355,7 @@ def test_search_containment():
                                            in_directory=location)
         print(status, out, err)
         assert '1 matches' in out
-        assert '95.8%' in out
+        assert '95.6%' in out
 
 
 def test_search_containment_sbt():
@@ -1363,7 +1364,8 @@ def test_search_containment_sbt():
         testdata1 = utils.get_test_data('short.fa')
         testdata2 = utils.get_test_data('short2.fa')
         status, out, err = utils.runscript('sourmash',
-                                           ['compute', testdata1, testdata2],
+                                           ['compute', testdata1, testdata2,
+                                            '--scaled', '1'],
                                            in_directory=location)
 
         status, out, err = utils.runscript('sourmash',
@@ -1378,7 +1380,7 @@ def test_search_containment_sbt():
                                            in_directory=location)
         print(status, out, err)
         assert '1 matches' in out
-        assert '95.8%' in out
+        assert '95.6%' in out
 
 
 def test_search_gzip():


### PR DESCRIPTION
I stumbled across some code that shouldn't have worked while writing a new test for #1374, and discovered that we are allowing `contained_by` to be called on `num` MinHash objects.

This is unambiguously wrong and I think we should remove it from the code base. Only `scaled` MinHashes allow accurate estimation of containment.  I guess we didn't know that a few years back, though, so it crept into the code base :).

https://github.com/dib-lab/sourmash/issues/1345 is relevant - but while there are reasonable places to call `count_common` on regular MinHashes, there are no reasonable places to call `contained_by`, AFAICT.

NOTE: this breaks backwards compatibility, but I think it's rectifies a bug so we're ok.

## Checklist

- [ ] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make coverage` Is the new code covered?
- [ ] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
