### PR TITLE
[MRG] pin needletail version to keep MSRV at 1.37

### DIFF
--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -60,7 +60,8 @@ wasm-opt = false # https://github.com/rustwasm/wasm-pack/issues/886
 [dev-dependencies]
 assert_matches = "1.3.0"
 criterion = "0.3.2"
-needletail = { version = "0.4.0", default-features = false }
+# Upgrade to 0.4.1 requires rust 1.42
+needletail = { version = "=0.4.0", default-features = false }
 predicates = "1.0.4"
 proptest = { version = "1.0.0", default-features = false, features = ["std"]}  # Upgrade to 0.10 requires rust 1.39
 rand = "0.8.2"


### PR DESCRIPTION
Needletail 0.4.1 uses the `matches!` macro, which was added on Rust 1.42. Since it is a dev-only dep, I'm pinning it to 0.4.0 until we bump our minimum supported Rust version to 1.42.

## Checklist

- [ ] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make coverage` Is the new code covered?
- [ ] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
