### PR TITLE
[WIP] Reduce wasm surface by removing index

### DIFF
--- a/src/core/src/cmd.rs
+++ b/src/core/src/cmd.rs
@@ -5,22 +5,9 @@ use getset::{CopyGetters, Getters, Setters};
 use typed_builder::TypedBuilder;
 
 use crate::encodings::HashFunctions;
-use crate::index::MHBT;
 use crate::signature::Signature;
 use crate::sketch::minhash::{max_hash_for_scaled, KmerMinHashBTree};
 use crate::sketch::Sketch;
-use crate::Error;
-
-pub fn prepare(index_path: &str) -> Result<(), Error> {
-    let mut index = MHBT::from_path(index_path)?;
-
-    // TODO equivalent to fill_internal in python
-    //unimplemented!();
-
-    index.save_file(index_path, None)?;
-
-    Ok(())
-}
 
 impl Signature {
     pub fn from_params(params: &ComputeParameters) -> Signature {

--- a/src/core/src/errors.rs
+++ b/src/core/src/errors.rs
@@ -42,9 +42,11 @@ pub enum SourmashError {
     #[error("Set error rate to a value smaller than 0.367696 and larger than 0.00203125")]
     HLLPrecisionBounds,
 
+    #[cfg(not(all(target_arch = "wasm32", target_vendor = "unknown")))]
     #[error(transparent)]
     ReadDataError(#[from] crate::index::storage::ReadDataError),
 
+    #[cfg(not(all(target_arch = "wasm32", target_vendor = "unknown")))]
     #[error(transparent)]
     StorageError(#[from] crate::index::storage::StorageError),
 

--- a/src/core/src/ffi/hyperloglog.rs
+++ b/src/core/src/ffi/hyperloglog.rs
@@ -2,9 +2,9 @@ use std::ffi::CStr;
 use std::os::raw::c_char;
 use std::slice;
 
-use crate::index::sbt::Update;
 use crate::signature::SigsTrait;
 use crate::sketch::hyperloglog::HyperLogLog;
+use crate::traits::Update;
 
 use crate::ffi::minhash::SourmashKmerMinHash;
 use crate::ffi::utils::ForeignObject;

--- a/src/core/src/ffi/nodegraph.rs
+++ b/src/core/src/ffi/nodegraph.rs
@@ -2,8 +2,8 @@ use std::ffi::CStr;
 use std::os::raw::c_char;
 use std::slice;
 
-use crate::index::sbt::Update;
 use crate::sketch::nodegraph::Nodegraph;
+use crate::traits::Update;
 
 use crate::ffi::minhash::SourmashKmerMinHash;
 use crate::ffi::utils::ForeignObject;

--- a/src/core/src/index/linear.rs
+++ b/src/core/src/index/linear.rs
@@ -7,8 +7,9 @@ use std::rc::Rc;
 use serde::{Deserialize, Serialize};
 use typed_builder::TypedBuilder;
 
-use crate::index::storage::{FSStorage, ReadData, Storage, StorageInfo, ToWriter};
+use crate::index::storage::{FSStorage, ReadData, Storage, StorageInfo};
 use crate::index::{Comparable, DatasetInfo, Index, SigStore};
+use crate::traits::ToWriter;
 use crate::Error;
 
 #[derive(TypedBuilder)]

--- a/src/core/src/index/sbt/mhbt.rs
+++ b/src/core/src/index/sbt/mhbt.rs
@@ -2,11 +2,12 @@ use std::collections::HashMap;
 use std::io::Write;
 
 use crate::index::sbt::{Factory, FromFactory, Node, Update, SBT};
-use crate::index::storage::{ReadData, ReadDataError, ToWriter};
+use crate::index::storage::{ReadData, ReadDataError};
 use crate::index::Comparable;
 use crate::signature::{Signature, SigsTrait};
 use crate::sketch::nodegraph::Nodegraph;
 use crate::sketch::Sketch;
+use crate::traits::ToWriter;
 use crate::Error;
 
 impl ToWriter for Nodegraph {

--- a/src/core/src/index/sbt/mod.rs
+++ b/src/core/src/index/sbt/mod.rs
@@ -24,14 +24,11 @@ use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
 use typed_builder::TypedBuilder;
 
-use crate::index::storage::{FSStorage, ReadData, Storage, StorageInfo, ToWriter};
+use crate::index::storage::{FSStorage, ReadData, Storage, StorageInfo};
 use crate::index::{Comparable, DatasetInfo, Index, SigStore};
 use crate::signature::Signature;
+use crate::traits::{ToWriter, Update};
 use crate::Error;
-
-pub trait Update<O> {
-    fn update(&self, other: &mut O) -> Result<(), Error>;
-}
 
 pub trait FromFactory<N> {
     fn factory(&self, name: &str) -> Result<N, Error>;

--- a/src/core/src/index/storage.rs
+++ b/src/core/src/index/storage.rs
@@ -126,9 +126,3 @@ impl Storage for FSStorage {
         }
     }
 }
-
-pub trait ToWriter {
-    fn to_writer<W>(&self, writer: &mut W) -> Result<(), Error>
-    where
-        W: Write;
-}

--- a/src/core/src/lib.rs
+++ b/src/core/src/lib.rs
@@ -20,8 +20,7 @@ pub mod errors;
 pub use errors::SourmashError as Error;
 
 pub mod cmd;
-
-pub mod index;
+pub mod traits;
 
 pub mod signature;
 pub mod sketch;
@@ -38,6 +37,7 @@ cfg_if! {
     if #[cfg(all(target_arch = "wasm32", target_vendor = "unknown"))] {
         pub mod wasm;
     } else {
+        pub mod index;
         pub mod ffi;
     }
 }

--- a/src/core/src/signature.rs
+++ b/src/core/src/signature.rs
@@ -18,8 +18,8 @@ use typed_builder::TypedBuilder;
 use wasm_bindgen::prelude::*;
 
 use crate::encodings::{aa_to_dayhoff, aa_to_hp, revcomp, to_aa, HashFunctions, VALID};
-use crate::index::storage::ToWriter;
 use crate::sketch::Sketch;
+use crate::traits::ToWriter;
 use crate::Error;
 use crate::HashIntoType;
 

--- a/src/core/src/sketch/hyperloglog/mod.rs
+++ b/src/core/src/sketch/hyperloglog/mod.rs
@@ -16,9 +16,9 @@ use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use serde::{Deserialize, Serialize};
 
 use crate::encodings::HashFunctions;
-use crate::index::sbt::Update;
 use crate::signature::SigsTrait;
 use crate::sketch::KmerMinHash;
+use crate::traits::Update;
 use crate::Error;
 use crate::HashIntoType;
 

--- a/src/core/src/sketch/mod.rs
+++ b/src/core/src/sketch/mod.rs
@@ -1,5 +1,7 @@
 pub mod hyperloglog;
 pub mod minhash;
+
+#[cfg(not(all(target_arch = "wasm32", target_vendor = "unknown")))]
 pub mod nodegraph;
 
 use serde::{Deserialize, Serialize};

--- a/src/core/src/sketch/nodegraph.rs
+++ b/src/core/src/sketch/nodegraph.rs
@@ -6,8 +6,8 @@ use std::slice;
 use byteorder::{BigEndian, ByteOrder, LittleEndian, ReadBytesExt, WriteBytesExt};
 use fixedbitset::FixedBitSet;
 
-use crate::index::sbt::Update;
 use crate::sketch::minhash::KmerMinHash;
+use crate::traits::Update;
 use crate::Error;
 use crate::HashIntoType;
 


### PR DESCRIPTION
For greyhound.sourmash.bio and similar browser-side demos I've been using a subset of sourmash that is compilable to webassembly. To make sure that new features and dependencies are added that break what webassembly supports I added a CI check that tries to build a JS package using `wasm-pack`.

But... that limits quite a bit what we can add to sourmash. We can't have C/C++ deps, for example. It also holds back some parallel stuff because rayon doesn't work well on wasm without many tweaks.

So, this PR removes some submodules from wasm (using configuration flags) so we can explore more before commiting to maintaining it in the long run, namely:
- index-related code, because there are other limitations for wasm32 (like not being able to address more than 2GB of RAM) that make it not as useful to have indices in the browser at the moment
- Nodegraph, with the goal of unlocking #1221 eventually

## Checklist

- [ ] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make coverage` Is the new code covered?
- [ ] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
