### PR TITLE
[MRG] Add '-h/--help' usage instructions to 'sourmash sketch' CLI

### DIFF
--- a/src/sourmash/cli/sketch/dna.py
+++ b/src/sourmash/cli/sketch/dna.py
@@ -1,11 +1,36 @@
 """create DNA signatures"""
 
+usage="""
+
+    sourmash sketch dna data/*.fna.gz
+
+The 'sketch dna' command reads in DNA sequences and outputs DNA
+sketches.
+
+By default, 'sketch dna' uses the parameter string 'k=31,scaled=1000,noabund'.
+
+This creates sketches with a k-mer size of 31, a scaled factor of
+1000, and no abundance tracking of k-mers.  You can specify one or
+more parameter strings of your own with -p, e.g.  'sourmash sketch dna
+-p k=31,noabund -p k=21,scaled=100,abund'.
+
+'sourmash sketch' takes input sequences in FASTA and FASTQ,
+uncompressed or gz/bz2 compressed.
+
+Please see the 'sketch' documentation for more details:
+  https://sourmash.readthedocs.io/en/latest/sourmash-sketch.html
+"""
+
 import sourmash
 from sourmash.logging import notify, print_results, error
 
+from sourmash import command_sketch
+assert command_sketch.DEFAULTS['dna'] == 'k=31,scaled=1000,noabund'
+
 
 def subparser(subparsers):
-    subparser = subparsers.add_parser('dna', aliases=['rna'])
+    subparser = subparsers.add_parser('dna', aliases=['rna'],
+                                      usage=usage)
     subparser.add_argument(
         '--license', default='CC0', type=str,
         help='signature license. Currently only CC0 is supported.'

--- a/src/sourmash/cli/sketch/dna.py
+++ b/src/sourmash/cli/sketch/dna.py
@@ -29,7 +29,8 @@ assert command_sketch.DEFAULTS['dna'] == 'k=31,scaled=1000,noabund'
 
 
 def subparser(subparsers):
-    subparser = subparsers.add_parser('dna', aliases=['rna', 'nucleotide'],
+    subparser = subparsers.add_parser('dna',
+                                      aliases=['rna', 'nucleotide', 'nt'],
                                       usage=usage)
     subparser.add_argument(
         '--license', default='CC0', type=str,

--- a/src/sourmash/cli/sketch/dna.py
+++ b/src/sourmash/cli/sketch/dna.py
@@ -12,7 +12,7 @@ By default, 'sketch dna' uses the parameter string 'k=31,scaled=1000,noabund'.
 This creates sketches with a k-mer size of 31, a scaled factor of
 1000, and no abundance tracking of k-mers.  You can specify one or
 more parameter strings of your own with -p, e.g.  'sourmash sketch dna
--p k=31,noabund -p k=21,scaled=100,abund'.
+-p k=31,noabund -p k=21,scaled=100,abund'. Note that a single `-p` parameter string can contain multiple ksize values, but only a single scaled value or abundance value, e.g. -p k=21,k=31,abund
 
 'sourmash sketch' takes input sequences in FASTA and FASTQ,
 uncompressed or gz/bz2 compressed.
@@ -29,7 +29,7 @@ assert command_sketch.DEFAULTS['dna'] == 'k=31,scaled=1000,noabund'
 
 
 def subparser(subparsers):
-    subparser = subparsers.add_parser('dna', aliases=['rna'],
+    subparser = subparsers.add_parser('dna', aliases=['rna', 'nucleotide'],
                                       usage=usage)
     subparser.add_argument(
         '--license', default='CC0', type=str,

--- a/src/sourmash/cli/sketch/protein.py
+++ b/src/sourmash/cli/sketch/protein.py
@@ -13,7 +13,7 @@ By default, 'sketch protein' uses the parameter string
 This corresponds to an amino-acid k-mer size of 10, a scaled factor
 of 200, and no abundance tracking of k-mers. You can specify one or
 more parameter strings of your own with -p, e.g. 'sourmash sketch
-protein -p k=11,noabund -p k=12,scaled=100,abund'.
+protein -p k=11,noabund -p k=12,scaled=100,abund'. Note that a single `-p` parameter string can contain multiple ksize values, but only a single scaled value or abundance value e.g. -p k=11,k=12,scaled=100,abund.
 
 'sourmash sketch' takes input sequences in FASTA and FASTQ,
 uncompressed or gz/bz2 compressed.

--- a/src/sourmash/cli/sketch/protein.py
+++ b/src/sourmash/cli/sketch/protein.py
@@ -1,11 +1,37 @@
 """create protein signatures"""
 
+usage="""
+
+    sourmash sketch protein data/*.fna.gz
+
+The 'sketch protein' command reads in protein sequences and outputs protein
+sketches.
+
+By default, 'sketch protein' uses the parameter string
+'k=10,scaled=200,noabund'.
+
+This corresponds to an amino-acid k-mer size of 10, a scaled factor
+of 200, and no abundance tracking of k-mers. You can specify one or
+more parameter strings of your own with -p, e.g. 'sourmash sketch
+protein -p k=11,noabund -p k=12,scaled=100,abund'.
+
+'sourmash sketch' takes input sequences in FASTA and FASTQ,
+uncompressed or gz/bz2 compressed.
+
+Please see the 'sketch' documentation for more details:
+  https://sourmash.readthedocs.io/en/latest/sourmash-sketch.html
+"""
+
 import sourmash
 from sourmash.logging import notify, print_results, error
 
+from sourmash import command_sketch
+assert command_sketch.DEFAULTS['protein'] == 'k=10,scaled=200,noabund'
+
 
 def subparser(subparsers):
-    subparser = subparsers.add_parser('protein', aliases=['aa', 'prot'])
+    subparser = subparsers.add_parser('protein', aliases=['aa', 'prot'],
+                                      usage=usage)
     subparser.add_argument(
         '--license', default='CC0', type=str,
         help='signature license. Currently only CC0 is supported.'

--- a/src/sourmash/cli/sketch/translate.py
+++ b/src/sourmash/cli/sketch/translate.py
@@ -1,11 +1,37 @@
 """create protein signature from DNA/RNA sequence"""
 
+usage="""
+
+    sourmash sketch translate data/*.fna.gz
+
+The 'sketch translate' command reads in DNA sequences and outputs protein
+sketches.
+
+By default, 'sketch translate' uses the parameter string
+'k=10,scaled=200,noabund'.
+
+This corresponds to a DNA k-mer size of 30 (and an amino-acid k-mer size
+of 10), a scaled factor of 200, and no abundance tracking of
+k-mers. You can specify one or more parameter strings of your own with
+-p, e.g. 'sourmash sketch translate -p k=11,noabund -p
+k=12,scaled=100,abund'.
+
+'sourmash sketch' takes input sequences in FASTA and FASTQ,
+uncompressed or gz/bz2 compressed.
+
+Please see the 'sketch' documentation for more details:
+  https://sourmash.readthedocs.io/en/latest/sourmash-sketch.html
+"""
+
+from sourmash import command_sketch
+assert command_sketch.DEFAULTS['protein'] == 'k=10,scaled=200,noabund'
+
 import sourmash
 from sourmash.logging import notify, print_results, error
 
 
 def subparser(subparsers):
-    subparser = subparsers.add_parser('translate')
+    subparser = subparsers.add_parser('translate', usage=usage)
     subparser.add_argument(
         '--license', default='CC0', type=str,
         help='signature license. Currently only CC0 is supported.'

--- a/src/sourmash/command_sketch.py
+++ b/src/sourmash/command_sketch.py
@@ -164,6 +164,10 @@ def _execute_sketch(args, signatures_factory):
     "Once configured, run 'sketch' the same way underneath."
     set_quiet(args.quiet)
 
+    if not args.filenames:
+        error('error: no input filenames provided! nothing to do - exiting.')
+        sys.exit(-1)
+
     if args.license != 'CC0':
         error('error: sourmash only supports CC0-licensed signatures. sorry!')
         sys.exit(-1)

--- a/tests/test_sourmash_sketch.py
+++ b/tests/test_sourmash_sketch.py
@@ -226,6 +226,27 @@ def test_multiple_moltypes():
 ### command line tests
 
 
+@utils.in_thisdir
+def test_do_sourmash_sketchdna_empty(c):
+    with pytest.raises(ValueError):
+        c.run_sourmash('sketch', 'dna')
+    assert 'error: no input filenames provided! nothing to do - exiting.' in c.last_result.err
+
+
+@utils.in_thisdir
+def test_do_sourmash_sketchprotein_empty(c):
+    with pytest.raises(ValueError):
+        c.run_sourmash('sketch', 'protein')
+    assert 'error: no input filenames provided! nothing to do - exiting.' in c.last_result.err
+
+
+@utils.in_thisdir
+def test_do_sourmash_sketchtranslate_empty(c):
+    with pytest.raises(ValueError):
+        c.run_sourmash('sketch', 'translate')
+    assert 'error: no input filenames provided! nothing to do - exiting.' in c.last_result.err
+
+
 def test_do_sourmash_sketchdna():
     with utils.TempDirectory() as location:
         testdata1 = utils.get_test_data('short.fa')


### PR DESCRIPTION
This PR adds usage information to `sourmash sketch` subcommands.

It also makes sure there are some inputs, which broke in #1362.

Fixes https://github.com/dib-lab/sourmash/issues/1385

## Checklist

- [ ] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make coverage` Is the new code covered?
- [ ] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
