### PR TITLE
[MRG] Fix CSV output for `sourmash lca classify` when `.name` is empty

### DIFF
--- a/src/sourmash/lca/command_classify.py
+++ b/src/sourmash/lca/command_classify.py
@@ -142,7 +142,7 @@ def classify(args):
                 debug(lineage)
 
                 # output each classification to the spreadsheet
-                row = [query_sig.name, status]
+                row = [str(query_sig), status]
                 row += lca_utils.zip_lineage(lineage)
 
                 # when outputting to stdout, make output intelligible

--- a/tests/test_lca.py
+++ b/tests/test_lca.py
@@ -974,7 +974,7 @@ def test_single_classify_to_output_no_name():
 
         outdata = open(os.path.join(location, 'outfile.txt'), 'rt').read()
         print((outdata,))
-        assert 'TARA_ASE_MAG_00031,found,Bacteria,Proteobacteria,Gammaproteobacteria,Alteromonadales,Alteromonadaceae,Alteromonas,Alteromonas_macleodii' in outdata
+        assert 'xyz,found,Bacteria,Proteobacteria,Gammaproteobacteria,Alteromonadales,Alteromonadaceae,Alteromonas,Alteromonas_macleodii' in outdata
         assert 'classified 1 signatures total' in err
         assert 'loaded 1 LCA databases' in err
 

--- a/tests/test_lca.py
+++ b/tests/test_lca.py
@@ -952,6 +952,33 @@ def test_single_classify_to_output():
         assert 'loaded 1 LCA databases' in err
 
 
+def test_single_classify_to_output_no_name():
+    with utils.TempDirectory() as location:
+        db1 = utils.get_test_data('lca/delmont-1.lca.json')
+        input_sig = utils.get_test_data('lca/TARA_ASE_MAG_00031.sig')
+        ss = sourmash.load_one_signature(input_sig, ksize=31)
+
+        outsig_filename = os.path.join(location, 'q.sig')
+        with open(outsig_filename, 'wt') as fp:
+            # remove name from signature here --
+            new_sig = sourmash.SourmashSignature(ss.minhash, filename='xyz')
+            sourmash.save_signatures([new_sig], fp)
+
+        cmd = ['lca', 'classify', '--db', db1, '--query', outsig_filename,
+               '-o', os.path.join(location, 'outfile.txt')]
+        status, out, err = utils.runscript('sourmash', cmd)
+
+        print(cmd)
+        print(out)
+        print(err)
+
+        outdata = open(os.path.join(location, 'outfile.txt'), 'rt').read()
+        print((outdata,))
+        assert 'TARA_ASE_MAG_00031,found,Bacteria,Proteobacteria,Gammaproteobacteria,Alteromonadales,Alteromonadaceae,Alteromonas,Alteromonas_macleodii' in outdata
+        assert 'classified 1 signatures total' in err
+        assert 'loaded 1 LCA databases' in err
+
+
 def test_single_classify_empty():
     with utils.TempDirectory() as location:
         db1 = utils.get_test_data('lca/both.lca.json')


### PR DESCRIPTION
Adjust CSV output for `sourmash lca classify` to use `str(query_sig)` rather than `query_sig.name` - the former is never empty, but the latter can be if no name was setup. This is the same resolution that was used for similar behavior by `gather` in https://github.com/dib-lab/sourmash/pull/1232.

Fixes #1394.

## Checklist

- [ ] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make coverage` Is the new code covered?
- [ ] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
