### PR TITLE
[MRG] Fix clippy lints introduced in 1.51

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5852a21819542e6809f68ba5a798600e69874e76",
-        "sha256": "05vqlnafz287wamy2a3kp6h32mmha1ahq8gzp7slihdci2ibcdx6",
+        "rev": "c0e881852006b132236cbf0301bd1939bb50867e",
+        "sha256": "0fy7z7yxk5n7yslsvx5cyc6h21qwi4bhxf3awhirniszlbvaazy2",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/5852a21819542e6809f68ba5a798600e69874e76.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/c0e881852006b132236cbf0301bd1939bb50867e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "rust-overlay": {
@@ -29,10 +29,10 @@
         "homepage": null,
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "62d46e74e18babdb1d2b3994dbb91d5fa4672597",
-        "sha256": "0v7bfn0m0g4yywzxxa8ygll41mb8506kvkfbywdx0g7r6ddvcndr",
+        "rev": "d414b80c0e6e96977b52b1a0a547ea7613a5c6d5",
+        "sha256": "14bidf0paxb4hdbq60pxgxijjw7hi5rzdg9vj490rsikk58fb2qs",
         "type": "tarball",
-        "url": "https://github.com/oxalica/rust-overlay/archive/62d46e74e18babdb1d2b3994dbb91d5fa4672597.tar.gz",
+        "url": "https://github.com/oxalica/rust-overlay/archive/d414b80c0e6e96977b52b1a0a547ea7613a5c6d5.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/src/core/src/ffi/hyperloglog.rs
+++ b/src/core/src/ffi/hyperloglog.rs
@@ -154,7 +154,7 @@ unsafe fn hll_from_buffer(ptr: *const c_char, insize: usize) -> Result<*mut Sour
         slice::from_raw_parts(ptr as *mut u8, insize)
     };
 
-    let hll = HyperLogLog::from_reader(&mut &buf[..])?;
+    let hll = HyperLogLog::from_reader(buf)?;
 
     Ok(SourmashHyperLogLog::from_rust(hll))
 }

--- a/src/core/src/ffi/nodegraph.rs
+++ b/src/core/src/ffi/nodegraph.rs
@@ -184,7 +184,7 @@ unsafe fn nodegraph_from_buffer(ptr: *const c_char, insize: usize) -> Result<*mu
         slice::from_raw_parts(ptr as *mut u8, insize)
     };
 
-    let ng = Nodegraph::from_reader(&mut &buf[..])?;
+    let ng = Nodegraph::from_reader(buf)?;
 
     Ok(SourmashNodegraph::from_rust(ng))
 }

--- a/src/core/src/lib.rs
+++ b/src/core/src/lib.rs
@@ -16,6 +16,9 @@
 //! routines can use the NCBI taxonomy but do not depend on it in any way.
 //! Documentation and further examples for each module can be found in the module descriptions below.
 
+// TODO: remove this line and update all the appropriate type names for 1.0
+#![allow(clippy::upper_case_acronyms)]
+
 pub mod errors;
 pub use errors::SourmashError as Error;
 

--- a/src/core/src/signature.rs
+++ b/src/core/src/signature.rs
@@ -376,7 +376,7 @@ impl Signature {
 
     pub fn from_path<P: AsRef<Path>>(path: P) -> Result<Vec<Signature>, Error> {
         let mut reader = io::BufReader::new(File::open(path)?);
-        Ok(Signature::from_reader(&mut reader)?)
+        Signature::from_reader(&mut reader)
     }
 
     pub fn from_reader<R>(rdr: R) -> Result<Vec<Signature>, Error>

--- a/src/core/src/sketch/hyperloglog/mod.rs
+++ b/src/core/src/sketch/hyperloglog/mod.rs
@@ -156,7 +156,7 @@ impl HyperLogLog {
 
     pub fn from_path<P: AsRef<Path>>(path: P) -> Result<HyperLogLog, Error> {
         let mut reader = io::BufReader::new(File::open(path)?);
-        Ok(HyperLogLog::from_reader(&mut reader)?)
+        HyperLogLog::from_reader(&mut reader)
     }
 }
 

--- a/src/core/src/sketch/nodegraph.rs
+++ b/src/core/src/sketch/nodegraph.rs
@@ -274,7 +274,7 @@ impl Nodegraph {
 
     pub fn from_path<P: AsRef<Path>>(path: P) -> Result<Nodegraph, Error> {
         let mut reader = io::BufReader::new(File::open(path)?);
-        Ok(Nodegraph::from_reader(&mut reader)?)
+        Nodegraph::from_reader(&mut reader)
     }
 
     pub fn tablesizes(&self) -> Vec<u64> {


### PR DESCRIPTION
`latest` is failing due to some new Clippy lints introduced in `1.51.0` (released today). Follow recommendations when appropriate, but disable the [upper_case_acronyms](https://rust-lang.github.io/rust-clippy/master/index.html#upper_case_acronyms) lint because it would change many type names (it could be a good thing to fix for 1.0, tho)

## Checklist

- [ ] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make coverage` Is the new code covered?
- [ ] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
