### PR TITLE
[MRG] expand signature selection and compatibility checking in database loading code

### DIFF
--- a/src/sourmash/index.py
+++ b/src/sourmash/index.py
@@ -160,8 +160,12 @@ class LinearIndex(Index):
 
     def select(self, **kwargs):
         def select_sigs(ss):
-            # eliminate things from kwargs with no value
-            kw = { k : v for (k, v) in kwargs.items() if v is not None }
+            # eliminate things from kwargs with no or zero
+            kw = { k : v for (k, v) in kwargs.items() if v }
+            print(kw, kwargs)
+            if not kw:
+                return True
+
             if 'ksize' in kw and kw['ksize'] != ss.minhash.ksize:
                 return False
             if 'moltype' in kw and kw['moltype'] != ss.minhash.moltype:

--- a/src/sourmash/index.py
+++ b/src/sourmash/index.py
@@ -125,7 +125,7 @@ class Index(ABC):
 
     @abstractmethod
     def select(self, ksize=None, moltype=None, scaled=None, num=None,
-               abund=None):
+               abund=None, containment=None):
         ""
 
 class LinearIndex(Index):
@@ -171,6 +171,13 @@ class LinearIndex(Index):
                 return False
             if 'moltype' in kw and kw['moltype'] != ss.minhash.moltype:
                 return False
+
+            if 'containment' in kw:
+                if not 'scaled' in kw:
+                    raise ValueError("'containment' requires 'scaled' in Index.select'")
+                if not ss.minhash.scaled:
+                    return False
+
             if 'scaled' in kw:
                 if ss.minhash.num or kw['scaled'] != ss.minhash.scaled:
                     return False

--- a/src/sourmash/index.py
+++ b/src/sourmash/index.py
@@ -188,9 +188,6 @@ class LinearIndex(Index):
             if filter_fn(ss):
                 siglist.append(ss)
 
-        if not siglist:
-            raise ValueError("no signatures match")
-
         return LinearIndex(siglist, self.filename)
 
 

--- a/src/sourmash/index.py
+++ b/src/sourmash/index.py
@@ -128,11 +128,26 @@ class Index(ABC):
     @abstractmethod
     def select(self, ksize=None, moltype=None, scaled=None, num=None,
                abund=None, containment=None):
-        ""
+        """Return Index containing only signatures that match requirements.
+
+        Current arguments can be any or all of:
+        * ksize
+        * moltype
+        * scaled
+        * num
+        * containment
+
+        'select' will raise ValueError if the requirements are incompatible
+        with the Index subclass.
+
+        'select' may return an empty object or None if no matches can be
+        found.
+        """
 
 
 def select_signature(ss, ksize=None, moltype=None, scaled=0, num=0,
                      containment=False):
+    "Check that the given signature matches the specificed requirements."
     # ksize match?
     if ksize and ksize != ss.minhash.ksize:
         return False
@@ -192,7 +207,10 @@ class LinearIndex(Index):
         return lidx
 
     def select(self, **kwargs):
-        "Select signatures that match the given requirements. @CTB doc."
+        """Return new LinearIndex containing only signatures that match req's.
+
+        Does not raise ValueError, but may return an empty Index.
+        """
         # eliminate things from kwargs with None or zero value
         kw = { k : v for (k, v) in kwargs.items() if v }
 
@@ -202,9 +220,6 @@ class LinearIndex(Index):
                 siglist.append(ss)
 
         return LinearIndex(siglist, self.filename)
-
-    def filter(self, filter_fn): # @CTB may not be necessary any more
-        siglist = []
 
 
 class MultiIndex(Index):

--- a/src/sourmash/index.py
+++ b/src/sourmash/index.py
@@ -162,8 +162,8 @@ class LinearIndex(Index):
         def select_sigs(ss):
             # eliminate things from kwargs with no or zero
             kw = { k : v for (k, v) in kwargs.items() if v }
-            import sys
-            print(kw, kwargs, file=sys.stderr)
+            #import sys # @CTB remove
+            #print(kw, kwargs, file=sys.stderr)
             if not kw:
                 return True
 

--- a/src/sourmash/index.py
+++ b/src/sourmash/index.py
@@ -188,6 +188,9 @@ class LinearIndex(Index):
             if filter_fn(ss):
                 siglist.append(ss)
 
+        if not siglist:
+            raise ValueError("no signatures match")
+
         return LinearIndex(siglist, self.filename)
 
 

--- a/src/sourmash/index.py
+++ b/src/sourmash/index.py
@@ -162,7 +162,8 @@ class LinearIndex(Index):
         def select_sigs(ss):
             # eliminate things from kwargs with no or zero
             kw = { k : v for (k, v) in kwargs.items() if v }
-            print(kw, kwargs)
+            import sys
+            print(kw, kwargs, file=sys.stderr)
             if not kw:
                 return True
 

--- a/src/sourmash/index.py
+++ b/src/sourmash/index.py
@@ -7,6 +7,8 @@ import os
 
 
 class Index(ABC):
+    is_database = False
+
     @abstractmethod
     def signatures(self):
         "Return an iterator over all signatures in the Index object."

--- a/src/sourmash/index.py
+++ b/src/sourmash/index.py
@@ -179,7 +179,7 @@ class LinearIndex(Index):
                     return False
 
             if 'scaled' in kw:
-                if ss.minhash.num or kw['scaled'] != ss.minhash.scaled:
+                if ss.minhash.num:
                     return False
             if 'num' in kw:
                 if ss.minhash.scaled or kw['num'] != ss.minhash.num:

--- a/src/sourmash/lca/lca_db.py
+++ b/src/sourmash/lca/lca_db.py
@@ -175,6 +175,11 @@ class LCA_Database(Index):
                containment=False):
         """Make sure this database matches the requested requirements.
 
+        As with SBTs, queries with higher scaled values than the database
+        can still be used for containment search, but not for similarity
+        search. See SBT.select(...) for details, and _find_signatures for
+        implementation.
+
         Will always raise ValueError if a requirement cannot be met.
         """
         if num:
@@ -475,12 +480,16 @@ class LCA_Database(Index):
         This is essentially a fast implementation of find that collects all
         the signatures with overlapping hash values. Note that similarity
         searches (containment=False) will not be returned in sorted order.
+
+        As with SBTs, queries with higher scaled values than the database
+        can still be used for containment search, but not for similarity
+        search. See SBT.select(...) for details.
         """
         # make sure we're looking at the same scaled value as database
         if self.scaled > minhash.scaled:
             minhash = minhash.downsample(scaled=self.scaled)
         elif self.scaled < minhash.scaled and not ignore_scaled:
-            # note that containment cannot be calculated w/o matching scaled.
+            # note that similarity cannot be calculated w/o matching scaled.
             raise ValueError("lca db scaled is {} vs query {}; must downsample".format(self.scaled, minhash.scaled))
 
         query_mins = set(minhash.hashes)

--- a/src/sourmash/lca/lca_db.py
+++ b/src/sourmash/lca/lca_db.py
@@ -173,7 +173,10 @@ class LCA_Database(Index):
 
     def select(self, ksize=None, moltype=None, num=0, scaled=0,
                containment=False):
-        "Selector interface - make sure this database matches requirements."
+        """Make sure this database matches the requested requirements.
+
+        Will always raise ValueError if a requirement cannot be met.
+        """
         if num:
             raise ValueError("cannot use 'num' MinHashes to search LCA database")
 

--- a/src/sourmash/lca/lca_db.py
+++ b/src/sourmash/lca/lca_db.py
@@ -55,6 +55,8 @@ class LCA_Database(Index):
     `hashval_to_idx` is a dictionary from individual hash values to sets of
     `idx`.
     """
+    is_database = True
+
     def __init__(self, ksize, scaled, moltype='DNA'):
         self.ksize = int(ksize)
         self.scaled = int(scaled)

--- a/src/sourmash/lca/lca_db.py
+++ b/src/sourmash/lca/lca_db.py
@@ -169,12 +169,13 @@ class LCA_Database(Index):
         for v in self._signatures.values():
             yield v
 
-    def select(self, ksize=None, moltype=None, num=0, scaled=0):
+    def select(self, ksize=None, moltype=None, num=0, scaled=0,
+               containment=False):
         "Selector interface - make sure this database matches requirements."
         if num:
             raise ValueError("cannot use num MinHashes on LCA database")
 
-        if scaled > self.scaled:
+        if scaled > self.scaled and not containment:
             raise ValueError(f"cannot use scaled={scaled} on this database ({self.scaled})")
 
         if ksize is not None and self.ksize != ksize:

--- a/src/sourmash/lca/lca_db.py
+++ b/src/sourmash/lca/lca_db.py
@@ -174,7 +174,7 @@ class LCA_Database(Index):
         if num:
             raise ValueError("cannot use num MinHashes on LCA database")
 
-        if scaled < self.scaled:
+        if scaled > self.scaled:
             raise ValueError(f"cannot use scaled={scaled} on this database ({self.scaled})")
 
         ok = True

--- a/src/sourmash/lca/lca_db.py
+++ b/src/sourmash/lca/lca_db.py
@@ -177,16 +177,12 @@ class LCA_Database(Index):
         if scaled > self.scaled:
             raise ValueError(f"cannot use scaled={scaled} on this database ({self.scaled})")
 
-        ok = True
         if ksize is not None and self.ksize != ksize:
-            ok = False
+            raise ValueError(f"ksize on this database is {self.ksize}; this is different from requested ksize of {ksize}")
         if moltype is not None and moltype != self.moltype:
-            ok = False
+            raise ValueError(f"moltype on this database is {self.moltype}; this is different from requested moltype of {moltype}")
 
-        if ok:
-            return self
-
-        raise ValueError("cannot select LCA on ksize {} / moltype {}".format(ksize, moltype))
+        return self
 
     @classmethod
     def load(cls, db_name):

--- a/src/sourmash/lca/lca_db.py
+++ b/src/sourmash/lca/lca_db.py
@@ -173,10 +173,10 @@ class LCA_Database(Index):
                containment=False):
         "Selector interface - make sure this database matches requirements."
         if num:
-            raise ValueError("cannot use num MinHashes on LCA database")
+            raise ValueError("cannot use 'num' MinHashes to search LCA database")
 
         if scaled > self.scaled and not containment:
-            raise ValueError(f"cannot use scaled={scaled} on this database ({self.scaled})")
+            raise ValueError(f"cannot use scaled={scaled} on this database (scaled={self.scaled})")
 
         if ksize is not None and self.ksize != ksize:
             raise ValueError(f"ksize on this database is {self.ksize}; this is different from requested ksize of {ksize}")

--- a/src/sourmash/lca/lca_db.py
+++ b/src/sourmash/lca/lca_db.py
@@ -169,8 +169,14 @@ class LCA_Database(Index):
         for v in self._signatures.values():
             yield v
 
-    def select(self, ksize=None, moltype=None):
+    def select(self, ksize=None, moltype=None, num=0, scaled=0):
         "Selector interface - make sure this database matches requirements."
+        if num:
+            raise ValueError("cannot use num MinHashes on LCA database")
+
+        if scaled < self.scaled:
+            raise ValueError(f"cannot use scaled={scaled} on this database ({self.scaled})")
+
         ok = True
         if ksize is not None and self.ksize != ksize:
             ok = False

--- a/src/sourmash/logging.py
+++ b/src/sourmash/logging.py
@@ -41,6 +41,17 @@ def debug(s, *args, **kwargs):
         sys.stderr.flush()
 
 
+def debug_literal(s, *args, **kwargs):
+    "A debug logging function => stderr."
+    if _quiet or not _debug:
+        return
+
+    print(u'\r\033[K', end=u'', file=sys.stderr)
+    print(s, file=sys.stderr, end=kwargs.get('end', u'\n'))
+    if kwargs.get('flush'):
+        sys.stderr.flush()
+
+
 def error(s, *args, **kwargs):
     "A simple error logging function => stderr."
     print(u'\r\033[K', end=u'', file=sys.stderr)

--- a/src/sourmash/sbt.py
+++ b/src/sourmash/sbt.py
@@ -201,7 +201,7 @@ class SBT(Index):
         if num:
             if not (num and first_sig.minhash.num):
                 raise ValueError(f"cannot search SBT: num={num}, {first_sig.minhash.num}")
-            if num == first_sig.minhash.num:
+            if num != first_sig.minhash.num:
                 raise ValueError(f"num mismatch for SBT: num={num}, {first_sig.minhash.num}")
 
         if scaled:

--- a/src/sourmash/sbt.py
+++ b/src/sourmash/sbt.py
@@ -189,7 +189,8 @@ class SBT(Index):
         for k in self.leaves():
             yield k.data
 
-    def select(self, ksize=None, moltype=None, num=0, scaled=0):
+    def select(self, ksize=None, moltype=None, num=0, scaled=0,
+               containment=False):
         first_sig = next(iter(self.signatures()))
 
         ok = True
@@ -197,6 +198,12 @@ class SBT(Index):
             ok = False
         if moltype is not None and first_sig.minhash.moltype != moltype:
             ok = False
+
+        if containment:
+            if not scaled:
+                raise ValueError("'containment' requires 'scaled' in SBT.select'")
+            if not first_sig.minhash.scaled:
+                raise ValueError("cannot search this SBT for containment; signatures are not calculated with scaled")
 
         if num:
             if not (num and first_sig.minhash.num):
@@ -207,7 +214,7 @@ class SBT(Index):
         if scaled:
             if not (scaled and first_sig.minhash.scaled):
                 raise ValueError(f"cannot search SBT: scaled={scaled}, {first_sig.minhash.scaled}")
-            if scaled > first_sig.minhash.scaled:
+            if scaled > first_sig.minhash.scaled and not containment:
                 raise ValueError(f"scaled mismatch: {scaled}, {first_sig.minhash.scaled}")
 
         if ok:

--- a/src/sourmash/sbt.py
+++ b/src/sourmash/sbt.py
@@ -198,10 +198,17 @@ class SBT(Index):
         if moltype is not None and first_sig.minhash.moltype != moltype:
             ok = False
 
-        if num and not (num and first_sig.minhash.num):
-            raise ValueError(f"cannot search SBT: num={num}, {first_sig.minhash.num}")
-        if scaled and not (scaled and first_sig.minhash.scaled):
-            raise ValueError(f"cannot search SBT: scaled={scaled}, {first_sig.minhash.scaled}")
+        if num:
+            if not (num and first_sig.minhash.num):
+                raise ValueError(f"cannot search SBT: num={num}, {first_sig.minhash.num}")
+            if num == first_sig.minhash.num:
+                raise ValueError(f"num mismatch for SBT: num={num}, {first_sig.minhash.num}")
+
+        if scaled:
+            if not (scaled and first_sig.minhash.scaled):
+                raise ValueError(f"cannot search SBT: scaled={scaled}, {first_sig.minhash.scaled}")
+            if scaled > first_sig.minhash.scaled:
+                raise ValueError(f"scaled mismatch: {scaled}, {first_sig.minhash.scaled}")
 
         if ok:
             return self

--- a/src/sourmash/sbt.py
+++ b/src/sourmash/sbt.py
@@ -195,6 +195,19 @@ class SBT(Index):
         """Make sure this database matches the requested requirements.
 
         Will always raise ValueError if a requirement cannot be met.
+
+        The only tricky bit here is around downsampling: if the scaled
+        value being requested is higher than the signatures in the
+        SBT, we can use the SBT for containment but not for
+        similarity. This is because:
+
+        * if we are doing containment searches, the intermediate nodes
+          can still be used for calculating containment of signatures
+          with higher scaled values. This is because only hashes that match
+          in the higher range are used for containment scores.
+        * however, for similarity, _all_ hashes are used, and we cannot
+          implicitly downsample or necessarily estimate similarity if
+          the scaled values differ.
         """
         # pull out a signature from this collection -
         first_sig = next(iter(self.signatures()))

--- a/src/sourmash/sbt.py
+++ b/src/sourmash/sbt.py
@@ -192,7 +192,10 @@ class SBT(Index):
 
     def select(self, ksize=None, moltype=None, num=0, scaled=0,
                containment=False):
-        "Make sure this database matches requirements."
+        """Make sure this database matches the requested requirements.
+
+        Will always raise ValueError if a requirement cannot be met.
+        """
         # pull out a signature from this collection -
         first_sig = next(iter(self.signatures()))
         db_mh = first_sig.minhash

--- a/src/sourmash/sbt.py
+++ b/src/sourmash/sbt.py
@@ -171,6 +171,7 @@ class SBT(Index):
     We use two dicts to store the tree structure: One for the internal nodes,
     and another for the leaves (datasets).
     """
+    is_database = True
 
     def __init__(self, factory, *, d=2, storage=None, cache_size=None):
         self.factory = factory

--- a/src/sourmash/sbt.py
+++ b/src/sourmash/sbt.py
@@ -191,20 +191,27 @@ class SBT(Index):
 
     def select(self, ksize=None, moltype=None, num=0, scaled=0,
                containment=False):
+        "Make sure this database matches requirements."
+        # pull out a signature from this collection -
         first_sig = next(iter(self.signatures()))
         db_mh = first_sig.minhash
 
+        # check ksize.
         if ksize is not None and db_mh.ksize != ksize:
             raise ValueError(f"search ksize {ksize} is different from database ksize {db_mh.ksize}")
+
+        # check moltype.
         if moltype is not None and db_mh.moltype != moltype:
             raise ValueError(f"search moltype {moltype} is different from database moltype {db_mh.moltype}")
 
+        # containment requires 'scaled'.
         if containment:
             if not scaled:
                 raise ValueError("'containment' requires 'scaled' in SBT.select'")
             if not db_mh.scaled:
                 raise ValueError("cannot search this SBT for containment; signatures are not calculated with scaled")
 
+        # 'num' and 'scaled' do not mix.
         if num:
             if not db_mh.num:
                 raise ValueError(f"this database was created with 'scaled' MinHash sketches, not 'num'")
@@ -214,6 +221,8 @@ class SBT(Index):
         if scaled:
             if not db_mh.scaled:
                 raise ValueError(f"this database was created with 'num' MinHash sketches, not 'scaled'")
+
+            # we can downsample SBTs for containment operations.
             if scaled > db_mh.scaled and not containment:
                 raise ValueError(f"search scaled value {scaled} is less than database scaled value of {db_mh.scaled}")
 

--- a/src/sourmash/sbt.py
+++ b/src/sourmash/sbt.py
@@ -189,7 +189,7 @@ class SBT(Index):
         for k in self.leaves():
             yield k.data
 
-    def select(self, ksize=None, moltype=None):
+    def select(self, ksize=None, moltype=None, num=0, scaled=0):
         first_sig = next(iter(self.signatures()))
 
         ok = True
@@ -197,6 +197,11 @@ class SBT(Index):
             ok = False
         if moltype is not None and first_sig.minhash.moltype != moltype:
             ok = False
+
+        if num and not (num and first_sig.minhash.num):
+            raise ValueError(f"cannot search SBT: num={num}, {first_sig.minhash.num}")
+        if scaled and not (scaled and first_sig.minhash.scaled):
+            raise ValueError(f"cannot search SBT: scaled={scaled}, {first_sig.minhash.scaled}")
 
         if ok:
             return self

--- a/src/sourmash/sourmash_args.py
+++ b/src/sourmash/sourmash_args.py
@@ -161,7 +161,8 @@ def load_dbs_and_sigs(filenames, query, is_similarity_query, *, cache_size=None)
 
         try:
             db = _load_database(filename, False, cache_size=cache_size)
-        except Exception as e:  # @CTB too broad an exception clause!?
+        except ValueError as e:
+            # cannot load database!
             notify(str(e))
             sys.exit(-1)
 

--- a/src/sourmash/sourmash_args.py
+++ b/src/sourmash/sourmash_args.py
@@ -223,45 +223,48 @@ def load_dbs_and_sigs(filenames, query, is_similarity_query, *, cache_size=None)
             notify(str(e))
             sys.exit(-1)
 
-        # are we collecting signatures from an SBT?
-        if dbtype == DatabaseType.SBT:
-            if not check_tree_is_compatible(filename, db, query,
-                                            is_similarity_query):
-                sys.exit(-1)
+        #db = db.select(moltype=query_moltype, ksize=query_ksize)
+        #databases.append(db)
 
-            databases.append(db)
-            notify(f'loaded SBT {filename}', end='\r')
-            n_databases += 1
+        if 1:
+            # are we collecting signatures from an SBT?
+            if dbtype == DatabaseType.SBT:
+                if not check_tree_is_compatible(filename, db, query,
+                                                is_similarity_query):
+                    sys.exit(-1)
 
-        # or an LCA?
-        elif dbtype == DatabaseType.LCA:
-            if not check_lca_db_is_compatible(filename, db, query):
-                sys.exit(-1)
+                databases.append(db)
+                notify(f'loaded SBT {filename}', end='\r')
+                n_databases += 1
 
-            notify(f'loaded LCA {filename}', end='\r')
-            n_databases += 1
+            # or an LCA?
+            elif dbtype == DatabaseType.LCA:
+                if not check_lca_db_is_compatible(filename, db, query):
+                    sys.exit(-1)
 
-            databases.append(db)
+                notify(f'loaded LCA {filename}', end='\r')
+                n_databases += 1
 
-        # or a mixed collection of signatures?
-        elif dbtype == DatabaseType.SIGLIST:
-            db = db.select(moltype=query_moltype, ksize=query_ksize)
-            siglist = db.signatures()
-            filter_fn = lambda s: _check_signatures_are_compatible(query, s)
-            db = db.filter(filter_fn)
+                databases.append(db)
 
-            if not db:
-                notify(f"no compatible signatures found in '{filename}'")
-                sys.exit(-1)
+            # or a mixed collection of signatures?
+            elif dbtype == DatabaseType.SIGLIST:
+                db = db.select(moltype=query_moltype, ksize=query_ksize)
+                filter_fn = lambda s: _check_signatures_are_compatible(query, s)
+                db = db.filter(filter_fn)
 
-            databases.append(db)
+                if not db:
+                    notify(f"no compatible signatures found in '{filename}'")
+                    sys.exit(-1)
 
-            notify(f'loaded {len(db)} signatures from {filename}', end='\r')
-            n_signatures += len(db)
+                databases.append(db)
 
-        # unknown!?
-        else:
-            raise ValueError(f"unknown dbtype {dbtype}") # CTB check me.
+                notify(f'loaded {len(db)} signatures from {filename}', end='\r')
+                n_signatures += len(db)
+
+            # unknown!?
+            else:
+                raise ValueError(f"unknown dbtype {dbtype}") # CTB check me.
 
         # END for loop
 
@@ -273,7 +276,7 @@ def load_dbs_and_sigs(filenames, query, is_similarity_query, *, cache_size=None)
         notify(f'loaded {n_signatures} signatures.')
     elif n_databases:
         notify(f'loaded {n_databases} databases.')
-    else:
+    elif 0:
         notify('** ERROR: no signatures or databases loaded?')
         sys.exit(-1)
 

--- a/src/sourmash/sourmash_args.py
+++ b/src/sourmash/sourmash_args.py
@@ -228,10 +228,10 @@ def load_dbs_and_sigs(filenames, query, is_similarity_query, *, cache_size=None)
                            ksize=query_ksize,
                            num=query.minhash.num,
                            scaled=query.minhash.scaled)
-        except ValueError:
-            raise
-            notify(f"cannot use {filename} for this query")
-            continue
+        except ValueError as exc:
+            notify(f"ERROR: cannot use '{filename}' for this query.")
+            notify(str(exc))
+            sys.exit(-1)
 
         if not db:
             notify(f"no compatible signatures found in '{filename}'")

--- a/src/sourmash/sourmash_args.py
+++ b/src/sourmash/sourmash_args.py
@@ -223,11 +223,15 @@ def load_dbs_and_sigs(filenames, query, is_similarity_query, *, cache_size=None)
             notify(str(e))
             sys.exit(-1)
 
-        db = db.select(moltype=query_moltype,
-                       ksize=query_ksize,
-                       num=query.minhash.num,
-                       scaled=query.minhash.scaled)
-        databases.append(db)
+        try:
+            db = db.select(moltype=query_moltype,
+                           ksize=query_ksize,
+                           num=query.minhash.num,
+                           scaled=query.minhash.scaled)
+            databases.append(db)
+        except ValueError:
+            notify(f"cannot use {filename} for this query")
+            continue
 
         if 0:
             # are we collecting signatures from an SBT?

--- a/src/sourmash/sourmash_args.py
+++ b/src/sourmash/sourmash_args.py
@@ -15,7 +15,7 @@ from sourmash.lca.lca_db import load_single_database
 import sourmash.exceptions
 
 from . import signature
-from .logging import notify, error, debug
+from .logging import notify, error, debug_literal
 
 from .index import LinearIndex, MultiIndex
 from . import signature as sig
@@ -378,13 +378,13 @@ def _load_database(filename, traverse_yield_all, *, cache_size=None):
     # but nothing else.
     for (desc, load_fn) in _loader_functions:
         try:
-            debug(f"_load_databases: trying loader fn {desc}")
+            debug_literal(f"_load_databases: trying loader fn {desc}")
             db, dbtype = load_fn(filename,
                                  traverse_yield_all=traverse_yield_all,
                                  cache_size=cache_size)
         except ValueError as exc:
-            debug(f"_load_databases: FAIL on fn {desc}.")
-            debug(traceback.format_exc())
+            debug_literal(f"_load_databases: FAIL on fn {desc}.")
+            debug_literal(traceback.format_exc())
 
         if db:
             loaded = True

--- a/src/sourmash/sourmash_args.py
+++ b/src/sourmash/sourmash_args.py
@@ -228,10 +228,16 @@ def load_dbs_and_sigs(filenames, query, is_similarity_query, *, cache_size=None)
                            ksize=query_ksize,
                            num=query.minhash.num,
                            scaled=query.minhash.scaled)
-            databases.append(db)
         except ValueError:
+            raise
             notify(f"cannot use {filename} for this query")
             continue
+
+        if not db:
+            notify(f"no compatible signatures found in '{filename}'")
+            sys.exit(-1)
+
+        databases.append(db)
 
         if 0:
             # are we collecting signatures from an SBT?

--- a/src/sourmash/sourmash_args.py
+++ b/src/sourmash/sourmash_args.py
@@ -223,10 +223,13 @@ def load_dbs_and_sigs(filenames, query, is_similarity_query, *, cache_size=None)
             notify(str(e))
             sys.exit(-1)
 
-        #db = db.select(moltype=query_moltype, ksize=query_ksize)
-        #databases.append(db)
+        db = db.select(moltype=query_moltype,
+                       ksize=query_ksize,
+                       num=query.minhash.num,
+                       scaled=query.minhash.scaled)
+        databases.append(db)
 
-        if 1:
+        if 0:
             # are we collecting signatures from an SBT?
             if dbtype == DatabaseType.SBT:
                 if not check_tree_is_compatible(filename, db, query,
@@ -276,7 +279,9 @@ def load_dbs_and_sigs(filenames, query, is_similarity_query, *, cache_size=None)
         notify(f'loaded {n_signatures} signatures.')
     elif n_databases:
         notify(f'loaded {n_databases} databases.')
-    elif 0:
+
+
+    if not databases:
         notify('** ERROR: no signatures or databases loaded?')
         sys.exit(-1)
 

--- a/src/sourmash/sourmash_args.py
+++ b/src/sourmash/sourmash_args.py
@@ -211,6 +211,10 @@ def load_dbs_and_sigs(filenames, query, is_similarity_query, *, cache_size=None)
     query_ksize = query.minhash.ksize
     query_moltype = get_moltype(query)
 
+    containment = True
+    if is_similarity_query:
+        containment = False
+
     n_signatures = 0
     n_databases = 0
     databases = []
@@ -227,7 +231,8 @@ def load_dbs_and_sigs(filenames, query, is_similarity_query, *, cache_size=None)
             db = db.select(moltype=query_moltype,
                            ksize=query_ksize,
                            num=query.minhash.num,
-                           scaled=query.minhash.scaled)
+                           scaled=query.minhash.scaled,
+                           containment=containment)
         except ValueError as exc:
             notify(f"ERROR: cannot use '{filename}' for this query.")
             notify(str(exc))

--- a/tests/test_lca.py
+++ b/tests/test_lca.py
@@ -1908,8 +1908,8 @@ def test_incompat_lca_db_ksize_2(c):
     err = c.last_result.err
     print(err)
 
-    assert "ksize on db 'test.lca.json' is 25;" in err
-    assert 'this is different from query ksize of 31.' in err
+    assert "ERROR: cannot use 'test.lca.json' for this query." in err
+    assert "ksize on this database is 25; this is different from requested ksize of 31"
 
 
 @utils.in_tempdir

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -1857,6 +1857,8 @@ def test_search_incompatible(c):
 
 @utils.in_tempdir
 def test_search_traverse_incompatible(c):
+    # build a directory with some signatures in it, search for compatible
+    # signatures.
     searchdir = c.output('searchme')
     os.mkdir(searchdir)
 
@@ -1866,10 +1868,7 @@ def test_search_traverse_incompatible(c):
     shutil.copyfile(scaled_sig, c.output('searchme/scaled.sig'))
 
     c.run_sourmash("search", scaled_sig, c.output('searchme'))
-    print(c.last_result.out)
-    print(c.last_result.err)
-    assert 'incompatible - cannot compare.' in c.last_result.err
-    assert 'was calculated with --scaled,' in c.last_result.err
+    assert '100.0%       NC_009665.1 Shewanella baltica OS185, complete genome' in c.last_result.out
 
 
 # explanation: you cannot downsample a scaled SBT to match a scaled
@@ -3604,8 +3603,7 @@ def test_gather_traverse_incompatible(c):
     c.run_sourmash("gather", scaled_sig, c.output('searchme'))
     print(c.last_result.out)
     print(c.last_result.err)
-    assert 'incompatible - cannot compare.' in c.last_result.err
-    assert 'was calculated with --scaled,' in c.last_result.err
+    assert "5.2 Mbp      100.0%  100.0%    NC_009665.1 Shewanella baltica OS185,..." in c.last_result.out
 
 
 def test_gather_metagenome_output_unassigned():

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -3780,7 +3780,7 @@ def test_gather_query_downsample():
         print(out)
         print(err)
 
-        # assert 'loaded 12 signatures' in err @CTB
+        assert 'loaded 12 signatures' in err
         assert all(('4.9 Mbp      100.0%  100.0%' in out,
                     'NC_003197.2' in out))
 

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -1851,8 +1851,8 @@ def test_search_incompatible(c):
     assert c.last_result.status != 0
     print(c.last_result.out)
     print(c.last_result.err)
-    assert 'incompatible - cannot compare.' in c.last_result.err
-    assert 'was calculated with --scaled,' in c.last_result.err
+
+    assert "no compatible signatures found in " in c.last_result.err
 
 
 @utils.in_tempdir
@@ -1895,8 +1895,11 @@ def test_search_metagenome_downsample():
                                            in_directory=location, fail_ok=True)
         assert status == -1
 
-        assert "for tree 'gcf_all', scaled value is smaller than query." in err
-        assert 'tree scaled: 10000; query scaled: 100000. Cannot do similarity search.' in err
+        print(out)
+        print(err)
+
+        assert "ERROR: cannot use 'gcf_all' for this query." in err
+        assert "search scaled value 100000 is less than database scaled value of 10000" in err
 
 
 def test_search_metagenome_downsample_containment():
@@ -2054,7 +2057,11 @@ def test_do_sourmash_sbt_search_wrong_ksize():
                                            fail_ok=True)
 
         assert status == -1
-        assert 'this is different from' in err
+        print(out)
+        print(err)
+
+        assert "ERROR: cannot use 'zzz' for this query." in err
+        assert "search ksize 51 is different from database ksize 31" in err
 
 
 def test_do_sourmash_sbt_search_multiple():
@@ -2169,7 +2176,10 @@ def test_do_sourmash_sbt_search_downsample_2():
                                             '--threshold=0.01'],
                                            in_directory=location, fail_ok=True)
         assert status == -1
-        assert 'Cannot do similarity search.' in err
+        print(out)
+        print(err)
+        assert "ERROR: cannot use 'foo' for this query." in err
+        assert "search scaled value 100000 is less than database scaled value of 2000" in err
 
 
 def test_do_sourmash_index_single():
@@ -2464,7 +2474,10 @@ def test_do_sourmash_sbt_search_scaled_vs_num_1():
                                            fail_ok=True)
 
         assert status == -1
-        assert 'tree and query are incompatible for search' in err
+        print(out)
+        print(err)
+        assert "ERROR: cannot use '" in err
+        assert "this database was created with 'num' MinHash sketches, not 'scaled'" in err
 
 
 def test_do_sourmash_sbt_search_scaled_vs_num_2():
@@ -2496,7 +2509,10 @@ def test_do_sourmash_sbt_search_scaled_vs_num_2():
                                            fail_ok=True)
 
         assert status == -1
-        assert 'tree and query are incompatible for search' in err
+        print(out)
+        print(err)
+        assert "ERROR: cannot use '" in err
+        assert "this database was created with 'scaled' MinHash sketches, not 'num'" in err
 
 
 def test_do_sourmash_sbt_search_scaled_vs_num_3():
@@ -2521,7 +2537,9 @@ def test_do_sourmash_sbt_search_scaled_vs_num_3():
                                            fail_ok=True)
 
         assert status == -1
-        assert 'incompatible - cannot compare' in err
+        print(out)
+        print(err)
+        assert "no compatible signatures found in " in err
 
 
 def test_do_sourmash_sbt_search_scaled_vs_num_4():
@@ -2546,7 +2564,9 @@ def test_do_sourmash_sbt_search_scaled_vs_num_4():
                                            ['search', sig_loc2, sig_loc],
                                            fail_ok=True)
         assert status == -1
-        assert 'incompatible - cannot compare' in err
+        print(out)
+        print(err)
+        assert "no compatible signatures found in " in err
 
 
 def test_do_sourmash_check_search_vs_actual_similarity():
@@ -3748,6 +3768,7 @@ def test_gather_query_downsample():
     with utils.TempDirectory() as location:
         testdata_glob = utils.get_test_data('gather/GCF*.sig')
         testdata_sigs = glob.glob(testdata_glob)
+        print(testdata_sigs)
 
         query_sig = utils.get_test_data('GCF_000006945.2-s500.sig')
 
@@ -3759,7 +3780,7 @@ def test_gather_query_downsample():
         print(out)
         print(err)
 
-        assert 'loaded 12 signatures' in err
+        # assert 'loaded 12 signatures' in err @CTB
         assert all(('4.9 Mbp      100.0%  100.0%' in out,
                     'NC_003197.2' in out))
 


### PR DESCRIPTION
This is a PR into #1406.

Building off of the refactored database loading in https://github.com/dib-lab/sourmash/pull/1406, this PR introduces expanded signature selection and compatibility checking for `Index` classes.

This results in much simpler code with much less special-casing. 🎉 

Fixes https://github.com/dib-lab/sourmash/issues/1376
Addresses https://github.com/dib-lab/sourmash/issues/1072

Some searches may now work where they didn't before - for example,
* `test_search_traverse_incompatible` will now succeed, because it now selects the compatible signatures and ignores the incompatible ones.

TODO:
- [x] write specific tests against `select` interface for key `Index` subclasses: `LinearIndex`, `MultiIndex`, `SBT`, `LCA_Database` - punted to https://github.com/dib-lab/sourmash/issues/1427
- [x] also test that partial restrictions (e.g. just ksize) are appropriately implemented - punted to https://github.com/dib-lab/sourmash/issues/1427
- [x] clean up/simplify `LCA_Database.select(...)` logic
- [x] write up downsampling details ...somewhere - codebase, or docs? - since they are now cleanly separated out in `select(...)` ref #407
- [x] document in this PR which previously-failing commands (slash tests) now succeed and why :)

## Checklist

- [ ] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make coverage` Is the new code covered?
- [ ] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
