### PR TITLE
Rename `load_file_list_of_signatures` to `load_pathlist_from_file`

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,3 +8,4 @@
   major version number increment.
 - [ ] Was a spellchecker run on the source code and documentation after
   changes were made?
+- [ ] If it is your first contribution, make sure to create your [ORCID](https://orcid.org/register) id.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,4 +8,4 @@
   major version number increment.
 - [ ] Was a spellchecker run on the source code and documentation after
   changes were made?
-- [ ] please note your ORCID in the comments. If you don't have one, you can register for one [here].(https://orcid.org/register)
+- [ ] Please note your ORCID in the comments. If you don't have one, you can register for one [here].(https://orcid.org/register)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,4 +8,4 @@
   major version number increment.
 - [ ] Was a spellchecker run on the source code and documentation after
   changes were made?
-- [ ] If it is your first contribution, make sure to create your [ORCID](https://orcid.org/register) id.
+- [ ] please note your ORCID in the comments. If you don't have one, you can register for one [here].(https://orcid.org/register)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,4 +8,4 @@
   major version number increment.
 - [ ] Was a spellchecker run on the source code and documentation after
   changes were made?
-- [ ] Please note your ORCID in the comments. If you don't have one, you can register for one [here].(https://orcid.org/register)
+- [ ] Please note your ORCID in the comments. If you don't have one, you can register for one [here](https://orcid.org/register).

--- a/src/sourmash/command_sketch.py
+++ b/src/sourmash/command_sketch.py
@@ -154,9 +154,9 @@ class _signatures_for_sketch_factory(object):
 
 def _add_from_file_to_filenames(args):
     "Add filenames from --from-file to args.filenames"
-    from .sourmash_args import load_file_list_of_signatures
+    from .sourmash_args import load_pathlist_from_file
     if args.from_file:
-        file_list = load_file_list_of_signatures(args.from_file)
+        file_list = load_pathlist_from_file(args.from_file)
         args.filenames.extend(file_list)
 
 

--- a/src/sourmash/commands.py
+++ b/src/sourmash/commands.py
@@ -33,7 +33,7 @@ def compare(args):
 
     inp_files = list(args.signatures)
     if args.from_file:
-        more_files = sourmash_args.load_file_list_of_signatures(args.from_file)
+        more_files = sourmash_args.load_pathlist_from_file(args.from_file)
         inp_files.extend(more_files)
 
     progress = sourmash_args.SignatureLoadingProgress()
@@ -353,7 +353,7 @@ def index(args):
 
     inp_files = list(args.signatures)
     if args.from_file:
-        more_files = sourmash_args.load_file_list_of_signatures(args.from_file)
+        more_files = sourmash_args.load_pathlist_from_file(args.from_file)
         inp_files.extend(more_files)
 
     if not inp_files:
@@ -725,7 +725,7 @@ def multigather(args):
     args.db = [item for sublist in args.db for item in sublist]
     inp_files = [item for sublist in args.query for item in sublist]
     if args.query_from_file:
-        more_files = sourmash_args.load_file_list_of_signatures(args.query_from_file)
+        more_files = sourmash_args.load_pathlist_from_file(args.query_from_file)
         inp_files.extend(more_files)
 
     # need a query to get ksize, moltype for db loading

--- a/src/sourmash/lca/command_classify.py
+++ b/src/sourmash/lca/command_classify.py
@@ -101,7 +101,7 @@ def classify(args):
     notify('finding query signatures...')
     inp_files = list(args.query)
     if args.query_from_file:
-        more_files = sourmash_args.load_file_list_of_signatures(args.query_from_file)
+        more_files = sourmash_args.load_pathlist_from_file(args.query_from_file)
         inp_files.extend(more_files)
 
     if not check_files_exist(*inp_files):

--- a/src/sourmash/lca/command_index.py
+++ b/src/sourmash/lca/command_index.py
@@ -168,7 +168,7 @@ def index(args):
 
     inp_files = list(args.signatures)
     if args.from_file:
-        more_files = sourmash_args.load_file_list_of_signatures(args.from_file)
+        more_files = sourmash_args.load_pathlist_from_file(args.from_file)
         inp_files.extend(more_files)
 
     # track duplicates

--- a/src/sourmash/lca/command_summarize.py
+++ b/src/sourmash/lca/command_summarize.py
@@ -181,7 +181,7 @@ def summarize_main(args):
     inp_files = args.query
 
     if args.query_from_file:
-        more_files = sourmash_args.load_file_list_of_signatures(args.query_from_file)
+        more_files = sourmash_args.load_pathlist_from_file(args.query_from_file)
         inp_files.extend(more_files)
 
     if not inp_files:

--- a/src/sourmash/sourmash_args.py
+++ b/src/sourmash/sourmash_args.py
@@ -385,7 +385,7 @@ def _load_database(filename, traverse_yield_all, *, cache_size=None):
             idx_list = []
             src_list = []
 
-            file_list = load_file_list_of_signatures(filename)
+            file_list = load_pathlist_from_file(filename)
             for fname in file_list:
                 idx = load_file_as_index(fname)
                 src = fname
@@ -485,7 +485,7 @@ def load_file_as_signatures(filename, select_moltype=None, ksize=None,
         return loader
 
 
-def load_file_list_of_signatures(filename):
+def load_pathlist_from_file(filename):
     "Load a list-of-files text file."
     try:
         with open(filename, 'rt') as fp:


### PR DESCRIPTION
Fixes #1369 

This PR renames the function ```load_file_list_of_signatures``` to ```load_pathlist_from_file``` in 6 files. These files are:
- ```src/sourmash/lca/command_summarize.py```
- ```src/sourmash/command_sketch.py```
- ```src/sourmash/commands.py```
- ```src/sourmash/lca/command_classify.py```
- ```src/sourmash/lca/command_index.py```
- ```src/sourmash/sourmash_args.py```

TODO:
- [ ] Add some Python unit tests in ```tests/test_sourmash.py``` for this function, including empty file list, badly formatted ones, ones with duplicates.

Checklist:
- [ ] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make coverage` Is the new code covered?
- [ ] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
- [ ] Please note your ORCID in the comments. If you don't have one, you can register for one [here](https://orcid.org/register).