### PR TITLE
Adding information about updating developer environment to the developer docs

### DIFF
--- a/doc/developer.md
+++ b/doc/developer.md
@@ -64,11 +64,17 @@ tox -e dev
 . .tox/dev/bin/activate
 ```
 
-Finally, ou can also explicitly install all the Python dependencies for sourmash by running
+Finally, you can also explicitly install all the Python dependencies for sourmash by running
 ```
 pip install -r requirements.txt
 ```
 (but they are already installed in the virtualenv created with `tox -e dev`).
+
+## Updating your developer environment
+
+To update rust to the latest version, use [`rustup update`].
+
+To update your Python dependencies to the latest required for sourmash, you can run [`pip install -r requirements.txt`].
 
 ## Running tests and checks
 

--- a/doc/developer.md
+++ b/doc/developer.md
@@ -72,9 +72,9 @@ pip install -r requirements.txt
 
 ## Updating your developer environment
 
-To update rust to the latest version, use [`rustup update`].
+To update rust to the latest version, use `rustup update`.
 
-To update your Python dependencies to the latest required for sourmash, you can run [`pip install -r requirements.txt`].
+To update your Python dependencies to the latest required for sourmash, you can run `pip install -r requirements.txt`.
 
 ## Running tests and checks
 


### PR DESCRIPTION
* This involves modifications to `doc/developer.md`. 

* A new heading called "Updating your developer environment" has been added just above "Running tests and checks" in `doc/developer.md`. The commands for updating Rust and Python have been added under this heading.

* There was a typo in the current dev docs on the line:

> Finally, ou can also explicitly install all the Python dependencies for sourmash by running

'ou' has been modified to 'you' here.

* Fixes #1181
