### PR TITLE
[MRG] pin docutils to v0.16 to address doc building bug

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -70,6 +70,7 @@ doc =
     sphinxcontrib-napoleon
     nbsphinx
     ipython
+    docutils==0.16    # pin to avoid doc build bug - see #1437
 storage =
     ipfshttpclient>=0.4.13
     redis


### PR DESCRIPTION
This PR prevents docutils from upgrading to the latest release, v0.17, which causes some problems with Sphinx. See error message in #1437 for details.

Fixes #1437
