### PR TITLE
Add a check for LCA database error text in`tests/test_lca.py`

### DIFF
--- a/tests/test_lca.py
+++ b/tests/test_lca.py
@@ -399,12 +399,21 @@ def test_databases_load_fail_on_dir():
     with pytest.raises(ValueError) as exc:
         dblist, ksize, scaled = lca_utils.load_databases([filename1])
 
+    err = filename1.err
+    print(err)
+    assert f"Error while loading '{filename1}' as an LCA database" in err
+    assert not 'found 0 matches total;' in err
+
 
 def test_databases_load_fail_on_not_exist():
     filename1 = utils.get_test_data('does-not-exist')
     with pytest.raises(ValueError) as exc:
         dblist, ksize, scaled = lca_utils.load_databases([filename1])
 
+    err = filename1.err
+    print(err)
+    assert f"Error while loading '{filename1}'" in err
+    assert not 'found 0 matches total;' in err
 
 def test_db_repr():
     filename = utils.get_test_data('lca/delmont-1.lca.json')

--- a/tests/test_lca.py
+++ b/tests/test_lca.py
@@ -399,9 +399,9 @@ def test_databases_load_fail_on_dir():
     with pytest.raises(ValueError) as exc:
         dblist, ksize, scaled = lca_utils.load_databases([filename1])
 
-    err = filename1.err
+    err = str(exc.value)
     print(err)
-    assert f"Error while loading '{filename1}' as an LCA database" in err
+    assert f"'{filename1}' is not a file and cannot be loaded as an LCA database" in err
     assert not 'found 0 matches total;' in err
 
 
@@ -410,9 +410,9 @@ def test_databases_load_fail_on_not_exist():
     with pytest.raises(ValueError) as exc:
         dblist, ksize, scaled = lca_utils.load_databases([filename1])
 
-    err = filename1.err
+    err = str(exc.value)
     print(err)
-    assert f"Error while loading '{filename1}'" in err
+    assert f"'{filename1}' is not a file and cannot be loaded as an LCA database" in err
     assert not 'found 0 matches total;' in err
 
 def test_db_repr():


### PR DESCRIPTION
* In `src/sourmash/lca/lca_db.py`, the 1LCA_Database.load(...)1 class method checks to make sure that the filename is a directory, and if it is not, it raises a `ValueError` with the following string: `"'{db_name}' is not a file and cannot be loaded as an LCA database"`.
* This PR adds assert statements to `test_databases_load_fail_on_dir` and `test_databases_load_fail_on_not_exist` functions in `tests/test_lca.py` to check for this string value.
* Fixes #1415 