### PR TITLE
[MRG] Make `MinHash.downsample(...)` require keyword arguments & fix newly revealed buggy test.

### DIFF
--- a/src/sourmash/minhash.py
+++ b/src/sourmash/minhash.py
@@ -463,7 +463,6 @@ class MinHash(RustObject):
                 else:
                     max_hash=0
             else:
-                # @CTB testme
                 raise ValueError("scaled != 0 - cannot downsample a scaled MinHash this way")
         elif scaled is not None:
             if self.num:

--- a/src/sourmash/minhash.py
+++ b/src/sourmash/minhash.py
@@ -450,16 +450,21 @@ class MinHash(RustObject):
             raise TypeError("Must be a MinHash!")
         return self._methodcall(lib.kmerminhash_count_common, other._get_objptr(), downsample)
 
-    def downsample(self, num=None, scaled=None):
+    def downsample(self, *, num=None, scaled=None):
         """Copy this object and downsample new object to either `num` or
         `scaled`.
         """
         if num is None and scaled is None:
             raise ValueError('must specify either num or scaled to downsample')
         elif num is not None:
-            if self.num and self.num < num:
-                raise ValueError("new sample num is higher than current sample num")
-            max_hash=0
+            if self.num:
+                if self.num < num:
+                    raise ValueError("new sample num is higher than current sample num")
+                else:
+                    max_hash=0
+            else:
+                # @CTB testme
+                raise ValueError("scaled != 0 - cannot downsample a scaled MinHash this way")
         elif scaled is not None:
             if self.num:
                 raise ValueError("num != 0 - cannot downsample a standard MinHash")

--- a/tests/test_jaccard.py
+++ b/tests/test_jaccard.py
@@ -271,3 +271,17 @@ def test_scaled_on_real_data_2():
     mh2 = mh2.downsample(scaled=100000)
     assert round(mh1.similarity(mh2), 2) == 0.01
     assert round(mh2.similarity(mh1), 2) == 0.01
+
+
+def test_downsample_scaled_with_num():
+    from sourmash.signature import load_signatures
+
+    afile = 'scaled100/GCF_000005845.2_ASM584v2_genomic.fna.gz.sig.gz'
+    a = utils.get_test_data(afile)
+    sig1 = list(load_signatures(a))[0]
+    mh1 = sig1.minhash
+
+    with pytest.raises(ValueError) as exc:
+        mh = mh1.downsample(num=500)
+
+    assert 'cannot downsample a scaled MinHash this way' in str(exc.value)

--- a/tests/test_jaccard.py
+++ b/tests/test_jaccard.py
@@ -223,26 +223,21 @@ def test_scaled_on_real_data():
     assert round(mh1.similarity(mh2), 5) == 0.01644
     assert round(mh2.similarity(mh1), 5) == 0.01644
 
-    mh1 = mh1.downsample(num=10000)
-    mh2 = mh2.downsample(num=10000)
+    mh1 = mh1.downsample(scaled=100)
+    mh2 = mh2.downsample(scaled=100)
+    assert round(mh1.similarity(mh2), 5) == 0.01644
+    assert round(mh2.similarity(mh1), 5) == 0.01644
 
-    assert mh1.similarity(mh2) == 0.0183
-    assert mh2.similarity(mh1) == 0.0183
+    mh1 = mh1.downsample(scaled=1000)
+    mh2 = mh2.downsample(scaled=1000)
+    assert round(mh1.similarity(mh2), 5) == 0.01874
+    assert round(mh2.similarity(mh1), 5) == 0.01874
 
-    mh1 = mh1.downsample(num=1000)
-    mh2 = mh2.downsample(num=1000)
-    assert mh1.similarity(mh2) == 0.011
-    assert mh2.similarity(mh1) == 0.011
+    mh1 = mh1.downsample(scaled=10000)
+    mh2 = mh2.downsample(scaled=10000)
 
-    mh1 = mh1.downsample(num=100)
-    mh2 = mh2.downsample(num=100)
     assert mh1.similarity(mh2) == 0.01
     assert mh2.similarity(mh1) == 0.01
-
-    mh1 = mh1.downsample(num=10)
-    mh2 = mh2.downsample(num=10)
-    assert mh1.similarity(mh2) == 0.0
-    assert mh2.similarity(mh1) == 0.0
 
 
 def test_scaled_on_real_data_2():


### PR DESCRIPTION
I forgot to provide a parameter as a keyword argument to `MinHash.downsample(...)` over in #1392, and it silently did the wrong thing (which was caught by a test, but still).

This PR forces keyword arguments in `MinHash.downsample`, (i.e. you _must_ provide either `num=` or `scaled=`). It also catches the exciting new error that I found where `num` downsampling was mistakenly allowed on `scaled` signatures, adds a new (simple) test, and fixes an old test that was erroneously passing to be correctly passing.

