### PR TITLE
[MRG] add codecov configuration to fix paths

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,6 @@
+# config file for codecov, https://app.codecov.io/gh/dib-lab/sourmash/
+
+# use path fixing to properly report code coverage on source code
+# per https://docs.codecov.io/docs/fixing-paths
+fixes:
+- "::src/"


### PR DESCRIPTION
This PR adds `codecov.yml` for configuration of [our code coverage reporting at codecov.io](https://app.codecov.io/gh/dib-lab/sourmash/) so that the paths end up matching the source code paths.

Specifically, since we moved all the source code under `src/`, but the paths are being reported as `sourmash/` instead of `src/sourmash/` by our CI environment, codecov can't find the actual source code. This fixes that.
