### PR TITLE
[MRG] Fix path for tests and Rust coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -3,4 +3,4 @@
 # use path fixing to properly report code coverage on source code
 # per https://docs.codecov.io/docs/fixing-paths
 fixes:
-- "::src/"
+- "sourmash::src/sourmash"


### PR DESCRIPTION
Continuation of #1449 with a fix that works for `tests/` and the Rust coverage.

Tried it out in #1238 and coverage is properly reported: https://codecov.io/gh/dib-lab/sourmash/tree/13e6dcc44ecb8ce364c0362220fbc945a07780c5

<!--
Please replace this text with:

* a brief description of your changes in this PR
* which issues this fixes in the issue tracker, if any ("Fixes #XXX")
* which issues this PR is related to, if any ("Ref #XXX")

Please also be sure to note here if file formats, command-line
interface, and/or the top-level sourmash API will change because of
this PR.

If you are a new contributor, please provide
[your ORCID](https://orcid.org).  If you don't have one, please
[register for one](https://orcid.org/register).

Once the items above are done, and all checks pass, request a review!
-->