### PR TITLE
[MRG] add explicit test for incompatible num on `MinHash.__add__`

### DIFF
--- a/src/sourmash/minhash.py
+++ b/src/sourmash/minhash.py
@@ -563,6 +563,10 @@ class MinHash(RustObject):
         if not isinstance(other, MinHash):
             raise TypeError("can only add MinHash objects to MinHash objects!")
 
+        if self.num and other.num:
+            if self.num != other.num:
+                raise TypeError(f"incompatible num values: self={self.num} other={other.num}")
+
         new_obj = self.__copy__()
         new_obj += other
         return new_obj

--- a/tests/test__minhash.py
+++ b/tests/test__minhash.py
@@ -1594,6 +1594,19 @@ def test_is_molecule_type_4(track_abundance):
     assert mh.dayhoff
 
 
+def test_addition_num_incompatible():
+    mh1 = MinHash(10, 21)
+    mh2 = MinHash(20, 21)
+
+    mh1.add_hash(0)
+    mh2.add_hash(1)
+
+    with pytest.raises(TypeError) as exc:
+        mh3 = mh1 + mh2
+
+    assert "incompatible num values: self=10 other=20" in str(exc.value)
+
+
 def test_addition_abund():
     mh1 = MinHash(10, 21, track_abundance=True)
     mh2 = MinHash(10, 21, track_abundance=True)


### PR DESCRIPTION
Add a check and a test for incompatible `num` on `a + b` for MinHash objects, where behavior is otherwise unspecified.

Extracted from #1392.

Ready for review!
