### PR TITLE
fixing LCA_Database _repr_ so None is not displayed (working on issue)

### DIFF
--- a/src/sourmash/commands.py
+++ b/src/sourmash/commands.py
@@ -32,7 +32,7 @@ def compare(args):
 
     inp_files = list(args.signatures)
     if args.from_file:
-        more_files = sourmash_args.load_file_list_of_signatures(args.from_file)
+        more_files = sourmash_args.load_pathlist_from_file(args.from_file)
         inp_files.extend(more_files)
 
     progress = sourmash_args.SignatureLoadingProgress()
@@ -342,7 +342,7 @@ def index(args):
 
     inp_files = list(args.signatures)
     if args.from_file:
-        more_files = sourmash_args.load_file_list_of_signatures(args.from_file)
+        more_files = sourmash_args.load_pathlist_from_file(args.from_file)
         inp_files.extend(more_files)
 
     if not inp_files:
@@ -703,7 +703,7 @@ def multigather(args):
     args.db = [item for sublist in args.db for item in sublist]
     inp_files = [item for sublist in args.query for item in sublist]
     if args.query_from_file:
-        more_files = sourmash_args.load_file_list_of_signatures(args.query_from_file)
+        more_files = sourmash_args.load_pathlist_from_file(args.query_from_file)
         inp_files.extend(more_files)
 
     # need a query to get ksize, moltype for db loading

--- a/src/sourmash/lca/command_classify.py
+++ b/src/sourmash/lca/command_classify.py
@@ -101,7 +101,7 @@ def classify(args):
     notify('finding query signatures...')
     inp_files = list(args.query)
     if args.query_from_file:
-        more_files = sourmash_args.load_file_list_of_signatures(args.query_from_file)
+        more_files = sourmash_args.load_pathlist_from_file(args.query_from_file)
         inp_files.extend(more_files)
 
     if not check_files_exist(*inp_files):

--- a/src/sourmash/lca/command_index.py
+++ b/src/sourmash/lca/command_index.py
@@ -170,7 +170,7 @@ def index(args):
 
     inp_files = list(args.signatures)
     if args.from_file:
-        more_files = sourmash_args.load_file_list_of_signatures(args.from_file)
+        more_files = sourmash_args.load_pathlist_from_file(args.from_file)
         inp_files.extend(more_files)
 
     # track duplicates

--- a/src/sourmash/lca/command_summarize.py
+++ b/src/sourmash/lca/command_summarize.py
@@ -181,7 +181,7 @@ def summarize_main(args):
     inp_files = args.query
 
     if args.query_from_file:
-        more_files = sourmash_args.load_file_list_of_signatures(args.query_from_file)
+        more_files = sourmash_args.load_pathlist_from_file(args.query_from_file)
         inp_files.extend(more_files)
 
     if not inp_files:

--- a/src/sourmash/sourmash_args.py
+++ b/src/sourmash/sourmash_args.py
@@ -525,7 +525,7 @@ def load_file_as_signatures(filename, select_moltype=None, ksize=None,
     else:
         return loader
 
-def load_file_list_of_signatures(filename):
+def load_pathlist_from_file(filename):
     "Load a list-of-files text file."
     try:
         with open(filename, 'rt') as fp:


### PR DESCRIPTION
I'm currently trying to return the "LCA_Database()" when the self.filename is None, will be updating this issue as I go.
