### PR TITLE
[MRG] deal with `status == None` on `SystemExit` in test framework

### DIFF
--- a/tests/sourmash_tst_utils.py
+++ b/tests/sourmash_tst_utils.py
@@ -109,6 +109,8 @@ def runscript(scriptname, args, **kwargs):
             status = _runscript(scriptname)
         except SystemExit as err:
             status = err.code
+            if status == None:
+                status = 0
         except:  # pylint: disable=bare-except
             traceback.print_exc(file=sys.stderr)
             status = -1


### PR DESCRIPTION
I recently did ...something... to upgrade my home dev environment that caused all the command line tests to start failing.

Tracking it down further, it seems that some upgrade (of py.test? of python? not sure which) caused SystemExit to start faithfully reporting `sys.exit(None)` by raising `SystemExit` with a status code of `None` rather than `0`. Since most of the Python entry points in sourmash do not explicitly return 0, but our test cases explicitly test for `status == 0`, the tests fail.

This PR manually converts an exit status of `None` in `SystemExit` into a `0` again.

Ready for review & merge!