### PR TITLE
[MRG] add simple test for top-level SBT load and search API

### DIFF
--- a/src/sourmash/__init__.py
+++ b/src/sourmash/__init__.py
@@ -107,7 +107,7 @@ def search_sbt_index(*args, **kwargs):
     This function has been deprecated as of 3.5.1; please use
     'idx = load_file_as_index(...); idx.search(query, threshold=...)' instead.
     """
-    return load_sbt_index_private(*args, **kwargs)
+    return search_sbt_index_private(*args, **kwargs)
 
 from .sbtmh import create_sbt_index
 from . import lca

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -75,3 +75,14 @@ def test_load_fasta_as_signature():
     print(exc.value)
 
     assert f"Error while reading signatures from '{testfile}' - got sequences instead! Is this a FASTA/FASTQ file?" in str(exc.value)
+
+
+def test_load_and_search_sbt_api():
+    treefile = utils.get_test_data('prot/protein.sbt.zip')
+    queryfile = utils.get_test_data('prot/protein/GCA_001593925.1_ASM159392v1_protein.faa.gz.sig')
+
+    tree = sourmash.load_sbt_index(treefile)
+    query = sourmash.load_one_signature(queryfile)
+
+    results = list(sourmash.search_sbt_index(tree, query, 0))
+    assert len(results) == 2


### PR DESCRIPTION
Embarrassingly, it turns out that we don't currently have any tests for the top-level api functions `load_sbt_index` and `search_sbt_index`. Even more embarrassingly, `sourmash.search_sbt_index` is broken.

While they're already slated for removal in 5.0, we should probably keep them working for now 😆 .

This PR provides a simple test for these two API functions, and fixes `search_sbt_index`.