### PR TITLE
[MRG] Bump MSRV to 1.42 (and other dep fixes)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -247,8 +247,11 @@ jobs:
 
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.37.0
+          toolchain: 1.42.0
           override: true
+
+      - name: check if README matches MSRV defined here
+        run: grep '1.42.0' src/core/README.md
 
       - name: Set up Python 3.8
         uses: actions/setup-python@v1

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -28,7 +28,7 @@ bytecount = "0.6.0"
 byteorder = "1.3.4"
 cfg-if = "1.0"
 finch = { version = "0.4.1", optional = true }
-fixedbitset = "0.3.0"
+fixedbitset = "0.3.0" # 0.4.0 requires 1.39
 getset = "0.1.1"
 log = "0.4.8"
 md5 = "0.7.0"

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -23,12 +23,12 @@ parallel = ["rayon"]
 
 [dependencies]
 az = "1.0.0"
-backtrace = "=0.3.46" # later versions require rust 1.40
+backtrace = "0.3.56"
 bytecount = "0.6.0"
-byteorder = "1.3.4"
+byteorder = "1.4.3"
 cfg-if = "1.0"
 finch = { version = "0.4.1", optional = true }
-fixedbitset = "0.3.0" # 0.4.0 requires 1.39
+fixedbitset = "0.4.0"
 getset = "0.1.1"
 log = "0.4.8"
 md5 = "0.7.0"
@@ -40,9 +40,9 @@ once_cell = "1.3.1"
 rayon = { version = "1.3.0", optional = true }
 serde = { version = "1.0.110", features = ["derive"] }
 serde_json = "1.0.53"
-primal-check = "0.2.3"
+primal-check = "0.3.1"
 thiserror = "1.0"
-typed-builder = "0.7.0"
+typed-builder = "0.9.0"
 
 [target.'cfg(all(target_arch = "wasm32", target_vendor="unknown"))'.dependencies.wasm-bindgen]
 version = "0.2.62"
@@ -60,10 +60,9 @@ wasm-opt = false # https://github.com/rustwasm/wasm-pack/issues/886
 [dev-dependencies]
 assert_matches = "1.3.0"
 criterion = "0.3.2"
-# Upgrade to 0.4.1 requires rust 1.42
-needletail = { version = "=0.4.0", default-features = false }
+needletail = { version = "0.4.1", default-features = false }
 predicates = "1.0.4"
-proptest = { version = "1.0.0", default-features = false, features = ["std"]}  # Upgrade to 0.10 requires rust 1.39
+proptest = { version = "1.0.0", default-features = false, features = ["std"]}
 rand = "0.8.2"
 getrandom = { version = "0.2", features = ["js"] }
 tempfile = "3.1.0"

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -51,7 +51,7 @@ features = ["serde-serialize"]
 [target.'cfg(all(target_arch = "wasm32", target_vendor="unknown"))'.dev-dependencies]
 wasm-bindgen-test = "0.3.0"
 
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies.assert_cmd]
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies.assert_cmd]
 version = "1.0.1"
 
 [package.metadata.wasm-pack.profile.release]

--- a/src/core/README.md
+++ b/src/core/README.md
@@ -35,3 +35,7 @@ Please ask questions and files issues
 
 Development happens on github at
 [dib-lab/sourmash](https://github.com/dib-lab/sourmash).
+
+## Minimum supported Rust version
+
+Currently the minimum supported Rust version is 1.42.0.


### PR DESCRIPTION
Some dependency cleanup on the Rust side, considering that `niffler` will soon [require 1.42](https://github.com/luizirber/niffler/pull/42) and this also allows us to use all the latest versions of our dependencies.

On [Ubuntu](https://launchpad.net/ubuntu/+source/rustc) all the LTS versions have Rust 1.47 available (from security updates), and [Debian](https://tracker.debian.org/pkg/rustc) is `1.41` on stable and `1.48` in testing, so it could be an issue (but I'm not aware of anyone building sourmash from source on debian with their default Rust, so...)

<!--Please replace this text with:

* a brief description of your changes in this PR
* which issues this fixes in the issue tracker, if any ("Fixes #XXX")
* which issues this PR is related to, if any ("Ref #XXX")

Please also be sure to note here if file formats, command-line
interface, and/or the top-level sourmash API will change because of
this PR.

If you are a new contributor, please provide
[your ORCID](https://orcid.org).  If you don't have one, please
[register for one](https://orcid.org/register).

Once the items above are done, and all checks pass, request a review!
-->
