### PR TITLE
[WIP] Implement an in-memory storage for Indices in Rust

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ include/sourmash.h: src/core/src/lib.rs \
                     src/core/src/ffi/nodegraph.rs \
                     src/core/src/ffi/index/mod.rs \
                     src/core/src/ffi/index/revindex.rs \
+                    src/core/src/ffi/storage.rs \
                     src/core/src/errors.rs
 	cd src/core && \
 	RUSTC_BOOTSTRAP=1 cbindgen -c cbindgen.toml . -o ../../$@

--- a/include/sourmash.h
+++ b/include/sourmash.h
@@ -50,6 +50,8 @@ typedef struct SourmashHyperLogLog SourmashHyperLogLog;
 
 typedef struct SourmashKmerMinHash SourmashKmerMinHash;
 
+typedef struct SourmashMemStorage SourmashMemStorage;
+
 typedef struct SourmashNodegraph SourmashNodegraph;
 
 typedef struct SourmashRevIndex SourmashRevIndex;
@@ -261,6 +263,10 @@ double kmerminhash_similarity(const SourmashKmerMinHash *ptr,
 void kmerminhash_slice_free(uint64_t *ptr, uintptr_t insize);
 
 bool kmerminhash_track_abundance(const SourmashKmerMinHash *ptr);
+
+void memstorage_free(SourmashMemStorage *ptr);
+
+SourmashMemStorage *memstorage_new(void);
 
 void nodegraph_buffer_free(uint8_t *ptr, uintptr_t insize);
 

--- a/src/core/src/ffi/mod.rs
+++ b/src/core/src/ffi/mod.rs
@@ -12,6 +12,7 @@ pub mod index;
 pub mod minhash;
 pub mod nodegraph;
 pub mod signature;
+pub mod storage;
 
 use std::ffi::CStr;
 use std::os::raw::c_char;

--- a/src/core/src/ffi/storage.rs
+++ b/src/core/src/ffi/storage.rs
@@ -1,0 +1,20 @@
+use crate::ffi::utils::ForeignObject;
+use crate::storage::MemStorage;
+
+pub struct SourmashMemStorage;
+
+impl ForeignObject for SourmashMemStorage {
+    type RustObject = MemStorage;
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn memstorage_new() -> *mut SourmashMemStorage {
+    let memstorage = MemStorage::default();
+
+    SourmashMemStorage::from_rust(memstorage)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn memstorage_free(ptr: *mut SourmashMemStorage) {
+    SourmashMemStorage::drop(ptr);
+}

--- a/src/core/src/storage.rs
+++ b/src/core/src/storage.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::fs::{DirBuilder, File};
 use std::io::{BufReader, BufWriter, Read, Write};
 use std::path::PathBuf;
@@ -7,6 +8,7 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use typed_builder::TypedBuilder;
 
+use crate::errors::ReadDataError;
 use crate::Error;
 
 /// An abstraction for any place where we can store data.

--- a/src/core/src/storage.rs
+++ b/src/core/src/storage.rs
@@ -241,3 +241,28 @@ impl<'a> ZipStorage<'a> {
         })
     }
 }
+
+#[derive(Default)]
+pub struct MemStorage {
+    storage: Mutex<HashMap<String, Vec<u8>>>,
+}
+
+impl MemStorage {}
+
+impl Storage for MemStorage {
+    fn save(&self, path: &str, content: &[u8]) -> Result<String, Error> {
+        let mut lock = self.storage.lock().unwrap();
+        lock.insert(path.into(), content.into());
+        Ok(path.into())
+    }
+
+    fn load(&self, path: &str) -> Result<Vec<u8>, Error> {
+        let lock = self.storage.lock().unwrap();
+        let v = lock.get(path).ok_or(ReadDataError::LoadError)?;
+        Ok(v.clone())
+    }
+
+    fn args(&self) -> StorageArgs {
+        unimplemented!()
+    }
+}

--- a/src/sourmash/sbt_storage.py
+++ b/src/sourmash/sbt_storage.py
@@ -357,3 +357,18 @@ class RedisStorage(Storage):
 
     def __exit__(self, type, value, traceback):
         pass
+
+
+class MemStorage(Storage):
+
+    def __init__(self):
+        self._storage = {}
+
+    def save(self, path, content):
+        if not isinstance(content, bytes):
+            content = bytes(content)
+        self._storage[path] = content
+        return path
+
+    def load(self, path):
+        return self._storage.get(path, None)


### PR DESCRIPTION
I started implementing this in #1238 but ended up not using, but might be a start for other Rust-backed storages for indices.

<!-- 

Please replace this text with:

* a brief description of your changes in this PR
* which issues this fixes in the issue tracker, if any ("Fixes #XXX")
* which issues this PR is related to, if any ("Ref #XXX")

Please also be sure to note here if file formats, command-line
interface, and/or the top-level sourmash API will change because of
this PR.

If you are a new contributor, please provide
[your ORCID](https://orcid.org).  If you don't have one, please
[register for one](https://orcid.org/register).

Once the items above are done, and all checks pass, request a review!
-->