### PR TITLE
[MRG] Run tests for all PRs against any branch, not only latest

### DIFF
--- a/.github/workflows/asv.yml
+++ b/.github/workflows/asv.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [latest]
   pull_request:
-    branches: [latest]
   schedule:
     - cron: "0 0 * * *" # daily
 

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -5,7 +5,6 @@ on:
     branches: [latest]
     tags: v*
   pull_request:
-    branches: [latest]
   schedule:
     - cron: "0 0 * * *" # daily
 

--- a/.github/workflows/dev_envs.yml
+++ b/.github/workflows/dev_envs.yml
@@ -1,7 +1,6 @@
 name: "Dev env instructions"
 on:
   pull_request:
-    branches: [latest]
   push:
     branches: [latest]
 jobs:

--- a/.github/workflows/hypothesis.yml
+++ b/.github/workflows/hypothesis.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [latest]
   pull_request:
-    branches: [latest]
   schedule:
     - cron: "0 0 * * *" # daily
 

--- a/.github/workflows/khmer.yml
+++ b/.github/workflows/khmer.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [latest]
   pull_request:
-    branches: [latest]
   schedule:
     - cron: "0 0 * * *" # daily
 

--- a/.github/workflows/metadata.yml
+++ b/.github/workflows/metadata.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [latest]
   pull_request:
-    branches: [latest]
   schedule:
     - cron: "0 0 * * *" # daily
 

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [latest]
   pull_request:
-    branches: [latest]
   schedule:
     - cron: "0 0 * * *" # daily
 


### PR DESCRIPTION
Most recently manifested in #1465, which is a PR against another branch (not `latest`).

Since `[EXP]` PRs tend to do that, might as well allow it? This updates the Github Actions workflows to remove the restrictions to only run PRs against `latest`.