### PR TITLE
[MRG] Update and fix cbindgen config and CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -283,7 +283,7 @@ jobs:
       - uses: actions-rs/install@v0.1
         with:
           crate: cbindgen
-          version: 0.14.2
+          version: 0.19.0
           use-tool-cache: true
 
       - run: make include/sourmash.h

--- a/src/core/cbindgen.toml
+++ b/src/core/cbindgen.toml
@@ -1,6 +1,7 @@
 header = "/* c bindings to the sourmash library */"
 include_guard = "SOURMASH_H_INCLUDED"
 language = "C"
+style = "type"
 
 [parse]
 clean = true
@@ -13,3 +14,6 @@ rename_variants = "QualifiedScreamingSnakeCase"
 
 [export]
 exclude = ["HLL", "NoHashHasher", "HashIntersection"]
+
+[fn]
+sort_by = "Name"


### PR DESCRIPTION
This PR add some config options for `cbindgen` to account for some changes to the default C header format it generates.

Also updates `cbindgen` from `0.14` to `0.19` in CI.