### PR TITLE
[MRG] Add `MinHash.intersection(...)`

### DIFF
--- a/include/sourmash.h
+++ b/include/sourmash.h
@@ -195,7 +195,12 @@ void kmerminhash_hash_function_set(SourmashKmerMinHash *ptr, HashFunctions hash_
 
 bool kmerminhash_hp(const SourmashKmerMinHash *ptr);
 
-uint64_t kmerminhash_intersection(const SourmashKmerMinHash *ptr, const SourmashKmerMinHash *other);
+SourmashKmerMinHash *kmerminhash_intersection(const SourmashKmerMinHash *ptr,
+                                              const SourmashKmerMinHash *other);
+
+uint64_t kmerminhash_intersection_union_size(const SourmashKmerMinHash *ptr,
+                                             const SourmashKmerMinHash *other,
+                                             uint64_t *union_size);
 
 bool kmerminhash_is_compatible(const SourmashKmerMinHash *ptr, const SourmashKmerMinHash *other);
 

--- a/src/core/src/ffi/minhash.rs
+++ b/src/core/src/ffi/minhash.rs
@@ -352,9 +352,9 @@ unsafe fn kmerminhash_intersection(ptr: *mut SourmashKmerMinHash, other: *const 
     let this_mh = SourmashKmerMinHash::as_rust_mut(ptr);
     let other_mh = SourmashKmerMinHash::as_rust(other);
 
-    // let new_mh = KmerMinHash::new(this_mh.scaled(), this_mh.ksize() as u32, this_mh.hash_function(), this_mh.seed(), this_mh.track_abundance(), this_mh.num());
-
-    this_mh.intersection(other_mh)?;
+    let isect = this_mh.intersection(other_mh)?;
+    this_mh.clear();
+    this_mh.add_many(&isect.0)?;
 
     Ok(())
 }

--- a/src/core/src/ffi/minhash.rs
+++ b/src/core/src/ffi/minhash.rs
@@ -347,19 +347,6 @@ unsafe fn kmerminhash_merge(ptr: *mut SourmashKmerMinHash, other: *const Sourmas
 }
 }
 
-ffi_fn! {
-unsafe fn kmerminhash_intersection(ptr: *mut SourmashKmerMinHash, other: *const SourmashKmerMinHash) ->  Result<()> {
-    let this_mh = SourmashKmerMinHash::as_rust_mut(ptr);
-    let other_mh = SourmashKmerMinHash::as_rust(other);
-
-    let isect = this_mh.intersection(other_mh)?;
-    this_mh.clear();
-    this_mh.add_many(&isect.0)?;
-
-    Ok(())
-}
-}
-
 #[no_mangle]
 pub unsafe extern "C" fn kmerminhash_is_compatible(
     ptr: *const SourmashKmerMinHash,
@@ -389,15 +376,32 @@ unsafe fn kmerminhash_count_common(ptr: *const SourmashKmerMinHash, other: *cons
 }
 
 ffi_fn! {
-unsafe fn kmerminhash_intersection_size(ptr: *const SourmashKmerMinHash, other: *const SourmashKmerMinHash)
+unsafe fn kmerminhash_intersection(ptr: *const SourmashKmerMinHash, other: *const SourmashKmerMinHash)
+    -> Result<*mut SourmashKmerMinHash> {
+    let mh = SourmashKmerMinHash::as_rust(ptr);
+    let other_mh = SourmashKmerMinHash::as_rust(other);
+
+    let isect = mh.intersection(other_mh)?;
+    let mut new_mh = mh.clone();
+    new_mh.clear();
+    new_mh.add_many(&isect.0)?;
+
+    Ok(SourmashKmerMinHash::from_rust(new_mh))
+}
+}
+
+ffi_fn! {
+unsafe fn kmerminhash_intersection_union_size(ptr: *const SourmashKmerMinHash, other: *const SourmashKmerMinHash, union_size: *mut u64)
     -> Result<u64> {
     let mh = SourmashKmerMinHash::as_rust(ptr);
     let other_mh = SourmashKmerMinHash::as_rust(other);
 
-    if let Ok((_, size)) = mh.intersection_size(other_mh) {
-        return Ok(size);
+    if let Ok((common, union_s)) = mh.intersection_size(other_mh) {
+        *union_size = union_s;
+        return Ok(common);
     }
 
+    *union_size = 0;
     Ok(0)
 }
 }

--- a/src/core/src/ffi/minhash.rs
+++ b/src/core/src/ffi/minhash.rs
@@ -347,6 +347,19 @@ unsafe fn kmerminhash_merge(ptr: *mut SourmashKmerMinHash, other: *const Sourmas
 }
 }
 
+ffi_fn! {
+unsafe fn kmerminhash_intersection(ptr: *mut SourmashKmerMinHash, other: *const SourmashKmerMinHash) ->  Result<()> {
+    let this_mh = SourmashKmerMinHash::as_rust_mut(ptr);
+    let other_mh = SourmashKmerMinHash::as_rust(other);
+
+    // let new_mh = KmerMinHash::new(this_mh.scaled(), this_mh.ksize() as u32, this_mh.hash_function(), this_mh.seed(), this_mh.track_abundance(), this_mh.num());
+
+    this_mh.intersection(other_mh)?;
+
+    Ok(())
+}
+}
+
 #[no_mangle]
 pub unsafe extern "C" fn kmerminhash_is_compatible(
     ptr: *const SourmashKmerMinHash,
@@ -376,7 +389,7 @@ unsafe fn kmerminhash_count_common(ptr: *const SourmashKmerMinHash, other: *cons
 }
 
 ffi_fn! {
-unsafe fn kmerminhash_intersection(ptr: *const SourmashKmerMinHash, other: *const SourmashKmerMinHash)
+unsafe fn kmerminhash_intersection_size(ptr: *const SourmashKmerMinHash, other: *const SourmashKmerMinHash)
     -> Result<u64> {
     let mh = SourmashKmerMinHash::as_rust(ptr);
     let other_mh = SourmashKmerMinHash::as_rust(other);

--- a/src/core/src/sketch/minhash.rs
+++ b/src/core/src/sketch/minhash.rs
@@ -603,6 +603,7 @@ impl KmerMinHash {
     }
 
     // FIXME: intersection_size and count_common should be the same?
+    // (for scaled minhashes)
     pub fn intersection_size(&self, other: &KmerMinHash) -> Result<(u64, u64), Error> {
         self.check_compatible(other)?;
 

--- a/src/sourmash/index.py
+++ b/src/sourmash/index.py
@@ -109,15 +109,11 @@ class Index(ABC):
             # note: we run prepare_query here on the original query minhash.
             query_mh = prepare_query(query.minhash, subj_mh)
 
-            # generic definition of union and intersection that respects
-            # both num and scaled:
             assert not query_mh.track_abundance
             assert not subj_mh.track_abundance
-            merged = query_mh + subj_mh
-            intersect = merged.intersection(query_mh).intersection(subj_mh)
 
-            shared_size = len(intersect)
-            total_size = len(merged)
+            shared_size, total_size = query_mh.intersection_and_union_size(subj_mh)
+
             query_size = len(query_mh)
             subj_size = len(subj_mh)
 

--- a/src/sourmash/index.py
+++ b/src/sourmash/index.py
@@ -114,8 +114,7 @@ class Index(ABC):
             assert not query_mh.track_abundance
             assert not subj_mh.track_abundance
             merged = query_mh + subj_mh
-            intersect = set(query_mh.hashes) & set(subj_mh.hashes)
-            intersect &= set(merged.hashes)
+            intersect = query_mh.intersection(subj_mh).intersection(merged)
 
             shared_size = len(intersect)
             total_size = len(merged)

--- a/src/sourmash/index.py
+++ b/src/sourmash/index.py
@@ -114,7 +114,7 @@ class Index(ABC):
             assert not query_mh.track_abundance
             assert not subj_mh.track_abundance
             merged = query_mh + subj_mh
-            intersect = query_mh.intersection(subj_mh).intersection(merged)
+            intersect = merged.intersection(query_mh).intersection(subj_mh)
 
             shared_size = len(intersect)
             total_size = len(merged)

--- a/src/sourmash/minhash.py
+++ b/src/sourmash/minhash.py
@@ -606,7 +606,8 @@ class MinHash(RustObject):
             self.num, self.ksize, self.is_protein, self.dayhoff, self.hp,
             False, self.seed, self._max_hash
         )
-        a.add_many(isect)
+        a.merge(self)
+        a._methodcall(lib.kmerminhash_intersection, other._get_objptr())
         return a
 
     def set_abundances(self, values, clear=True):

--- a/src/sourmash/minhash.py
+++ b/src/sourmash/minhash.py
@@ -589,6 +589,26 @@ class MinHash(RustObject):
             raise TypeError("can only add MinHash objects to MinHash objects!")
         self._methodcall(lib.kmerminhash_merge, other._get_objptr())
 
+    def intersection(self, other):
+        if not isinstance(other, MinHash):
+            raise TypeError("can only intersect MinHash objects")
+        if self.track_abundance or other.track_abundance:
+            raise TypeError("can only intersect flat MinHash objects")
+        if not self._methodcall(lib.kmerminhash_is_compatible, other._get_objptr()):
+            raise TypeError("cannot intersect incompatible MinHash objects")
+
+        self_h = set(self.hashes)
+        other_h = set(other.hashes)
+
+        isect = self_h & other_h
+
+        a = MinHash(
+            self.num, self.ksize, self.is_protein, self.dayhoff, self.hp,
+            False, self.seed, self._max_hash
+        )
+        a.add_many(isect)
+        return a
+
     def set_abundances(self, values, clear=True):
         """Set abundances for hashes from ``values``, where
         ``values[hash] = abund``

--- a/src/sourmash/minhash.py
+++ b/src/sourmash/minhash.py
@@ -594,13 +594,6 @@ class MinHash(RustObject):
             raise TypeError("can only intersect MinHash objects")
         if self.track_abundance or other.track_abundance:
             raise TypeError("can only intersect flat MinHash objects")
-        if not self._methodcall(lib.kmerminhash_is_compatible, other._get_objptr()):
-            raise TypeError("cannot intersect incompatible MinHash objects")
-
-        self_h = set(self.hashes)
-        other_h = set(other.hashes)
-
-        isect = self_h & other_h
 
         a = MinHash(
             self.num, self.ksize, self.is_protein, self.dayhoff, self.hp,

--- a/src/sourmash/minhash.py
+++ b/src/sourmash/minhash.py
@@ -451,7 +451,7 @@ class MinHash(RustObject):
         return self._methodcall(lib.kmerminhash_count_common, other._get_objptr(), downsample)
 
     def intersection_and_union_size(self, other):
-        print(self, other)
+        "Calculate intersection and union sizes between `self` and `other`."
         mh_union = self + other
         mh_intersection = mh_union.intersection(self).intersection(other)
 

--- a/src/sourmash/minhash.py
+++ b/src/sourmash/minhash.py
@@ -507,15 +507,17 @@ class MinHash(RustObject):
         return a
 
     def flatten(self):
-        """Return a new MinHash with track_abundance=False."""
-        # create new object:
-        a = MinHash(
-            self.num, self.ksize, self.is_protein, self.dayhoff, self.hp,
-            False, self.seed, self._max_hash
-        )
-        a.add_many(self)
+        """If track_abundance=True, return a new flattened MinHash."""
+        if self.track_abundance:
+            # create new object:
+            a = MinHash(
+                self.num, self.ksize, self.is_protein, self.dayhoff, self.hp,
+                False, self.seed, self._max_hash
+            )
+            a.add_many(self)
 
-        return a
+            return a
+        return self
 
     def jaccard(self, other, downsample=False):
         "Calculate Jaccard similarity of two MinHash objects."

--- a/src/sourmash/minhash.py
+++ b/src/sourmash/minhash.py
@@ -450,6 +450,13 @@ class MinHash(RustObject):
             raise TypeError("Must be a MinHash!")
         return self._methodcall(lib.kmerminhash_count_common, other._get_objptr(), downsample)
 
+    def intersection_and_union_size(self, other):
+        print(self, other)
+        mh_union = self + other
+        mh_intersection = mh_union.intersection(self).intersection(other)
+
+        return len(mh_intersection), len(mh_union)
+
     def downsample(self, *, num=None, scaled=None):
         """Copy this object and downsample new object to either `num` or
         `scaled`.

--- a/src/sourmash/sbt.py
+++ b/src/sourmash/sbt.py
@@ -418,8 +418,7 @@ class SBT(Index):
 
                 assert not subj_mh.track_abundance
                 merged = subj_mh + query_mh
-                intersect = set(query_mh.hashes) & set(subj_mh.hashes)
-                intersect &= set(merged.hashes)
+                intersect = merged.intersection(query_mh).intersection(subj_mh)
 
                 shared_size = len(intersect)
                 total_size = len(merged)

--- a/src/sourmash/sbt.py
+++ b/src/sourmash/sbt.py
@@ -411,18 +411,15 @@ class SBT(Index):
 
             # leaf node? downsample so we can do signature comparison.
             if isinstance(node, SigLeaf):
+                is_leaf = True
+
                 subj_mh = downsample_node(node.data.minhash)
                 subj_size = len(subj_mh)
-
                 subj_mh = subj_mh.flatten()
 
                 assert not subj_mh.track_abundance
-                merged = subj_mh + query_mh
-                intersect = merged.intersection(query_mh).intersection(subj_mh)
 
-                shared_size = len(intersect)
-                total_size = len(merged)
-                is_leaf = True
+                shared_size, total_size = query_mh.intersection_and_union_size(subj_mh)
             else:  # Node / Nodegraph by minhash comparison
                 # no downsampling needed --
                 shared_size = node.data.matches(query_mh)

--- a/tests/test__minhash.py
+++ b/tests/test__minhash.py
@@ -1694,6 +1694,38 @@ def test_intersection_2_scaled():
     assert 0 in mh3.hashes
 
 
+def test_intersection_3_abundance_error():
+    # cannot intersect abundance MinHash
+    mh1 = MinHash(0, 21, scaled=1, track_abundance=True)
+    mh2 = MinHash(0, 21, scaled=1, track_abundance=True)
+
+    with pytest.raises(TypeError) as exc:
+        mh3 = mh1.intersection(mh2)
+
+    assert str(exc.value) == "can only intersect flat MinHash objects"
+
+
+def test_intersection_4_incompatible_ksize():
+    # cannot intersect incompatible ksize etc
+    mh1 = MinHash(500, 21)
+    mh2 = MinHash(500, 31)
+
+    with pytest.raises(ValueError) as exc:
+        mh3 = mh1.intersection(mh2)
+
+    assert str(exc.value) == "different ksizes cannot be compared"
+
+
+def test_intersection_5_incompatible():
+    # cannot intersect with non-MinHash objects
+    mh1 = MinHash(0, 21, scaled=1)
+
+    with pytest.raises(TypeError) as exc:
+        mh3 = mh1.intersection(set())
+
+    assert str(exc.value) == "can only intersect MinHash objects"
+
+
 def test_merge_abund():
     mh1 = MinHash(10, 21, track_abundance=True)
     mh2 = MinHash(10, 21, track_abundance=True)

--- a/tests/test__minhash.py
+++ b/tests/test__minhash.py
@@ -1664,6 +1664,36 @@ def test_iaddition_noabund():
     assert hashcounts[0] == 1
 
 
+def test_intersection_1_num():
+    mh1 = MinHash(10, 21)
+    mh2 = MinHash(10, 21)
+
+    mh1.add_hash(0)
+    mh1.add_hash(1)
+    mh2.add_hash(0)
+    mh2.add_hash(2)
+
+    mh3 = mh1.intersection(mh2)
+    print(set(mh3.hashes))
+    assert len(mh3) == 1
+    assert 0 in mh3.hashes
+
+
+def test_intersection_2_scaled():
+    mh1 = MinHash(0, 21, scaled=1)
+    mh2 = MinHash(0, 21, scaled=1)
+
+    mh1.add_hash(0)
+    mh1.add_hash(1)
+    mh2.add_hash(0)
+    mh2.add_hash(2)
+
+    mh3 = mh1.intersection(mh2)
+    print(set(mh3.hashes))
+    assert len(mh3) == 1
+    assert 0 in mh3.hashes
+
+
 def test_merge_abund():
     mh1 = MinHash(10, 21, track_abundance=True)
     mh2 = MinHash(10, 21, track_abundance=True)

--- a/tests/test__minhash.py
+++ b/tests/test__minhash.py
@@ -1726,6 +1726,58 @@ def test_intersection_5_incompatible():
     assert str(exc.value) == "can only intersect MinHash objects"
 
 
+def test_intersection_6_full_num():
+    # intersection of two "full" num objects is correct
+    mh1 = MinHash(20, 21)
+    mh2 = MinHash(20, 21)
+
+    for i in range(100):
+        mh1.add_hash(i)
+
+    for i in range(0, 100, 2):
+        mh2.add_hash(i)
+
+    # they are both full:
+    assert len(mh1) == 20
+    assert len(mh2) == 20
+
+    # intersection is symmetric:
+    mh3 = mh1.intersection(mh2)
+    mh4 = mh2.intersection(mh1)
+    assert mh3 == mh4
+
+    # everything in intersection is in both:
+    for k in mh3.hashes:
+        assert k in mh1.hashes
+        assert k in mh2.hashes
+
+
+def test_intersection_7_full_scaled():
+    # intersection of two scaled objects is correct
+    mh1 = MinHash(0, 21, scaled=100)
+    mh2 = MinHash(0, 21, scaled=100)
+
+    for i in range(100):
+        mh1.add_hash(i)
+
+    for i in range(0, 200, 2):
+        mh2.add_hash(i)
+
+    # they both have everything:
+    assert len(mh1) == 100
+    assert len(mh2) == 100
+
+    # intersection is symmetric:
+    mh3 = mh1.intersection(mh2)
+    mh4 = mh2.intersection(mh1)
+    assert mh3 == mh4
+
+    # everything in intersection is in both:
+    for k in mh3.hashes:
+        assert k in mh1.hashes
+        assert k in mh2.hashes
+
+
 def test_merge_abund():
     mh1 = MinHash(10, 21, track_abundance=True)
     mh2 = MinHash(10, 21, track_abundance=True)
@@ -1758,6 +1810,63 @@ def test_merge_noabund():
     hashcounts = mh1.hashes
     assert len(hashcounts) == 1
     assert hashcounts[0] == 1
+
+
+def test_merge_full_num():
+    # merge/union of two "full" num objects is correct
+    mh1 = MinHash(20, 21)
+    mh2 = MinHash(20, 21)
+
+    for i in range(100):
+        mh1.add_hash(i)
+
+    for i in range(0, 100, 2):
+        mh2.add_hash(i)
+
+    # they are both full:
+    assert len(mh1) == 20
+    assert len(mh2) == 20
+
+    # add is symmetric:
+    mh3 = mh1 + mh2
+    mh4 = mh2 + mh1
+    assert mh3 == mh4
+
+    # merge is full
+    assert len(mh3) == 20
+
+    # everything in union is in at least one
+    for k in mh3.hashes:
+        assert k in mh1.hashes or k in mh2.hashes
+
+
+def test_merge_scaled():
+    # merge/union of two reasonably full scaled objects is correct
+    mh1 = MinHash(0, 21, scaled=100)
+    mh2 = MinHash(0, 21, scaled=100)
+
+    for i in range(100):
+        mh1.add_hash(i)
+
+    for i in range(0, 200, 2):
+        mh2.add_hash(i)
+
+    assert len(mh1) == 100
+    assert len(mh2) == 100
+
+    # add is symmetric:
+    mh3 = mh1 + mh2
+    mh4 = mh2 + mh1
+    assert mh3 == mh4
+
+    # merge contains all the things
+    assert len(mh3) == 150
+
+    # everything in either one is in union
+    for k in mh1.hashes:
+        assert k in mh3.hashes
+    for k in mh2.hashes:
+        assert k in mh3.hashes
 
 
 def test_max_containment():

--- a/tests/test__minhash.py
+++ b/tests/test__minhash.py
@@ -1751,6 +1751,7 @@ def test_intersection_6_full_num():
         assert k in mh1.hashes
         assert k in mh2.hashes
 
+    assert mh1.intersection_and_union_size(mh2) == (10, 20)
 
 def test_intersection_7_full_scaled():
     # intersection of two scaled objects is correct
@@ -1776,6 +1777,8 @@ def test_intersection_7_full_scaled():
     for k in mh3.hashes:
         assert k in mh1.hashes
         assert k in mh2.hashes
+
+    assert mh1.intersection_and_union_size(mh2) == (50, 150)
 
 
 def test_merge_abund():


### PR DESCRIPTION
Note: merge into #1392.

Bring `MinHash.intersection(...)` in from Rust implementation.

**Question:** Do we need to bump the rust/sourmash version?