### PR TITLE
[MRG] Improving intersection and union calculations

### DIFF
--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -78,3 +78,7 @@ harness = false
 [[bench]]
 name = "nodegraph"
 harness = false
+
+[[bench]]
+name = "minhash"
+harness = false

--- a/src/core/benches/minhash.rs
+++ b/src/core/benches/minhash.rs
@@ -1,0 +1,54 @@
+#[macro_use]
+extern crate criterion;
+
+use std::fs::File;
+use std::io::{BufReader, Cursor, Read};
+use std::path::PathBuf;
+
+use sourmash::signature::Signature;
+use sourmash::sketch::minhash::KmerMinHash;
+use sourmash::sketch::Sketch;
+
+use criterion::Criterion;
+
+fn intersection(c: &mut Criterion) {
+    let mut filename = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    filename.push("../../tests/test-data/gather-abund/genome-s10.fa.gz.sig");
+    let file = File::open(filename).unwrap();
+    let reader = BufReader::new(file);
+    let mut sigs: Vec<Signature> = serde_json::from_reader(reader).expect("Loading error");
+    let mh = if let Sketch::MinHash(mh) = &sigs.swap_remove(0).sketches()[0] {
+        mh.clone()
+    } else {
+        unimplemented!()
+    };
+
+    let mut filename = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    filename.push("../../tests/test-data/gather-abund/genome-s11.fa.gz.sig");
+    let file = File::open(filename).unwrap();
+    let reader = BufReader::new(file);
+    let mut sigs: Vec<Signature> = serde_json::from_reader(reader).expect("Loading error");
+    let mh2 = if let Sketch::MinHash(mh) = &sigs.swap_remove(0).sketches()[0] {
+        mh.clone()
+    } else {
+        unimplemented!()
+    };
+
+    let mut group = c.benchmark_group("minhash");
+    group.sample_size(10);
+
+    group.bench_function("intersection", |b| {
+        b.iter(|| {
+            mh.intersection(&mh2).unwrap();
+        });
+    });
+
+    group.bench_function("intersection_size", |b| {
+        b.iter(|| {
+            mh.intersection_size(&mh2).unwrap();
+        });
+    });
+}
+
+criterion_group!(minhash, intersection);
+criterion_main!(minhash);

--- a/src/core/benches/minhash.rs
+++ b/src/core/benches/minhash.rs
@@ -2,11 +2,11 @@
 extern crate criterion;
 
 use std::fs::File;
-use std::io::{BufReader, Cursor, Read};
+use std::io::BufReader;
 use std::path::PathBuf;
 
-use sourmash::signature::Signature;
-use sourmash::sketch::minhash::KmerMinHash;
+use sourmash::signature::{Signature, SigsTrait};
+use sourmash::sketch::minhash::{KmerMinHash, KmerMinHashBTree};
 use sourmash::sketch::Sketch;
 
 use criterion::Criterion;
@@ -46,6 +46,63 @@ fn intersection(c: &mut Criterion) {
     group.bench_function("intersection_size", |b| {
         b.iter(|| {
             mh.intersection_size(&mh2).unwrap();
+        });
+    });
+
+    let mut mh1 = KmerMinHash::builder()
+        .num(0)
+        .max_hash(1_000_000)
+        .ksize(21)
+        .build();
+    let mut mh2 = KmerMinHash::builder()
+        .num(0)
+        .max_hash(1_000_000)
+        .ksize(21)
+        .build();
+
+    let mut mh1_btree = KmerMinHashBTree::builder()
+        .num(0)
+        .max_hash(1_000_000)
+        .ksize(21)
+        .build();
+    let mut mh2_btree = KmerMinHashBTree::builder()
+        .num(0)
+        .max_hash(1_000_000)
+        .ksize(21)
+        .build();
+
+    for i in 0..=1_000_000 {
+        if i % 2 == 0 {
+            mh1.add_hash(i);
+            mh1_btree.add_hash(i);
+        }
+        if i % 45 == 0 {
+            mh2.add_hash(i);
+            mh2_btree.add_hash(i);
+        }
+    }
+
+    group.bench_function("large intersection", |b| {
+        b.iter(|| {
+            mh1.intersection(&mh2).unwrap();
+        });
+    });
+
+    group.bench_function("large intersection_size", |b| {
+        b.iter(|| {
+            mh1.intersection_size(&mh2).unwrap();
+        });
+    });
+
+    group.bench_function("large intersection btree", |b| {
+        b.iter(|| {
+            mh1_btree.intersection(&mh2_btree).unwrap();
+        });
+    });
+
+    group.bench_function("large intersection_size btree", |b| {
+        b.iter(|| {
+            mh1_btree.intersection_size(&mh2_btree).unwrap();
         });
     });
 }

--- a/src/core/src/sketch/minhash.rs
+++ b/src/core/src/sketch/minhash.rs
@@ -579,27 +579,72 @@ impl KmerMinHash {
     pub fn intersection(&self, other: &KmerMinHash) -> Result<(Vec<u64>, u64), Error> {
         self.check_compatible(other)?;
 
-        let mut combined_mh = KmerMinHash::new(
-            self.scaled(),
-            self.ksize,
-            self.hash_function,
-            self.seed,
-            self.abunds.is_some(),
-            self.num,
-        );
+        if self.num != 0 {
+            // Intersection for regular MinHash sketches
+            let mut combined_mh = KmerMinHash::new(
+                self.scaled(),
+                self.ksize,
+                self.hash_function,
+                self.seed,
+                self.abunds.is_some(),
+                self.num,
+            );
 
-        combined_mh.merge(&self)?;
-        combined_mh.merge(&other)?;
+            combined_mh.merge(&self)?;
+            combined_mh.merge(&other)?;
 
-        let it1 = Intersection::new(self.mins.iter(), other.mins.iter());
+            let it1 = Intersection::new(self.mins.iter(), other.mins.iter());
 
-        // TODO: there is probably a way to avoid this Vec here,
-        // and pass the it1 as left in it2.
-        let i1: Vec<u64> = it1.cloned().collect();
-        let it2 = Intersection::new(i1.iter(), combined_mh.mins.iter());
+            // TODO: there is probably a way to avoid this Vec here,
+            // and pass the it1 as left in it2.
+            let i1: Vec<u64> = it1.cloned().collect();
+            let it2 = Intersection::new(i1.iter(), combined_mh.mins.iter());
 
-        let common: Vec<u64> = it2.cloned().collect();
-        Ok((common, combined_mh.mins.len() as u64))
+            let common: Vec<u64> = it2.cloned().collect();
+            Ok((common, combined_mh.mins.len() as u64))
+        } else {
+            // Intersection for scaled MinHash sketches
+
+            let mut me = self.mins.iter().peekable();
+            let mut other = other.mins.iter().peekable();
+            let mut common: Vec<u64> = vec![];
+            let mut union_size = 0;
+
+            loop {
+                match (me.peek(), other.peek()) {
+                    (Some(ref left_key), Some(ref right_key)) => {
+                        let res = left_key.cmp(right_key);
+                        match res {
+                            Ordering::Less => {
+                                me.next();
+                                union_size += 1;
+                            }
+                            Ordering::Greater => {
+                                other.next();
+                                union_size += 1;
+                            }
+                            Ordering::Equal => {
+                                other.next();
+                                common.push(***left_key);
+                                me.next();
+                                union_size += 1;
+                            }
+                        };
+                    }
+                    (None, Some(_)) => {
+                        other.next();
+                        union_size += 1;
+                    }
+                    (Some(_), None) => {
+                        me.next();
+                        union_size += 1;
+                    }
+                    _ => break,
+                };
+            }
+
+            Ok((common, union_size as u64))
+        }
     }
 
     // FIXME: intersection_size and count_common should be the same?
@@ -607,26 +652,69 @@ impl KmerMinHash {
     pub fn intersection_size(&self, other: &KmerMinHash) -> Result<(u64, u64), Error> {
         self.check_compatible(other)?;
 
-        let mut combined_mh = KmerMinHash::new(
-            self.scaled(),
-            self.ksize,
-            self.hash_function,
-            self.seed,
-            self.abunds.is_some(),
-            self.num,
-        );
+        if self.num != 0 {
+            // Intersection for regular MinHash sketches
+            let mut combined_mh = KmerMinHash::new(
+                self.scaled(),
+                self.ksize,
+                self.hash_function,
+                self.seed,
+                self.abunds.is_some(),
+                self.num,
+            );
 
-        combined_mh.merge(&self)?;
-        combined_mh.merge(&other)?;
+            combined_mh.merge(&self)?;
+            combined_mh.merge(&other)?;
 
-        let it1 = Intersection::new(self.mins.iter(), other.mins.iter());
+            let it1 = Intersection::new(self.mins.iter(), other.mins.iter());
 
-        // TODO: there is probably a way to avoid this Vec here,
-        // and pass the it1 as left in it2.
-        let i1: Vec<u64> = it1.cloned().collect();
-        let it2 = Intersection::new(i1.iter(), combined_mh.mins.iter());
+            // TODO: there is probably a way to avoid this Vec here,
+            // and pass the it1 as left in it2.
+            let i1: Vec<u64> = it1.cloned().collect();
+            let it2 = Intersection::new(i1.iter(), combined_mh.mins.iter());
 
-        Ok((it2.count() as u64, combined_mh.mins.len() as u64))
+            Ok((it2.count() as u64, combined_mh.mins.len() as u64))
+        } else {
+            // Intersection for scaled MinHash sketches
+            let mut me = self.mins.iter().peekable();
+            let mut other = other.mins.iter().peekable();
+            let mut common = 0;
+            let mut union_size = 0;
+
+            loop {
+                match (me.peek(), other.peek()) {
+                    (Some(ref left_key), Some(ref right_key)) => {
+                        let res = left_key.cmp(right_key);
+                        match res {
+                            Ordering::Less => {
+                                me.next();
+                                union_size += 1;
+                            }
+                            Ordering::Greater => {
+                                other.next();
+                                union_size += 1;
+                            }
+                            Ordering::Equal => {
+                                other.next();
+                                me.next();
+                                common += 1;
+                                union_size += 1;
+                            }
+                        };
+                    }
+                    (None, Some(_)) => {
+                        other.next();
+                        union_size += 1;
+                    }
+                    (Some(_), None) => {
+                        me.next();
+                        union_size += 1;
+                    }
+                    _ => break,
+                };
+            }
+            Ok((common as u64, union_size as u64))
+        }
     }
 
     // calculate Jaccard similarity, ignoring abundance.
@@ -866,6 +954,56 @@ impl<T: Ord, I: Iterator<Item = T>> Iterator for Intersection<T, I> {
                 }
             }
         }
+    }
+}
+
+struct Union<T, I: Iterator<Item = T>> {
+    iter: Peekable<I>,
+    other: Peekable<I>,
+}
+
+impl<T: Ord, I: Iterator<Item = T>> Iterator for Union<T, I> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<T> {
+        let res = match (self.iter.peek(), self.other.peek()) {
+            (Some(ref left_key), Some(ref right_key)) => left_key.cmp(right_key),
+            (None, Some(_)) => {
+                return self.other.next();
+            }
+            (Some(_), None) => {
+                return self.iter.next();
+            }
+            _ => return None,
+        };
+
+        match res {
+            Ordering::Less => self.iter.next(),
+            Ordering::Greater => self.other.next(),
+            Ordering::Equal => {
+                self.other.next();
+                self.iter.next()
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::Union;
+
+    #[test]
+    fn test_union() {
+        let v1 = [1u64, 2, 4, 10];
+        let v2 = [1u64, 3, 4, 9];
+
+        let union: Vec<u64> = Union {
+            iter: v1.iter().peekable(),
+            other: v2.iter().peekable(),
+        }
+        .cloned()
+        .collect();
+        assert_eq!(union, [1, 2, 3, 4, 9, 10]);
     }
 }
 


### PR DESCRIPTION
Playing a bit with the `intersection()` and `intersection_size()` methods in Rust. I started looking into this because of #1474 #1392 and the nagging suspicion that the calls to `.merge` were making the performance worse. I isolated the `.merge()` call for num MH sketches, and started working on scaled MH sketches first (because they are easier to reason about).

In order to measure it, I created two new benchmarks (run with `cargo bench -- minhash`).

This is the baseline (`latest`):
```
minhash/intersection    
                        time:   [4.4254 us 4.4562 us 4.4819 us]
minhash/intersection_size
                        time:   [4.4531 us 4.4733 us 4.5121 us]
```

For the first try, I created an `Union` iterator, similar to the current `Intersection` iterator:
```
minhash/intersection
                        time:   [4.0357 us 4.0462 us 4.0572 us]
                        change: [-10.946% -9.8118% -8.6927%] (p = 0.00 < 0.05)
minhash/intersection_size
                        time:   [3.5351 us 3.5544 us 3.5758 us]
                        change: [-21.742% -21.152% -20.534%] (p = 0.00 < 0.05)
```
This is already pretty good, but it ends up iterating twice over the data.

The second try is an unrolled version (combining the `Intersection` and `Union` iterators, and keeping only data we need):
```
minhash/intersection
                        time:   [1.7962 us 1.8025 us 1.8056 us]
                        change: [-60.819% -60.157% -59.532%] (p = 0.00 < 0.05)
minhash/intersection_size
                        time:   [2.3091 us 2.3147 us 2.3190 us]
                        change: [-48.940% -48.615% -48.267%] (p = 0.00 < 0.05)
```
Twice as fast, nice.

So, I tried to run `gather` from https://github.com/luizirber/sourmash_resources, and...
![image](https://user-images.githubusercontent.com/6642/115493278-f9fc1f80-a252-11eb-9bd2-45356b5e88ef.png)
It's pretty similar to the `latest` results :joy: 

So, the problem is in other places, but might as well merge this eventually because it is faster in microbenchmarks? =P


