### PR TITLE
[MRG] Add `run` and `runtmp` pytest fixtures.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,13 +1,23 @@
 import os
 
-import matplotlib.pyplot as plt
-plt.rcParams.update({'figure.max_open_warning': 0})
-
 from hypothesis import settings, Verbosity
 import pytest
 
 import matplotlib.pyplot as plt
 plt.rcParams.update({'figure.max_open_warning': 0})
+
+from sourmash_tst_utils import TempDirectory, RunnerContext
+
+
+@pytest.fixture
+def runtmp():
+    with TempDirectory() as location:
+        yield RunnerContext(location)
+
+
+@pytest.fixture
+def run():
+    yield RunnerContext(os.getcwd())
 
 
 @pytest.fixture(params=[True, False])

--- a/tests/sourmash_tst_utils.py
+++ b/tests/sourmash_tst_utils.py
@@ -1,5 +1,4 @@
 "Various utilities used by sourmash tests."
-
 import sys
 import os
 import tempfile
@@ -12,10 +11,9 @@ import pkg_resources
 from pkg_resources import Requirement, resource_filename, ResolutionError
 import traceback
 from io import open  # pylint: disable=redefined-builtin
-try:
-    from StringIO import StringIO
-except ImportError:
-    from io import StringIO
+from io import StringIO
+
+import decorator
 
 
 SIG_FILES = [os.path.join('demo', f) for f in (
@@ -193,6 +191,7 @@ class RunnerContext(object):
             raise ValueError(self)
 
         return self.last_result
+    sourmash = run_sourmash
 
     def run(self, scriptname, *args, **kwargs):
         "Run a script with the given arguments."
@@ -225,13 +224,13 @@ class RunnerContext(object):
 
 
 def in_tempdir(fn):
-    def wrapper(*args, **kwargs):
+    def wrapper(func, *args, **kwargs):
         with TempDirectory() as location:
             ctxt = RunnerContext(location)
             newargs = [ctxt] + list(args)
-            return fn(*newargs, **kwargs)
+            return func(*newargs, **kwargs)
 
-    return wrapper
+    return decorator.decorator(wrapper, fn)
 
 
 def in_thisdir(fn):

--- a/tests/sourmash_tst_utils.py
+++ b/tests/sourmash_tst_utils.py
@@ -13,8 +13,6 @@ import traceback
 from io import open  # pylint: disable=redefined-builtin
 from io import StringIO
 
-import decorator
-
 
 SIG_FILES = [os.path.join('demo', f) for f in (
   "SRR2060939_1.sig", "SRR2060939_2.sig", "SRR2241509_1.sig",
@@ -224,13 +222,13 @@ class RunnerContext(object):
 
 
 def in_tempdir(fn):
-    def wrapper(func, *args, **kwargs):
+    def wrapper(*args, **kwargs):
         with TempDirectory() as location:
             ctxt = RunnerContext(location)
             newargs = [ctxt] + list(args)
-            return func(*newargs, **kwargs)
+            return fn(*newargs, **kwargs)
 
-    return decorator.decorator(wrapper, fn)
+    return wrapper
 
 
 def in_thisdir(fn):

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -859,7 +859,7 @@ def test_gather_query_db_md5_ambiguous(c):
     assert "Error! Multiple signatures start with md5 '1'" in err
 
 
-def test_gather_lca_db(runtmp, track_abundance):
+def test_gather_lca_db(runtmp):
     # can we do a 'sourmash gather' on an LCA database?
     query = utils.get_test_data('47+63.fa.sig')
     lca_db = utils.get_test_data('lca/47+63.lca.json')

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -859,15 +859,14 @@ def test_gather_query_db_md5_ambiguous(c):
     assert "Error! Multiple signatures start with md5 '1'" in err
 
 
-@utils.in_tempdir
-def test_gather_lca_db(c):
+def test_gather_lca_db(runtmp, track_abundance):
     # can we do a 'sourmash gather' on an LCA database?
     query = utils.get_test_data('47+63.fa.sig')
     lca_db = utils.get_test_data('lca/47+63.lca.json')
 
-    c.run_sourmash('gather', query, lca_db)
-    print(c)
-    assert 'NC_009665.1 Shewanella baltica OS185' in str(c.last_result.out)
+    runtmp.sourmash('gather', query, lca_db)
+    print(runtmp)
+    assert 'NC_009665.1 Shewanella baltica OS185' in str(runtmp.last_result.out)
 
 
 @utils.in_tempdir
@@ -1443,19 +1442,18 @@ def test_search_containment_s10():
         assert '16.7%' in out
 
 
-@utils.in_thisdir
-def test_search_containment_s10_no_max(c):
+def test_search_containment_s10_no_max(run):
     # check --containment for s10/s10-small
     q1 = utils.get_test_data('scaled/genome-s10.fa.gz.sig')
     q2 = utils.get_test_data('scaled/genome-s10-small.fa.gz.sig')
 
     with pytest.raises(ValueError) as exc:
-        c.run_sourmash('search', q1, q2, '--containment',
+        run.run_sourmash('search', q1, q2, '--containment',
                        '--max-containment')
 
-    print(c.last_result.out)
-    print(c.last_result.err)
-    assert "ERROR: cannot specify both --containment and --max-containment!" in c.last_result.err
+    print(run.last_result.out)
+    print(run.last_result.err)
+    assert "ERROR: cannot specify both --containment and --max-containment!" in run.last_result.err
 
 
 def test_search_max_containment_s10_pairwise():


### PR DESCRIPTION
This PR adds `run` and `runtmp` fixtures, as a safer alternative to `@utils.in_thisdir` and `@utils.in_tempdir` decorators.

Briefly, decorators and test fixtures do not happily co-exist, and I am in need of running functions with decorators in a temp directory.

Both provide a `RunnerContext` object as do the current decorators, so to use them you can do e.g.

```
def test_me(runtmp):
    runtmp.sourmash(...)

    assert runtmp.last_result.status == 0
    assert expected_output in runtmp.last_result.out
```
