### PR TITLE
[MRG] Fix small papercuts: SyntaxWarning and coverage reports

### DIFF
--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -4116,12 +4116,11 @@ def test_gather_abund_10_1_ignore_abundance(c):
         some_results = False
         for row in r:
             some_results = True
-            assert row['average_abund'] is ''
-            assert row['median_abund'] is ''
-            assert row['std_abund'] is ''
+            assert row['average_abund'] == ''
+            assert row['median_abund'] == ''
+            assert row['std_abund'] == ''
 
         assert some_results
-            
 
 
 @utils.in_tempdir

--- a/tox.ini
+++ b/tox.ini
@@ -46,6 +46,7 @@ commands = pytest \
            --cov "{envsitepackagesdir}/sourmash" \
            --cov . \
            --cov-config "{toxinidir}/tox.ini" \
+           --cov-report= \
            --junitxml {toxworkdir}/junit.{envname}.xml \
            {posargs:.}
 
@@ -59,6 +60,7 @@ commands = pytest \
            --cov "{envsitepackagesdir}/sourmash" \
            --cov . \
            --cov-config "{toxinidir}/tox.ini" \
+           --cov-report= \
            --junitxml {toxworkdir}/junit.{envname}.xml \
            --run-hypothesis \
            --hypothesis-show-statistics \
@@ -72,6 +74,7 @@ commands = pytest \
            --cov "{envsitepackagesdir}/sourmash" \
            --cov . \
            --cov-config "{toxinidir}/tox.ini" \
+           --cov-report= \
            --junitxml {toxworkdir}/junit.{envname}.xml \
            -k test_nodegraph \
            {posargs:.}
@@ -83,6 +86,7 @@ commands = pytest \
            --cov "{envsitepackagesdir}/sourmash" \
            --cov . \
            --cov-config "{toxinidir}/tox.ini" \
+           --cov-report= \
            --junitxml {toxworkdir}/junit.{envname}.xml \
            -k test_nodegraph \
            {posargs:.}


### PR DESCRIPTION
Fix two things that are bothering me when running tests:

- [`SyntaxWarning` for usage of `is` instead of `==` when checking for equality](https://github.com/dib-lab/sourmash/runs/2461065355?check_suite_focus=true#step:12:56)
  ```
  /sourmash/tests/test_sourmash.py:4120: SyntaxWarning: "is" with a literal. Did you mean "=="?
      assert row['median_abund'] is ''
  ```
- [Coverage reporting on the terminal](https://github.com/dib-lab/sourmash/runs/2461065355?check_suite_focus=true#step:12:392). It is a lot of information that is not always useful. The same info is available with `tox -e coverage` if needed (or in codecov when the PR is updated)
