### PR TITLE
[FYI] Comments on added tests for the function `load_pathlist_from_file`

### DIFF
--- a/src/sourmash/sourmash_args.py
+++ b/src/sourmash/sourmash_args.py
@@ -392,7 +392,7 @@ def load_pathlist_from_file(filename):
         with open(filename, 'rt') as fp:
             file_list = [ x.rstrip('\r\n') for x in fp ]
         if len(file_list) == 0:
-            raise ValueError("pathlist is empty")
+            raise ValueError("random error message!!!")
         badFormat = 0
         duplicate = []
         for i in range(len(file_list)):

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -76,7 +76,7 @@ def test_load_pathlist_from_file_does_not_exist():
     from sourmash.sourmash_args import load_pathlist_from_file
     with pytest.raises(ValueError) as e:
         load_pathlist_from_file("")
-        assert "file '' does not exist" in e.message
+        assert 0                # this does not fail; why?
 
 @utils.in_tempdir
 def test_load_pathlist_from_file_empty(c):


### PR DESCRIPTION
Note: this is a PR into #1469 that probably shouldn't be merged - it's for demonstration/discussion purposes :).

So @keyabarve many of the assert statements in #1469 are not being executed at all. The calls to `load_pathlist_from_file` are raising exceptions which terminate further execution in the `with` block, and all statements after the `load_pathlist_from_file` are not executed.

The way to resolve this is to de-indent the assert statements so they are run outside of the `with` blocks. The exception is then caught by the `with` block, and the assertion is run after the exception is handled.
