### PR TITLE
[MRG] check for JSON in first byte of LCA database file

### DIFF
--- a/src/sourmash/lca/lca_db.py
+++ b/src/sourmash/lca/lca_db.py
@@ -212,6 +212,15 @@ class LCA_Database(Index):
             xopen = gzip.open
 
         with xopen(db_name, 'rt') as fp:
+            try:
+                first_ch = fp.read(1)
+            except ValueError:
+                first_ch = 'X'
+            if first_ch[0] != '{':
+                raise ValueError(f"'{db_name}' is not an LCA database file.")
+
+            fp.seek(0)
+
             load_d = {}
             try:
                 load_d = json.load(fp)

--- a/tests/test_lca.py
+++ b/tests/test_lca.py
@@ -394,6 +394,16 @@ def test_databases():
     assert scaled == 10000
 
 
+def test_databases_load_fail_on_no_JSON():
+    filename1 = utils.get_test_data('prot/protein.zip')
+    with pytest.raises(ValueError) as exc:
+        dblist, ksize, scaled = lca_utils.load_databases([filename1])
+
+    err = str(exc.value)
+    print(err)
+    assert f"'{filename1}' is not an LCA database file." in err
+
+
 def test_databases_load_fail_on_dir():
     filename1 = utils.get_test_data('lca')
     with pytest.raises(ValueError) as exc:


### PR DESCRIPTION
Change `LCA_Database.load(...)` to look at the first byte of the LCA database file, to see if it's a plausible JSON file.

This avoids costly loading of very large files by the rather dumb JSON loader we're using ;). See https://github.com/dib-lab/sourmash/issues/1483

Other, better fixes could include - 

* changing over to a different JSON loader
* doing more sophisticated checks

but this fix works fine for now!
