### PR TITLE
[MRG] Clean up clippy lints from 1.52

### DIFF
--- a/.github/workflows/dev_envs.yml
+++ b/.github/workflows/dev_envs.yml
@@ -15,14 +15,19 @@ jobs:
       id: cache-nix
       uses: actions/cache@v2
       with:
-        path: /nix/store
-        key: nix-${{ hashFiles('shell.nix') }}-${{ hashFiles('nix/**') }}
+        path: |
+          ~/.nix-portable/store
+          ~/bin/nix-portable
+        key: nix-${{ hashFiles('shell.nix') }}-${{ hashFiles('nix/**') }}-v008
 
-    - uses: cachix/install-nix-action@v12
-      with:
-        nix_path: nixpkgs=channel:nixos-20.09
+    - name: Install nix-portable
+      if: steps.cache-nix.outputs.cache-hit != 'true'
+      run: |
+        mkdir ~/bin
+        wget -qO ~/bin/nix-portable https://github.com/DavHau/nix-portable/releases/download/v008/nix-portable
+        chmod +x ~/bin/nix-portable
 
-    - run: nix-shell --command "tox -e py39"
+    - run: ~/bin/nix-portable nix-shell --command "tox -e py39"
 
   mamba:
     runs-on: ubuntu-latest

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c0e881852006b132236cbf0301bd1939bb50867e",
-        "sha256": "0fy7z7yxk5n7yslsvx5cyc6h21qwi4bhxf3awhirniszlbvaazy2",
+        "rev": "e62feb3bf4a603e26755238303bda0c24651e155",
+        "sha256": "1gkamm044jrksjrisr7h9grg8p2y6rk01x6391asrx988hm2rh9s",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/c0e881852006b132236cbf0301bd1939bb50867e.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/e62feb3bf4a603e26755238303bda0c24651e155.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "rust-overlay": {
@@ -29,10 +29,10 @@
         "homepage": null,
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "d414b80c0e6e96977b52b1a0a547ea7613a5c6d5",
-        "sha256": "14bidf0paxb4hdbq60pxgxijjw7hi5rzdg9vj490rsikk58fb2qs",
+        "rev": "d8efe70dc561c4bea0b7bf440d36ce98c497e054",
+        "sha256": "0hdj5d635dq6zwj8d4ady1kyl9mwmsxvy6vqyd3xq0p2w18ffi4r",
         "type": "tarball",
-        "url": "https://github.com/oxalica/rust-overlay/archive/d414b80c0e6e96977b52b1a0a547ea7613a5c6d5.tar.gz",
+        "url": "https://github.com/oxalica/rust-overlay/archive/d8efe70dc561c4bea0b7bf440d36ce98c497e054.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/shell.nix
+++ b/shell.nix
@@ -13,6 +13,10 @@ in
       (python38.withPackages(ps: with ps; [ virtualenv tox setuptools ]))
       (python39.withPackages(ps: with ps; [ virtualenv setuptools ]))
       (python37.withPackages(ps: with ps; [ virtualenv setuptools ]))
+      py-spy
+      heaptrack
+      cargo-watch
+      cargo-limit
       wasmtime
       wasm-pack
     ];

--- a/src/core/src/from.rs
+++ b/src/core/src/from.rs
@@ -40,7 +40,6 @@ impl From<MashSketcher> for KmerMinHash {
 mod test {
     use std::collections::HashMap;
     use std::collections::HashSet;
-    use std::iter::FromIterator;
 
     use crate::encodings::HashFunctions;
     use crate::signature::SigsTrait;
@@ -68,8 +67,8 @@ mod test {
 
         let b_hashes = b.to_vec();
 
-        let s1: HashSet<_> = HashSet::from_iter(a.mins().into_iter());
-        let s2: HashSet<_> = HashSet::from_iter(b_hashes.iter().map(|x| x.hash as u64));
+        let s1: HashSet<_> = a.mins().into_iter().collect();
+        let s2: HashSet<_> = b_hashes.iter().map(|x| x.hash as u64).collect();
         let i1 = &s1 & &s2;
 
         assert!(i1.len() == a.size());
@@ -77,7 +76,7 @@ mod test {
 
         if let Some(abunds) = a.abunds() {
             let mins = a.mins();
-            let smap: HashMap<_, _> = HashMap::from_iter(mins.iter().zip(abunds.iter()));
+            let smap: HashMap<_, _> = mins.iter().zip(abunds.iter()).collect();
             println!("{:?}", smap);
             for item in b_hashes.iter() {
                 assert!(smap.contains_key(&(item.hash as u64)));
@@ -105,8 +104,8 @@ mod test {
 
         let c = KmerMinHash::from(b);
 
-        let s1: HashSet<_> = HashSet::from_iter(a.mins().into_iter());
-        let s2: HashSet<_> = HashSet::from_iter(c.mins().into_iter());
+        let s1: HashSet<_> = a.mins().into_iter().collect();
+        let s2: HashSet<_> = c.mins().into_iter().collect();
         let i1 = &s1 & &s2;
 
         assert!(i1.len() == a.mins().len());
@@ -115,9 +114,9 @@ mod test {
         if let Some(a_abunds) = a.abunds() {
             if let Some(c_abunds) = c.abunds() {
                 let a_mins = a.mins();
-                let a_smap: HashMap<_, _> = HashMap::from_iter(a_mins.iter().zip(a_abunds.iter()));
+                let a_smap: HashMap<_, _> = a_mins.iter().zip(a_abunds.iter()).collect();
                 let c_mins = c.mins();
-                let c_smap: HashMap<_, _> = HashMap::from_iter(c_mins.iter().zip(c_abunds.iter()));
+                let c_smap: HashMap<_, _> = c_mins.iter().zip(c_abunds.iter()).collect();
                 for item in a_smap.iter() {
                     assert!(c_smap.contains_key(*item.0));
                     assert!(c_smap.get(*item.0).unwrap() == item.1);

--- a/src/core/src/sketch/hyperloglog/mod.rs
+++ b/src/core/src/sketch/hyperloglog/mod.rs
@@ -147,10 +147,10 @@ impl HyperLogLog {
         rdr.read_exact(&mut registers)?;
 
         Ok(HyperLogLog {
+            registers,
             p,
             q,
             ksize,
-            registers,
         })
     }
 

--- a/src/core/src/sketch/minhash.rs
+++ b/src/core/src/sketch/minhash.rs
@@ -1437,11 +1437,9 @@ impl KmerMinHashBTree {
     }
 
     pub fn abunds(&self) -> Option<Vec<u64>> {
-        if let Some(abunds) = &self.abunds {
-            Some(abunds.values().cloned().collect())
-        } else {
-            None
-        }
+        self.abunds
+            .as_ref()
+            .map(|abunds| abunds.values().cloned().collect())
     }
 
     // create a downsampled copy of self
@@ -1541,11 +1539,9 @@ impl From<KmerMinHashBTree> for KmerMinHash {
         );
 
         let mins = other.mins.into_iter().collect();
-        let abunds = if let Some(abunds) = other.abunds {
-            Some(abunds.values().cloned().collect())
-        } else {
-            None
-        };
+        let abunds = other
+            .abunds
+            .map(|abunds| abunds.values().cloned().collect());
 
         new_mh.mins = mins;
         new_mh.abunds = abunds;
@@ -1566,11 +1562,9 @@ impl From<KmerMinHash> for KmerMinHashBTree {
         );
 
         let mins: BTreeSet<u64> = other.mins.into_iter().collect();
-        let abunds = if let Some(abunds) = other.abunds {
-            Some(mins.iter().cloned().zip(abunds.into_iter()).collect())
-        } else {
-            None
-        };
+        let abunds = other
+            .abunds
+            .map(|abunds| mins.iter().cloned().zip(abunds.into_iter()).collect());
 
         new_mh.mins = mins;
         new_mh.abunds = abunds;

--- a/src/core/src/sketch/nodegraph.rs
+++ b/src/core/src/sketch/nodegraph.rs
@@ -418,7 +418,7 @@ mod test {
 
     #[test]
     fn load_compressed() {
-        let mut reader = BufReader::new(&COMPRESSED_RAW_DATA[..]);
+        let mut reader = BufReader::new(COMPRESSED_RAW_DATA);
 
         let ng: Nodegraph = Nodegraph::from_reader(&mut reader).expect("Loading error");
         assert_eq!(ng.tablesizes(), &[19, 17, 13, 11, 7, 5]);
@@ -468,7 +468,7 @@ mod test {
 
     #[test]
     fn binary_repr_load() {
-        let mut reader = BufReader::new(&RAW_DATA[..]);
+        let mut reader = BufReader::new(RAW_DATA);
         let khmer_ng: Nodegraph = Nodegraph::from_reader(&mut reader).expect("Loading error");
         assert_eq!(khmer_ng.tablesizes(), &[19, 17, 13, 11, 7, 5]);
         assert_eq!(khmer_ng.ksize(), 3);


### PR DESCRIPTION
New Rust release, new `clippy` recommendations =]

Also updates CI for nix to use [nix-portable](https://github.com/DavHau/nix-portable) and better caching to lower runtimes.