### PR TITLE
[MRG] Force unload data from SBT searches by default (and fix ZipStorage deallocation along the way)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -65,7 +65,7 @@ demo =
     ipython
 doc =
     sphinx
-    myst-parser[sphinx]>=0.12.2
+    myst-parser~=0.13.7
     alabaster
     sphinxcontrib-napoleon
     nbsphinx

--- a/src/sourmash/commands.py
+++ b/src/sourmash/commands.py
@@ -420,6 +420,8 @@ def index(args):
 
     notify('loaded {} sigs; saving SBT under "{}"', n, args.sbt_name)
     tree.save(args.sbt_name, sparseness=args.sparseness)
+    if tree.storage:
+        tree.storage.close()
 
 
 def search(args):

--- a/src/sourmash/sbt.py
+++ b/src/sourmash/sbt.py
@@ -579,6 +579,7 @@ class SBT(Index):
             subdir = '.sbt.{}'.format(name)
             storage_args = FSStorage("", subdir).init_args()
             storage.save(subdir + "/", b"")
+            storage.subdir = subdir
             index_filename = os.path.abspath(path)
         else:                             # path.endswith('.sbt.json')
             assert path.endswith('.sbt.json')
@@ -658,7 +659,7 @@ class SBT(Index):
             tree_data = json.dumps(info).encode("utf-8")
             save_path = "{}.sbt.json".format(name)
             storage.save(save_path, tree_data)
-            storage.close()
+            storage.flush()
 
         elif kind == "FS":
             with open(index_filename, 'w') as fp:

--- a/src/sourmash/sbt.py
+++ b/src/sourmash/sbt.py
@@ -297,7 +297,7 @@ class SBT(Index):
     def _find_nodes(self, search_fn, *args, **kwargs):
         "Search the tree using `search_fn`."
 
-        unload_data = kwargs.get("unload_data", False)
+        unload_data = kwargs.get("unload_data", True)
 
         # initialize search queue with top node of tree
         matches = []


### PR DESCRIPTION
Missing bit from #1370, re: https://github.com/dib-lab/sourmash/pull/1370#issuecomment-837106300

While changing the SBT code, this triggered deeper bugs in ZipStorage, so I fixed them too. I changed the `.save()` method to only `.flush()` the storage, but not `.close()` it. Because the `.flush()` call uses a temp file, I'm also avoiding deleting it (because it becomes the new `ZipStorage`), and also dealing with some interesting cases during deallocation (flushing/closing the underlying Zip file properly).

TODO:
- [x] ~should this be exposed back to the command line? I don't think it actually makes sense for current use cases, so `unload_data` in `SBT.find` becomes available only at the Python API level~