### PR TITLE
[MRG] Partial fix for doc build issues with notebooks

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -65,7 +65,7 @@ demo =
     ipython
 doc =
     sphinx
-    myst-parser[sphinx]>=0.12.2
+    myst-parser~=0.13.7
     alabaster
     sphinxcontrib-napoleon
     nbsphinx


### PR DESCRIPTION
Seems like something changed with `myst-parser 0.14.0` that broke our notebooks. At first it seemed to be missing `tags` in the `metadata` field of each cell in the notebook, but when I fixed that it triggered errors about missing `widgets` fields, and so... I'm pinning `myst-parser` to `0.13.7` for now.