### PR TITLE
[MRG] fix gather against signatures with abundances

### DIFF
--- a/src/sourmash/search.py
+++ b/src/sourmash/search.py
@@ -316,7 +316,7 @@ def gather_databases(query, counters, threshold_bp, ignore_abundance):
         # (CTB note: this means that if a high scaled/low res signature is
         # found early on, resolution will be low from then on.)
         query_mh = query.minhash.downsample(scaled=cmp_scaled)
-        found_mh = best_match.minhash.downsample(scaled=cmp_scaled)
+        found_mh = best_match.minhash.downsample(scaled=cmp_scaled).flatten()
         orig_query_mh = orig_query_mh.downsample(scaled=cmp_scaled)
         sum_abunds = sum(( orig_query_abunds[k] for k in orig_query_mh.hashes ))
 

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -2919,6 +2919,15 @@ def test_gather_csv(linear_gather, prefetch_gather):
             assert row['gather_result_rank'] == '0'
 
 
+def test_gather_abund_x_abund(runtmp, prefetch_gather, linear_gather):
+    sig47 = utils.get_test_data('track_abund/47.fa.sig')
+    sig63 = utils.get_test_data('track_abund/63.fa.sig')
+
+    runtmp.sourmash('gather', sig47, sig63)
+
+    assert '2.5 Mbp       49.2%   48.3%       1.0    NC_011663.1' in runtmp.last_result.out
+
+
 def test_gather_multiple_sbts(prefetch_gather, linear_gather):
     with utils.TempDirectory() as location:
         testdata1 = utils.get_test_data('short.fa')


### PR DESCRIPTION
The refactoring of gather in #1370 introduced a bug where matching signatures were not flattened, which caused `gather` to exit with a `TypeError` exception. This PR provides a fix and a test.

Fixes https://github.com/dib-lab/sourmash/issues/1518

@taylorreiter ready for review!
