### PR TITLE
[WIP] Dev documentation fixes

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -225,4 +225,5 @@ extras =
 deps = {[testenv]deps}
 usedevelop = True
 commands = python -m pip list --format=columns
-           python -c "print(r'{envpython}')"
+           python -c "print(r'Path to Python in the dev environment: {envpython}')"
+           python -c "print('\n\n You can activate the dev environment with\n   source .tox/dev/bin/activate\n or, if you are using tox-conda,\n   conda activate .tox/dev\n')"


### PR DESCRIPTION
## TODO

- [ ] Clarifications about `tox -e dev` (how to activate environment)
  - [x] `tox.ini`
  - [ ] Developer docs
- [ ] You only need one of the suggested envs, not all of them (mamba + nix + `rustup`/`virtualenv`)

Covers some of the discussions in #1375 