### PR TITLE
[WIP] Oxidized LinearIndex

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,8 @@ include/sourmash.h: src/core/src/lib.rs \
                     src/core/src/ffi/minhash.rs \
                     src/core/src/ffi/signature.rs \
                     src/core/src/ffi/nodegraph.rs \
+                    src/core/src/index/mod.rs \
+                    src/core/src/index/linear.rs \
                     src/core/src/errors.rs
 	cd src/core && \
 	RUSTUP_TOOLCHAIN=nightly cbindgen -c cbindgen.toml . -o ../../$@

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,8 @@ include/sourmash.h: src/core/src/lib.rs \
                     src/core/src/ffi/minhash.rs \
                     src/core/src/ffi/signature.rs \
                     src/core/src/ffi/nodegraph.rs \
+                    src/core/src/ffi/index/mod.rs \
+                    src/core/src/ffi/index/linear.rs \
                     src/core/src/index/mod.rs \
                     src/core/src/index/linear.rs \
                     src/core/src/errors.rs

--- a/include/sourmash.h
+++ b/include/sourmash.h
@@ -254,6 +254,10 @@ bool kmerminhash_track_abundance(const SourmashKmerMinHash *ptr);
 
 void linearindex_free(SourmashLinearIndex *ptr);
 
+void linearindex_insert_many(SourmashLinearIndex *ptr,
+                             const SourmashSignature *const *search_sigs_ptr,
+                             uintptr_t insigs);
+
 uintptr_t linearindex_len(const SourmashLinearIndex *ptr);
 
 SourmashLinearIndex *linearindex_new(void);

--- a/include/sourmash.h
+++ b/include/sourmash.h
@@ -16,6 +16,13 @@ enum HashFunctions {
 };
 typedef uint32_t HashFunctions;
 
+enum SearchType {
+  SEARCH_TYPE_JACCARD = 1,
+  SEARCH_TYPE_CONTAINMENT = 2,
+  SEARCH_TYPE_MAX_CONTAINMENT = 3,
+};
+typedef uint32_t SearchType;
+
 enum SourmashErrorCode {
   SOURMASH_ERROR_CODE_NO_ERROR = 0,
   SOURMASH_ERROR_CODE_PANIC = 1,
@@ -53,6 +60,8 @@ typedef struct SourmashKmerMinHash SourmashKmerMinHash;
 typedef struct SourmashLinearIndex SourmashLinearIndex;
 
 typedef struct SourmashNodegraph SourmashNodegraph;
+
+typedef struct SourmashSearchFn SourmashSearchFn;
 
 typedef struct SourmashSearchResult SourmashSearchResult;
 
@@ -252,6 +261,11 @@ void kmerminhash_slice_free(uint64_t *ptr, uintptr_t insize);
 
 bool kmerminhash_track_abundance(const SourmashKmerMinHash *ptr);
 
+const SourmashSearchResult *const *linearindex_find(const SourmashLinearIndex *ptr,
+                                                    const SourmashSearchFn *search_fn_ptr,
+                                                    const SourmashSignature *sig_ptr,
+                                                    uintptr_t *size);
+
 void linearindex_free(SourmashLinearIndex *ptr);
 
 void linearindex_insert_many(SourmashLinearIndex *ptr,
@@ -310,6 +324,10 @@ void nodegraph_update_mh(SourmashNodegraph *ptr, const SourmashKmerMinHash *optr
 SourmashNodegraph *nodegraph_with_tables(uintptr_t ksize,
                                          uintptr_t starting_size,
                                          uintptr_t n_tables);
+
+void searchfn_free(SourmashSearchFn *ptr);
+
+SourmashSearchFn *searchfn_new(SearchType search_type, double threshold);
 
 SourmashStr searchresult_filename(const SourmashSearchResult *ptr);
 

--- a/include/sourmash.h
+++ b/include/sourmash.h
@@ -50,7 +50,11 @@ typedef struct SourmashHyperLogLog SourmashHyperLogLog;
 
 typedef struct SourmashKmerMinHash SourmashKmerMinHash;
 
+typedef struct SourmashLinearIndex SourmashLinearIndex;
+
 typedef struct SourmashNodegraph SourmashNodegraph;
+
+typedef struct SourmashSearchResult SourmashSearchResult;
 
 typedef struct SourmashSignature SourmashSignature;
 
@@ -248,6 +252,15 @@ void kmerminhash_slice_free(uint64_t *ptr, uintptr_t insize);
 
 bool kmerminhash_track_abundance(const SourmashKmerMinHash *ptr);
 
+void linearindex_free(SourmashLinearIndex *ptr);
+
+uintptr_t linearindex_len(const SourmashLinearIndex *ptr);
+
+SourmashLinearIndex *linearindex_new_with_sigs(const SourmashSignature *const *search_sigs_ptr,
+                                               uintptr_t insigs);
+
+SourmashSignature **linearindex_signatures(const SourmashLinearIndex *ptr, uintptr_t *size);
+
 void nodegraph_buffer_free(uint8_t *ptr, uintptr_t insize);
 
 bool nodegraph_count(SourmashNodegraph *ptr, uint64_t h);
@@ -291,6 +304,14 @@ void nodegraph_update_mh(SourmashNodegraph *ptr, const SourmashKmerMinHash *optr
 SourmashNodegraph *nodegraph_with_tables(uintptr_t ksize,
                                          uintptr_t starting_size,
                                          uintptr_t n_tables);
+
+SourmashStr searchresult_filename(const SourmashSearchResult *ptr);
+
+void searchresult_free(SourmashSearchResult *ptr);
+
+double searchresult_score(const SourmashSearchResult *ptr);
+
+SourmashSignature *searchresult_signature(const SourmashSearchResult *ptr);
 
 void signature_add_protein(SourmashSignature *ptr, const char *sequence);
 

--- a/include/sourmash.h
+++ b/include/sourmash.h
@@ -256,6 +256,8 @@ void linearindex_free(SourmashLinearIndex *ptr);
 
 uintptr_t linearindex_len(const SourmashLinearIndex *ptr);
 
+SourmashLinearIndex *linearindex_new(void);
+
 SourmashLinearIndex *linearindex_new_with_sigs(const SourmashSignature *const *search_sigs_ptr,
                                                uintptr_t insigs);
 

--- a/include/sourmash.h
+++ b/include/sourmash.h
@@ -327,7 +327,7 @@ SourmashNodegraph *nodegraph_with_tables(uintptr_t ksize,
 
 void searchfn_free(SourmashSearchFn *ptr);
 
-SourmashSearchFn *searchfn_new(SearchType search_type, double threshold);
+SourmashSearchFn *searchfn_new(SearchType search_type, double threshold, bool best_only);
 
 SourmashStr searchresult_filename(const SourmashSearchResult *ptr);
 

--- a/nix/rust.nix
+++ b/nix/rust.nix
@@ -3,7 +3,7 @@
 let
   pkgs =
     import sources.nixpkgs { overlays = [ (import sources.rust-overlay) ]; };
-  rustVersion = pkgs.rust-bin.stable.latest.rust.override {
+  rustVersion = pkgs.rust-bin.nightly.latest.rust.override {
     #extensions = [ "rust-src" ];
     #targets = [ "x86_64-unknown-linux-musl" ];
     targets = [ "wasm32-wasi" "wasm32-unknown-unknown" ];

--- a/shell.nix
+++ b/shell.nix
@@ -13,12 +13,14 @@ in
       (python38.withPackages(ps: with ps; [ virtualenv tox setuptools ]))
       (python39.withPackages(ps: with ps; [ virtualenv setuptools ]))
       (python37.withPackages(ps: with ps; [ virtualenv setuptools ]))
+      rust-cbindgen
       py-spy
       heaptrack
       cargo-watch
       cargo-limit
       wasmtime
       wasm-pack
+      gdb
     ];
 
     shellHook = ''

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -43,6 +43,7 @@ serde_json = "1.0.53"
 primal-check = "0.3.1"
 thiserror = "1.0"
 typed-builder = "0.9.0"
+atomic_float = "0.1.0"
 
 [target.'cfg(all(target_arch = "wasm32", target_vendor="unknown"))'.dependencies.wasm-bindgen]
 version = "0.2.62"

--- a/src/core/src/ffi/index/linear.rs
+++ b/src/core/src/ffi/index/linear.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 use std::slice;
 
 use crate::index::linear::LinearIndex;
-use crate::index::Index;
+use crate::index::{Index, SigStore};
 use crate::signature::{Signature, SigsTrait};
 use crate::sketch::minhash::KmerMinHash;
 use crate::sketch::Sketch;
@@ -19,217 +19,47 @@ impl ForeignObject for SourmashLinearIndex {
 }
 
 ffi_fn! {
-  unsafe fn linearindex_new_with_paths(
-      search_sigs_ptr: *const *const SourmashStr,
-      insigs: usize,
-      template_ptr: *const SourmashKmerMinHash,
-      threshold: usize,
-      queries_ptr: *const *const SourmashKmerMinHash,
-      inqueries: usize,
-      keep_sigs: bool,
-  ) -> Result<*mut SourmashLinearIndex> {
-    let search_sigs: Vec<PathBuf> = {
-      assert!(!search_sigs_ptr.is_null());
-        slice::from_raw_parts(search_sigs_ptr, insigs).iter().map(|path| {
-          let mut new_path = PathBuf::new();
-          new_path.push(SourmashStr::as_rust(*path).as_str());
-          new_path}
-          ).collect()
+unsafe fn linearindex_new_with_sigs(
+    search_sigs_ptr: *const *const SourmashSignature,
+    insigs: usize,
+) -> Result<*mut SourmashLinearIndex> {
+    let search_sigs: Vec<SigStore<Signature>> = {
+        assert!(!search_sigs_ptr.is_null());
+        slice::from_raw_parts(search_sigs_ptr, insigs)
+            .iter()
+            .map(|sig| SourmashSignature::as_rust(*sig))
+            .cloned()
+            .map(|sig| {
+                SigStore::builder()
+                    .data(sig)
+                    .filename("")
+                    .name("")
+                    .metadata("")
+                    .storage(None)
+                    .build()
+            })
+            .collect()
     };
 
-    let linear_index = LinearIndex::builder().build();
-
-    unimplemented!();
-    /*
-
-    let template = {
-      assert!(!template_ptr.is_null());
-      //TODO: avoid clone here
-      Sketch::MinHash(SourmashKmerMinHash::as_rust(template_ptr).clone())
-    };
-
-    let queries_vec: Vec<KmerMinHash>;
-    let queries: Option<&[KmerMinHash]> = if queries_ptr.is_null() {
-      None
-    } else {
-        queries_vec =
-          slice::from_raw_parts(queries_ptr, inqueries).iter().map(|mh_ptr|
-            // TODO: avoid this clone
-          SourmashKmerMinHash::as_rust(*mh_ptr).clone()).collect();
-        Some(queries_vec.as_ref())
-    };
-      let revindex = RevIndex::new(
-        search_sigs.as_ref(),
-        &template,
-        threshold,
-        queries,
-        keep_sigs
-      );
-      Ok(SourmashRevIndex::from_rust(revindex))
-    */
+    let linear_index = LinearIndex::builder().datasets(search_sigs).build();
 
     Ok(SourmashLinearIndex::from_rust(linear_index))
-  }
 }
-
-/*
-ffi_fn! {
-  unsafe fn revindex_new_with_sigs(
-      search_sigs_ptr: *const *const SourmashSignature,
-      insigs: usize,
-      template_ptr: *const SourmashKmerMinHash,
-      threshold: usize,
-      queries_ptr: *const *const SourmashKmerMinHash,
-      inqueries: usize,
-  ) -> Result<*mut SourmashRevIndex> {
-    let search_sigs: Vec<Signature> = {
-      assert!(!search_sigs_ptr.is_null());
-        slice::from_raw_parts(search_sigs_ptr, insigs).iter().map(|sig|
-          SourmashSignature::as_rust(*sig)
-          ).cloned().collect()
-    };
-
-    let template = {
-      assert!(!template_ptr.is_null());
-      //TODO: avoid clone here
-      Sketch::MinHash(SourmashKmerMinHash::as_rust(template_ptr).clone())
-    };
-
-    let queries_vec: Vec<KmerMinHash>;
-    let queries: Option<&[KmerMinHash]> = if queries_ptr.is_null() {
-      None
-    } else {
-        queries_vec =
-          slice::from_raw_parts(queries_ptr, inqueries).iter().map(|mh_ptr|
-            // TODO: avoid this clone
-          SourmashKmerMinHash::as_rust(*mh_ptr).clone()).collect();
-        Some(queries_vec.as_ref())
-    };
-      let revindex = RevIndex::new_with_sigs(
-        search_sigs,
-        &template,
-        threshold,
-        queries,
-      );
-      Ok(SourmashRevIndex::from_rust(revindex))
-  }
 }
-*/
 
 #[no_mangle]
-pub unsafe extern "C" fn linear_index_free(ptr: *mut SourmashLinearIndex) {
+pub unsafe extern "C" fn linearindex_free(ptr: *mut SourmashLinearIndex) {
     SourmashLinearIndex::drop(ptr);
 }
 
-/*
-ffi_fn! {
-unsafe fn revindex_search(
-    ptr: *const SourmashRevIndex,
-    sig_ptr: *const SourmashSignature,
-    threshold: f64,
-    do_containment: bool,
-    _ignore_abundance: bool,
-    size: *mut usize
-) -> Result<*const *const SourmashSearchResult> {
-    let revindex = SourmashRevIndex::as_rust(ptr);
-    let sig = SourmashSignature::as_rust(sig_ptr);
-
-    if sig.signatures.is_empty() {
-        *size = 0;
-        return Ok(std::ptr::null::<*const SourmashSearchResult>());
-    }
-
-    let mh = if let Sketch::MinHash(mh) = &sig.signatures[0] {
-        mh
-    } else {
-        // TODO: what if it is not a mh?
-        unimplemented!()
-    };
-
-    let results: Vec<(f64, Signature, String)> = revindex
-        .find_signatures(mh, threshold, do_containment, true)?
-        .into_iter()
-        .collect();
-
-    // FIXME: use the ForeignObject trait, maybe define new method there...
-    let ptr_sigs: Vec<*const SourmashSearchResult> = results.into_iter().map(|x| {
-      Box::into_raw(Box::new(x)) as *const SourmashSearchResult
-    }).collect();
-
-    let b = ptr_sigs.into_boxed_slice();
-    *size = b.len();
-
-    Ok(Box::into_raw(b) as *const *const SourmashSearchResult)
-}
-}
-
-ffi_fn! {
-unsafe fn revindex_gather(
-    ptr: *const SourmashRevIndex,
-    sig_ptr: *const SourmashSignature,
-    threshold: f64,
-    _do_containment: bool,
-    _ignore_abundance: bool,
-    size: *mut usize
-) -> Result<*const *const SourmashSearchResult> {
-    let revindex = SourmashRevIndex::as_rust(ptr);
-    let sig = SourmashSignature::as_rust(sig_ptr);
-
-    if sig.signatures.is_empty() {
-        *size = 0;
-        return Ok(std::ptr::null::<*const SourmashSearchResult>());
-    }
-
-    let mh = if let Sketch::MinHash(mh) = &sig.signatures[0] {
-        mh
-    } else {
-        // TODO: what if it is not a mh?
-        unimplemented!()
-    };
-
-    // TODO: proper threshold calculation
-    let threshold: usize = (threshold * (mh.size() as f64)) as _;
-
-    let counter = revindex.counter_for_query(&mh);
-        dbg!(&counter);
-
-    let results: Vec<(f64, Signature, String)> = revindex
-        .gather(counter, threshold, mh)
-        .unwrap() // TODO: proper error handling
-        .into_iter()
-        .map(|r| {
-            let filename = r.filename().to_owned();
-            let sig = r.get_match();
-            (r.f_match(), sig, filename)
-        })
-        .collect();
-
-
-    // FIXME: use the ForeignObject trait, maybe define new method there...
-    let ptr_sigs: Vec<*const SourmashSearchResult> = results.into_iter().map(|x| {
-      Box::into_raw(Box::new(x)) as *const SourmashSearchResult
-    }).collect();
-
-    let b = ptr_sigs.into_boxed_slice();
-    *size = b.len();
-
-    Ok(Box::into_raw(b) as *const *const SourmashSearchResult)
-}
-}
-
 #[no_mangle]
-pub unsafe extern "C" fn revindex_scaled(ptr: *const SourmashRevIndex) -> u64 {
-    let revindex = SourmashRevIndex::as_rust(ptr);
-    if let Sketch::MinHash(mh) = revindex.template() {
-        mh.scaled()
-    } else {
-        unimplemented!()
-    }
+pub unsafe extern "C" fn linearindex_len(ptr: *const SourmashLinearIndex) -> usize {
+    let index = SourmashLinearIndex::as_rust(ptr);
+    index.len()
 }
-*/
 
 ffi_fn! {
-unsafe fn linear_index_signatures(ptr: *const SourmashLinearIndex,
+unsafe fn linearindex_signatures(ptr: *const SourmashLinearIndex,
                                   size: *mut usize) -> Result<*mut *mut SourmashSignature> {
     let index = SourmashLinearIndex::as_rust(ptr);
 

--- a/src/core/src/ffi/index/linear.rs
+++ b/src/core/src/ffi/index/linear.rs
@@ -1,16 +1,23 @@
 use std::slice;
 
 use crate::index::linear::LinearIndex;
-use crate::index::{Index, SigStore};
+use crate::index::{Index, SearchFn, SigStore};
 use crate::signature::Signature;
 
+use crate::ffi::index::SourmashSearchResult;
 use crate::ffi::signature::SourmashSignature;
 use crate::ffi::utils::ForeignObject;
 
 pub struct SourmashLinearIndex;
 
+pub struct SourmashSearchFn;
+
 impl ForeignObject for SourmashLinearIndex {
     type RustObject = LinearIndex<Signature>;
+}
+
+impl ForeignObject for SourmashSearchFn {
+    type RustObject = SearchFn;
 }
 
 #[no_mangle]
@@ -81,5 +88,34 @@ unsafe fn linearindex_signatures(ptr: *const SourmashLinearIndex,
     *size = b.len();
 
     Ok(Box::into_raw(b) as *mut *mut SourmashSignature)
+}
+}
+
+ffi_fn! {
+unsafe fn linearindex_find(
+    ptr: *const SourmashLinearIndex,
+    search_fn_ptr: *const SourmashSearchFn,
+    sig_ptr: *const SourmashSignature,
+    size: *mut usize,
+) -> Result<*const *const SourmashSearchResult> {
+    let linearindex = SourmashLinearIndex::as_rust(ptr);
+    let search_fn = SourmashSearchFn::as_rust(search_fn_ptr);
+    let query = SourmashSignature::as_rust(sig_ptr);
+
+    let results: Vec<(f64, Signature, String)> = linearindex
+        .find_new(search_fn, query)?
+        .into_iter()
+        .collect();
+
+    // FIXME: use the ForeignObject trait, maybe define new method there...
+    let ptr_sigs: Vec<*const SourmashSearchResult> = results
+        .into_iter()
+        .map(|x| Box::into_raw(Box::new(x)) as *const SourmashSearchResult)
+        .collect();
+
+    let b = ptr_sigs.into_boxed_slice();
+    *size = b.len();
+
+    Ok(Box::into_raw(b) as *const *const SourmashSearchResult)
 }
 }

--- a/src/core/src/ffi/index/linear.rs
+++ b/src/core/src/ffi/index/linear.rs
@@ -1,0 +1,248 @@
+use std::path::PathBuf;
+use std::slice;
+
+use crate::index::linear::LinearIndex;
+use crate::index::Index;
+use crate::signature::{Signature, SigsTrait};
+use crate::sketch::minhash::KmerMinHash;
+use crate::sketch::Sketch;
+
+use crate::ffi::index::SourmashSearchResult;
+use crate::ffi::minhash::SourmashKmerMinHash;
+use crate::ffi::signature::SourmashSignature;
+use crate::ffi::utils::{ForeignObject, SourmashStr};
+
+pub struct SourmashLinearIndex;
+
+impl ForeignObject for SourmashLinearIndex {
+    type RustObject = LinearIndex<Signature>;
+}
+
+ffi_fn! {
+  unsafe fn linearindex_new_with_paths(
+      search_sigs_ptr: *const *const SourmashStr,
+      insigs: usize,
+      template_ptr: *const SourmashKmerMinHash,
+      threshold: usize,
+      queries_ptr: *const *const SourmashKmerMinHash,
+      inqueries: usize,
+      keep_sigs: bool,
+  ) -> Result<*mut SourmashLinearIndex> {
+    let search_sigs: Vec<PathBuf> = {
+      assert!(!search_sigs_ptr.is_null());
+        slice::from_raw_parts(search_sigs_ptr, insigs).iter().map(|path| {
+          let mut new_path = PathBuf::new();
+          new_path.push(SourmashStr::as_rust(*path).as_str());
+          new_path}
+          ).collect()
+    };
+
+    let linear_index = LinearIndex::builder().build();
+
+    unimplemented!();
+    /*
+
+    let template = {
+      assert!(!template_ptr.is_null());
+      //TODO: avoid clone here
+      Sketch::MinHash(SourmashKmerMinHash::as_rust(template_ptr).clone())
+    };
+
+    let queries_vec: Vec<KmerMinHash>;
+    let queries: Option<&[KmerMinHash]> = if queries_ptr.is_null() {
+      None
+    } else {
+        queries_vec =
+          slice::from_raw_parts(queries_ptr, inqueries).iter().map(|mh_ptr|
+            // TODO: avoid this clone
+          SourmashKmerMinHash::as_rust(*mh_ptr).clone()).collect();
+        Some(queries_vec.as_ref())
+    };
+      let revindex = RevIndex::new(
+        search_sigs.as_ref(),
+        &template,
+        threshold,
+        queries,
+        keep_sigs
+      );
+      Ok(SourmashRevIndex::from_rust(revindex))
+    */
+
+    Ok(SourmashLinearIndex::from_rust(linear_index))
+  }
+}
+
+/*
+ffi_fn! {
+  unsafe fn revindex_new_with_sigs(
+      search_sigs_ptr: *const *const SourmashSignature,
+      insigs: usize,
+      template_ptr: *const SourmashKmerMinHash,
+      threshold: usize,
+      queries_ptr: *const *const SourmashKmerMinHash,
+      inqueries: usize,
+  ) -> Result<*mut SourmashRevIndex> {
+    let search_sigs: Vec<Signature> = {
+      assert!(!search_sigs_ptr.is_null());
+        slice::from_raw_parts(search_sigs_ptr, insigs).iter().map(|sig|
+          SourmashSignature::as_rust(*sig)
+          ).cloned().collect()
+    };
+
+    let template = {
+      assert!(!template_ptr.is_null());
+      //TODO: avoid clone here
+      Sketch::MinHash(SourmashKmerMinHash::as_rust(template_ptr).clone())
+    };
+
+    let queries_vec: Vec<KmerMinHash>;
+    let queries: Option<&[KmerMinHash]> = if queries_ptr.is_null() {
+      None
+    } else {
+        queries_vec =
+          slice::from_raw_parts(queries_ptr, inqueries).iter().map(|mh_ptr|
+            // TODO: avoid this clone
+          SourmashKmerMinHash::as_rust(*mh_ptr).clone()).collect();
+        Some(queries_vec.as_ref())
+    };
+      let revindex = RevIndex::new_with_sigs(
+        search_sigs,
+        &template,
+        threshold,
+        queries,
+      );
+      Ok(SourmashRevIndex::from_rust(revindex))
+  }
+}
+*/
+
+#[no_mangle]
+pub unsafe extern "C" fn linear_index_free(ptr: *mut SourmashLinearIndex) {
+    SourmashLinearIndex::drop(ptr);
+}
+
+/*
+ffi_fn! {
+unsafe fn revindex_search(
+    ptr: *const SourmashRevIndex,
+    sig_ptr: *const SourmashSignature,
+    threshold: f64,
+    do_containment: bool,
+    _ignore_abundance: bool,
+    size: *mut usize
+) -> Result<*const *const SourmashSearchResult> {
+    let revindex = SourmashRevIndex::as_rust(ptr);
+    let sig = SourmashSignature::as_rust(sig_ptr);
+
+    if sig.signatures.is_empty() {
+        *size = 0;
+        return Ok(std::ptr::null::<*const SourmashSearchResult>());
+    }
+
+    let mh = if let Sketch::MinHash(mh) = &sig.signatures[0] {
+        mh
+    } else {
+        // TODO: what if it is not a mh?
+        unimplemented!()
+    };
+
+    let results: Vec<(f64, Signature, String)> = revindex
+        .find_signatures(mh, threshold, do_containment, true)?
+        .into_iter()
+        .collect();
+
+    // FIXME: use the ForeignObject trait, maybe define new method there...
+    let ptr_sigs: Vec<*const SourmashSearchResult> = results.into_iter().map(|x| {
+      Box::into_raw(Box::new(x)) as *const SourmashSearchResult
+    }).collect();
+
+    let b = ptr_sigs.into_boxed_slice();
+    *size = b.len();
+
+    Ok(Box::into_raw(b) as *const *const SourmashSearchResult)
+}
+}
+
+ffi_fn! {
+unsafe fn revindex_gather(
+    ptr: *const SourmashRevIndex,
+    sig_ptr: *const SourmashSignature,
+    threshold: f64,
+    _do_containment: bool,
+    _ignore_abundance: bool,
+    size: *mut usize
+) -> Result<*const *const SourmashSearchResult> {
+    let revindex = SourmashRevIndex::as_rust(ptr);
+    let sig = SourmashSignature::as_rust(sig_ptr);
+
+    if sig.signatures.is_empty() {
+        *size = 0;
+        return Ok(std::ptr::null::<*const SourmashSearchResult>());
+    }
+
+    let mh = if let Sketch::MinHash(mh) = &sig.signatures[0] {
+        mh
+    } else {
+        // TODO: what if it is not a mh?
+        unimplemented!()
+    };
+
+    // TODO: proper threshold calculation
+    let threshold: usize = (threshold * (mh.size() as f64)) as _;
+
+    let counter = revindex.counter_for_query(&mh);
+        dbg!(&counter);
+
+    let results: Vec<(f64, Signature, String)> = revindex
+        .gather(counter, threshold, mh)
+        .unwrap() // TODO: proper error handling
+        .into_iter()
+        .map(|r| {
+            let filename = r.filename().to_owned();
+            let sig = r.get_match();
+            (r.f_match(), sig, filename)
+        })
+        .collect();
+
+
+    // FIXME: use the ForeignObject trait, maybe define new method there...
+    let ptr_sigs: Vec<*const SourmashSearchResult> = results.into_iter().map(|x| {
+      Box::into_raw(Box::new(x)) as *const SourmashSearchResult
+    }).collect();
+
+    let b = ptr_sigs.into_boxed_slice();
+    *size = b.len();
+
+    Ok(Box::into_raw(b) as *const *const SourmashSearchResult)
+}
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn revindex_scaled(ptr: *const SourmashRevIndex) -> u64 {
+    let revindex = SourmashRevIndex::as_rust(ptr);
+    if let Sketch::MinHash(mh) = revindex.template() {
+        mh.scaled()
+    } else {
+        unimplemented!()
+    }
+}
+*/
+
+ffi_fn! {
+unsafe fn linear_index_signatures(ptr: *const SourmashLinearIndex,
+                                  size: *mut usize) -> Result<*mut *mut SourmashSignature> {
+    let index = SourmashLinearIndex::as_rust(ptr);
+
+    let sigs = index.signatures();
+
+    // FIXME: use the ForeignObject trait, maybe define new method there...
+    let ptr_sigs: Vec<*mut SourmashSignature> = sigs.into_iter().map(|x| {
+      Box::into_raw(Box::new(x)) as *mut SourmashSignature
+    }).collect();
+
+    let b = ptr_sigs.into_boxed_slice();
+    *size = b.len();
+
+    Ok(Box::into_raw(b) as *mut *mut SourmashSignature)
+}
+}

--- a/src/core/src/ffi/index/linear.rs
+++ b/src/core/src/ffi/index/linear.rs
@@ -1,21 +1,21 @@
-use std::path::PathBuf;
 use std::slice;
 
 use crate::index::linear::LinearIndex;
 use crate::index::{Index, SigStore};
-use crate::signature::{Signature, SigsTrait};
-use crate::sketch::minhash::KmerMinHash;
-use crate::sketch::Sketch;
+use crate::signature::Signature;
 
-use crate::ffi::index::SourmashSearchResult;
-use crate::ffi::minhash::SourmashKmerMinHash;
 use crate::ffi::signature::SourmashSignature;
-use crate::ffi::utils::{ForeignObject, SourmashStr};
+use crate::ffi::utils::ForeignObject;
 
 pub struct SourmashLinearIndex;
 
 impl ForeignObject for SourmashLinearIndex {
     type RustObject = LinearIndex<Signature>;
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn linearindex_new() -> *mut SourmashLinearIndex {
+    SourmashLinearIndex::from_rust(LinearIndex::builder().build())
 }
 
 ffi_fn! {

--- a/src/core/src/ffi/index/linear.rs
+++ b/src/core/src/ffi/index/linear.rs
@@ -1,23 +1,18 @@
 use std::slice;
 
 use crate::index::linear::LinearIndex;
-use crate::index::{Index, SearchFn, SigStore};
+use crate::index::{Index, SigStore};
 use crate::signature::Signature;
 
 use crate::ffi::index::SourmashSearchResult;
+use crate::ffi::search::SourmashSearchFn;
 use crate::ffi::signature::SourmashSignature;
 use crate::ffi::utils::ForeignObject;
 
 pub struct SourmashLinearIndex;
 
-pub struct SourmashSearchFn;
-
 impl ForeignObject for SourmashLinearIndex {
     type RustObject = LinearIndex<Signature>;
-}
-
-impl ForeignObject for SourmashSearchFn {
-    type RustObject = SearchFn;
 }
 
 #[no_mangle]

--- a/src/core/src/ffi/index/mod.rs
+++ b/src/core/src/ffi/index/mod.rs
@@ -1,0 +1,37 @@
+pub mod linear;
+
+use crate::signature::Signature;
+
+use crate::ffi::signature::SourmashSignature;
+use crate::ffi::utils::{ForeignObject, SourmashStr};
+
+pub struct SourmashSearchResult;
+
+impl ForeignObject for SourmashSearchResult {
+    type RustObject = (f64, Signature, String);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn searchresult_free(ptr: *mut SourmashSearchResult) {
+    SourmashSearchResult::drop(ptr);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn searchresult_score(ptr: *const SourmashSearchResult) -> f64 {
+    let result = SourmashSearchResult::as_rust(ptr);
+    result.0
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn searchresult_filename(ptr: *const SourmashSearchResult) -> SourmashStr {
+    let result = SourmashSearchResult::as_rust(ptr);
+    (result.2).clone().into()
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn searchresult_signature(
+    ptr: *const SourmashSearchResult,
+) -> *mut SourmashSignature {
+    let result = SourmashSearchResult::as_rust(ptr);
+    SourmashSignature::from_rust((result.1).clone())
+}

--- a/src/core/src/ffi/mod.rs
+++ b/src/core/src/ffi/mod.rs
@@ -8,6 +8,7 @@ pub mod utils;
 
 pub mod cmd;
 pub mod hyperloglog;
+pub mod index;
 pub mod minhash;
 pub mod nodegraph;
 pub mod signature;

--- a/src/core/src/ffi/mod.rs
+++ b/src/core/src/ffi/mod.rs
@@ -11,6 +11,7 @@ pub mod hyperloglog;
 pub mod index;
 pub mod minhash;
 pub mod nodegraph;
+pub mod search;
 pub mod signature;
 
 use std::ffi::CStr;

--- a/src/core/src/ffi/search.rs
+++ b/src/core/src/ffi/search.rs
@@ -1,0 +1,46 @@
+use crate::index::{JaccardSearch, SearchType};
+use crate::signature::Signature;
+
+use crate::ffi::signature::SourmashSignature;
+use crate::ffi::utils::{ForeignObject, SourmashStr};
+
+pub struct SourmashSearchFn;
+
+impl ForeignObject for SourmashSearchFn {
+    type RustObject = JaccardSearch;
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn searchfn_free(ptr: *mut SourmashSearchFn) {
+    SourmashSearchFn::drop(ptr);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn searchfn_new(
+    search_type: SearchType,
+    threshold: f64,
+) -> *mut SourmashSearchFn {
+    SourmashSearchFn::from_rust(JaccardSearch::with_threshold(search_type, threshold))
+}
+
+/*
+#[no_mangle]
+pub unsafe extern "C" fn searchresult_score(ptr: *const SourmashSearchResult) -> f64 {
+    let result = SourmashSearchResult::as_rust(ptr);
+    result.0
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn searchresult_filename(ptr: *const SourmashSearchResult) -> SourmashStr {
+    let result = SourmashSearchResult::as_rust(ptr);
+    (result.2).clone().into()
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn searchresult_signature(
+    ptr: *const SourmashSearchResult,
+) -> *mut SourmashSignature {
+    let result = SourmashSearchResult::as_rust(ptr);
+    SourmashSignature::from_rust((result.1).clone())
+}
+*/

--- a/src/core/src/ffi/search.rs
+++ b/src/core/src/ffi/search.rs
@@ -17,6 +17,9 @@ pub unsafe extern "C" fn searchfn_free(ptr: *mut SourmashSearchFn) {
 pub unsafe extern "C" fn searchfn_new(
     search_type: SearchType,
     threshold: f64,
+    best_only: bool,
 ) -> *mut SourmashSearchFn {
-    SourmashSearchFn::from_rust(JaccardSearch::with_threshold(search_type, threshold))
+    let mut func = JaccardSearch::with_threshold(search_type, threshold);
+    func.set_best_only(best_only);
+    SourmashSearchFn::from_rust(func)
 }

--- a/src/core/src/ffi/search.rs
+++ b/src/core/src/ffi/search.rs
@@ -1,8 +1,6 @@
 use crate::index::{JaccardSearch, SearchType};
-use crate::signature::Signature;
 
-use crate::ffi::signature::SourmashSignature;
-use crate::ffi::utils::{ForeignObject, SourmashStr};
+use crate::ffi::utils::ForeignObject;
 
 pub struct SourmashSearchFn;
 
@@ -22,25 +20,3 @@ pub unsafe extern "C" fn searchfn_new(
 ) -> *mut SourmashSearchFn {
     SourmashSearchFn::from_rust(JaccardSearch::with_threshold(search_type, threshold))
 }
-
-/*
-#[no_mangle]
-pub unsafe extern "C" fn searchresult_score(ptr: *const SourmashSearchResult) -> f64 {
-    let result = SourmashSearchResult::as_rust(ptr);
-    result.0
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn searchresult_filename(ptr: *const SourmashSearchResult) -> SourmashStr {
-    let result = SourmashSearchResult::as_rust(ptr);
-    (result.2).clone().into()
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn searchresult_signature(
-    ptr: *const SourmashSearchResult,
-) -> *mut SourmashSignature {
-    let result = SourmashSearchResult::as_rust(ptr);
-    SourmashSignature::from_rust((result.1).clone())
-}
-*/

--- a/src/core/src/ffi/utils.rs
+++ b/src/core/src/ffi/utils.rs
@@ -314,3 +314,7 @@ pub unsafe extern "C" fn sourmash_str_free(s: *mut SourmashStr) {
         (*s).free()
     }
 }
+
+impl ForeignObject for SourmashStr {
+    type RustObject = SourmashStr;
+}

--- a/src/core/src/index/linear.rs
+++ b/src/core/src/index/linear.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use typed_builder::TypedBuilder;
 
 use crate::index::storage::{FSStorage, ReadData, Storage, StorageInfo, ToWriter};
-use crate::index::{Comparable, DatasetInfo, Index, SearchFn, SigStore};
+use crate::index::{Comparable, DatasetInfo, Index, JaccardSearch, SigStore};
 use crate::signature::Signature;
 use crate::Error;
 
@@ -190,7 +190,7 @@ where
 impl LinearIndex<Signature> {
     pub fn find_new(
         &self,
-        search_fn: &SearchFn,
+        search_fn: &JaccardSearch,
         query: &Signature,
     ) -> Result<Vec<(f64, Signature, String)>, Error> {
         unimplemented!()

--- a/src/core/src/index/linear.rs
+++ b/src/core/src/index/linear.rs
@@ -8,7 +8,8 @@ use serde::{Deserialize, Serialize};
 use typed_builder::TypedBuilder;
 
 use crate::index::storage::{FSStorage, ReadData, Storage, StorageInfo, ToWriter};
-use crate::index::{Comparable, DatasetInfo, Index, SigStore};
+use crate::index::{Comparable, DatasetInfo, Index, SearchFn, SigStore};
+use crate::signature::Signature;
 use crate::Error;
 
 #[derive(TypedBuilder)]
@@ -183,5 +184,15 @@ where
 
     pub fn len(&self) -> usize {
         self.datasets.len()
+    }
+}
+
+impl LinearIndex<Signature> {
+    pub fn find_new(
+        &self,
+        search_fn: &SearchFn,
+        query: &Signature,
+    ) -> Result<Vec<(f64, Signature, String)>, Error> {
+        unimplemented!()
     }
 }

--- a/src/core/src/index/linear.rs
+++ b/src/core/src/index/linear.rs
@@ -30,7 +30,7 @@ struct LinearInfo<L> {
 impl<'a, L> Index<'a> for LinearIndex<L>
 where
     L: Clone + Comparable<L> + 'a,
-    SigStore<L>: From<L>,
+    SigStore<L>: From<L> + ReadData<L>,
 {
     type Item = L;
     //type SignatureIterator = std::slice::Iter<'a, Self::Item>;
@@ -58,15 +58,13 @@ where
     fn signatures(&self) -> Vec<Self::Item> {
         self.datasets
             .iter()
-            .map(|x| x.data.get().unwrap().clone())
+            .map(|x| (*x).data().unwrap())
+            .cloned()
             .collect()
     }
 
     fn signature_refs(&self) -> Vec<&Self::Item> {
-        self.datasets
-            .iter()
-            .map(|x| x.data.get().unwrap())
-            .collect()
+        self.datasets.iter().map(|x| (*x).data().unwrap()).collect()
     }
 
     /*
@@ -181,5 +179,9 @@ where
 
     pub fn storage(&self) -> Option<Rc<dyn Storage>> {
         self.storage.clone()
+    }
+
+    pub fn len(&self) -> usize {
+        self.datasets.len()
     }
 }

--- a/src/core/src/index/linear.rs
+++ b/src/core/src/index/linear.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use typed_builder::TypedBuilder;
 
 use crate::index::{Comparable, DatasetInfo, Index, JaccardSearch, SigStore};
-use crate::signature::Signature;
+use crate::signature::{Signature, SigsTrait};
 use crate::Error;
 use crate::{
     index::storage::{FSStorage, ReadData, Storage, StorageInfo, ToWriter},
@@ -221,9 +221,9 @@ impl LinearIndex<Signature> {
                     unimplemented!()
                 }
 
-                let (shared_size, total_size) = query_mh.intersection_size(&subj_mh).unwrap();
-                let query_size = query.size();
-                let subj_size = subj.size();
+                let (shared_size, total_size) = dbg!(query_mh.intersection_size(&subj_mh).unwrap());
+                let query_size = query_mh.size();
+                let subj_size = subj_mh.size();
 
                 let score: f64 = search_fn.score(
                     query_size.try_into().unwrap(),

--- a/src/core/src/index/mod.rs
+++ b/src/core/src/index/mod.rs
@@ -330,3 +330,5 @@ impl<L> From<DatasetInfo> for SigStore<L> {
         }
     }
 }
+
+pub struct SearchFn {}

--- a/src/core/src/index/mod.rs
+++ b/src/core/src/index/mod.rs
@@ -344,6 +344,7 @@ pub struct JaccardSearch {
     search_type: SearchType,
     threshold: AtomicF64,
     require_scaled: bool,
+    best_only: bool,
 }
 
 impl JaccardSearch {
@@ -355,8 +356,9 @@ impl JaccardSearch {
 
         JaccardSearch {
             search_type,
-            require_scaled,
             threshold: AtomicF64::new(0.0),
+            require_scaled,
+            best_only: false,
         }
     }
 
@@ -364,6 +366,10 @@ impl JaccardSearch {
         let s = Self::new(search_type);
         s.set_threshold(threshold);
         s
+    }
+
+    pub fn set_best_only(&mut self, best_only: bool) {
+        self.best_only = best_only;
     }
 
     pub fn set_threshold(&self, threshold: f64) {
@@ -407,6 +413,9 @@ impl JaccardSearch {
 
     /// Return True if this match should be collected.
     pub fn collect(&self, score: f64, subj: &Signature) -> bool {
+        if self.best_only {
+            self.threshold.fetch_max(score, Ordering::Relaxed);
+        }
         true
     }
 

--- a/src/core/src/index/mod.rs
+++ b/src/core/src/index/mod.rs
@@ -331,4 +331,40 @@ impl<L> From<DatasetInfo> for SigStore<L> {
     }
 }
 
-pub struct SearchFn {}
+#[repr(u32)]
+pub enum SearchType {
+    Jaccard = 1,
+    Containment = 2,
+    MaxContainment = 3,
+}
+
+pub struct JaccardSearch {
+    search_type: SearchType,
+    threshold: f64,
+    require_scaled: bool,
+}
+
+impl JaccardSearch {
+    pub fn new(search_type: SearchType) -> Self {
+        let require_scaled = match search_type {
+            SearchType::Containment | SearchType::MaxContainment => true,
+            SearchType::Jaccard => false,
+        };
+
+        JaccardSearch {
+            search_type,
+            require_scaled,
+            threshold: 0.,
+        }
+    }
+
+    pub fn with_threshold(search_type: SearchType, threshold: f64) -> Self {
+        let mut s = Self::new(search_type);
+        s.set_threshold(threshold);
+        s
+    }
+
+    pub fn set_threshold(&mut self, threshold: f64) {
+        self.threshold = threshold;
+    }
+}

--- a/src/sourmash/index.py
+++ b/src/sourmash/index.py
@@ -430,11 +430,14 @@ class LinearIndex(Index, RustObject):
 
         Returns a list.
         """
+        self._init_inner()
+
         size = ffi.new("uintptr_t *")
         results_ptr = self._methodcall(
             lib.linearindex_find,
-            search_fn._get_objptr(),
+            search_fn._as_rust(),
             query._get_objptr(),
+            size
         )
 
         size = size[0]

--- a/src/sourmash/index.py
+++ b/src/sourmash/index.py
@@ -351,7 +351,8 @@ class LinearIndex(Index, RustObject):
             not self.__signatures
             and self._objptr == ffi.NULL
         ):
-            raise ValueError("No signatures provided")
+            # no signatures provided, initializing empty LinearIndex
+            self._objptr = lib.linearindex_new()
         elif self.__signatures and self._objptr != ffi.NULL:
             raise NotImplementedError("Need to update LinearIndex")
 

--- a/src/sourmash/search.py
+++ b/src/sourmash/search.py
@@ -164,7 +164,7 @@ class JaccardSearch:
 
         return rustcall(
             lib.searchfn_new,
-            self.search_type.value(),
+            self.search_type.value,
             self.threshold,
         )
 

--- a/src/sourmash/search.py
+++ b/src/sourmash/search.py
@@ -166,15 +166,34 @@ class JaccardSearch:
             lib.searchfn_new,
             self.search_type.value,
             self.threshold,
+            False
         )
 
 
 class JaccardSearchBestOnly(JaccardSearch):
     "A subclass of JaccardSearch that implements best-only."
+
     def collect(self, score, match):
         "Raise the threshold to the best match found so far."
         self.threshold = max(self.threshold, score)
         return True
+
+    def _as_rust(self):
+        """
+        Return a compatible Rust search function.
+
+        The Rust function duplicates the implementation of this class, since
+        there is no good way to call back into Python code without involving a
+        lot of machinery.
+        """
+
+        return rustcall(
+            lib.searchfn_new,
+            self.search_type.value,
+            self.threshold,
+            True
+        )
+
 
 
 # generic SearchResult tuple.


### PR DESCRIPTION
The main benefit of oxidizing `LinearIndex` is the ability to run in parallel (using `rayon`).
While parallelization is doable in Python, it involves a lot of pickling if using `multiprocessing`-like libraries.

Pulling bits from #1238, especially the FFI and delayed initialization ideas.

~15~ ~3~ ~2~ (before `find` implementation)
~17~ 7 failing tests during the `find` implementation, but... it is starting to work?

## TODO

- [x] implement `find` in Rust
- [ ] Implement `search`/`gather`?
- [ ] performance measures (nagging feeling it might be slower because it pulls `.signatures()` from the Rust layer)
- [ ] Implement a `new_with_paths` constructor that defers loading to Rust, especially for all the `--filelist` cases (places in the CLI that convert a list of files into a LinearIndex)