### PR TITLE
 [MRG] fix gather against signatures with abundances, in a new place.

### DIFF
--- a/src/sourmash/index.py
+++ b/src/sourmash/index.py
@@ -240,7 +240,7 @@ class Index(ABC):
         sr = result[0]
         match_mh = sr.signature.minhash
         scaled = max(query_mh.scaled, match_mh.scaled)
-        match_mh = match_mh.downsample(scaled=scaled)
+        match_mh = match_mh.downsample(scaled=scaled).flatten()
         query_mh = query_mh.downsample(scaled=scaled)
         intersect_mh = match_mh.intersection(query_mh)
 

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -2923,7 +2923,7 @@ def test_gather_abund_x_abund(runtmp, prefetch_gather, linear_gather):
     sig47 = utils.get_test_data('track_abund/47.fa.sig')
     sig63 = utils.get_test_data('track_abund/63.fa.sig')
 
-    runtmp.sourmash('gather', sig47, sig63)
+    runtmp.sourmash('gather', sig47, sig63, linear_gather, prefetch_gather)
 
     assert '2.5 Mbp       49.2%   48.3%       1.0    NC_011663.1' in runtmp.last_result.out
 


### PR DESCRIPTION
In https://github.com/dib-lab/sourmash/pull/1519, we fixed a bug #1518 introduced in #1370.

Unfortunately, I borked the test, and the fix wasn't tested with `--no-prefetch`. This PR fixes the tests in the old fix and then fixes the remaining bug.

@bluegenes @taylorreiter ready for review and merge!