### PR TITLE
[MRG] Add "&" and " | " option to Minhash intersection and Minhash merge

### DIFF
--- a/src/sourmash/index.py
+++ b/src/sourmash/index.py
@@ -242,7 +242,7 @@ class Index(ABC):
         scaled = max(query_mh.scaled, match_mh.scaled)
         match_mh = match_mh.downsample(scaled=scaled).flatten()
         query_mh = query_mh.downsample(scaled=scaled)
-        intersect_mh = match_mh.intersection(query_mh)
+        intersect_mh = match_mh & query_mh
 
         return [sr, intersect_mh]
 
@@ -623,7 +623,7 @@ class CounterGather:
 
         # calculate intersection of this "best match" with query.
         match_mh = match.minhash.downsample(scaled=scaled).flatten()
-        intersect_mh = cur_query_mh.intersection(match_mh)
+        intersect_mh = cur_query_mh & match_mh
         location = self.locations[dataset_id]
 
         # build result & return intersection

--- a/src/sourmash/minhash.py
+++ b/src/sourmash/minhash.py
@@ -602,13 +602,7 @@ class MinHash(RustObject):
         if not isinstance(other, MinHash):
             raise TypeError("can only add MinHash objects to MinHash objects!")
         self._methodcall(lib.kmerminhash_merge, other._get_objptr())
-
-#   | = merge
-    def __or__(self, other):
-        if not isinstance(other, MinHash):
-            raise TypeError("can only add MinHash objects to MinHash objects!")
-        self._methodcall(lib.kmerminhash_merge, other._get_objptr())
-
+    __or__ = merge
 
     def intersection(self, other):
         if not isinstance(other, MinHash):
@@ -618,17 +612,7 @@ class MinHash(RustObject):
 
         ptr = self._methodcall(lib.kmerminhash_intersection, other._get_objptr())
         return MinHash._from_objptr(ptr)
-
-#   & = intersection
-    def __and__(self, other):
-        if not isinstance(other, MinHash):
-            raise TypeError("can only intersect MinHash objects")
-        if self.track_abundance or other.track_abundance:
-            raise TypeError("can only intersect flat MinHash objects")
-
-        ptr = self._methodcall(lib.kmerminhash_intersection, other._get_objptr())
-        return MinHash._from_objptr(ptr)    
-
+    __and__ = intersection
 
     def set_abundances(self, values, clear=True):
         """Set abundances for hashes from ``values``, where

--- a/src/sourmash/minhash.py
+++ b/src/sourmash/minhash.py
@@ -603,6 +603,13 @@ class MinHash(RustObject):
             raise TypeError("can only add MinHash objects to MinHash objects!")
         self._methodcall(lib.kmerminhash_merge, other._get_objptr())
 
+#   | = merge
+    def __or__(self, other):
+        if not isinstance(other, MinHash):
+            raise TypeError("can only add MinHash objects to MinHash objects!")
+        self._methodcall(lib.kmerminhash_merge, other._get_objptr())
+
+
     def intersection(self, other):
         if not isinstance(other, MinHash):
             raise TypeError("can only intersect MinHash objects")
@@ -611,6 +618,17 @@ class MinHash(RustObject):
 
         ptr = self._methodcall(lib.kmerminhash_intersection, other._get_objptr())
         return MinHash._from_objptr(ptr)
+
+#   & = intersection
+    def __and__(self, other):
+        if not isinstance(other, MinHash):
+            raise TypeError("can only intersect MinHash objects")
+        if self.track_abundance or other.track_abundance:
+            raise TypeError("can only intersect flat MinHash objects")
+
+        ptr = self._methodcall(lib.kmerminhash_intersection, other._get_objptr())
+        return MinHash._from_objptr(ptr)    
+
 
     def set_abundances(self, values, clear=True):
         """Set abundances for hashes from ``values``, where

--- a/src/sourmash/minhash.py
+++ b/src/sourmash/minhash.py
@@ -591,6 +591,7 @@ class MinHash(RustObject):
         new_obj = self.to_mutable()
         new_obj += other
         return new_obj
+    __or__ = __add__
 
     def __iadd__(self, other):
         if not isinstance(other, MinHash):
@@ -602,7 +603,6 @@ class MinHash(RustObject):
         if not isinstance(other, MinHash):
             raise TypeError("can only add MinHash objects to MinHash objects!")
         self._methodcall(lib.kmerminhash_merge, other._get_objptr())
-    __or__ = merge
 
     def intersection(self, other):
         if not isinstance(other, MinHash):

--- a/src/sourmash/sbt_storage.py
+++ b/src/sourmash/sbt_storage.py
@@ -206,7 +206,7 @@ class ZipStorage(Storage):
             zf_names = set(self.zipfile.namelist())
             if buffer_names:
                 new_data = buffer_names - zf_names
-                duplicated = buffer_names.intersection(zf_names)
+                duplicated = buffer_names & zf_names
 
                 if duplicated:
                     # bad news, need to create new file...

--- a/src/sourmash/search.py
+++ b/src/sourmash/search.py
@@ -322,7 +322,7 @@ def gather_databases(query, counters, threshold_bp, ignore_abundance):
 
         # calculate intersection with query hashes:
         unique_intersect_bp = cmp_scaled * len(intersect_mh)
-        intersect_orig_mh = orig_query_mh.intersection(found_mh)
+        intersect_orig_mh = orig_query_mh & found_mh
         intersect_bp = cmp_scaled * len(intersect_orig_mh)
 
         # calculate fractions wrt first denominator - genome size
@@ -416,7 +416,7 @@ def prefetch_database(query, database, threshold_bp):
         db_mh = match.minhash.flatten().downsample(scaled=scaled)
 
         # calculate db match intersection with query hashes:
-        intersect_mh = query_mh.intersection(db_mh)
+        intersect_mh = query_mh & db_mh
         assert len(intersect_mh) >= threshold
 
         f_query_match = db_mh.contained_by(query_mh)

--- a/src/sourmash/sig/__main__.py
+++ b/src/sourmash/sig/__main__.py
@@ -297,7 +297,7 @@ def overlap(args):
     hashes_1 = set(sig1.minhash.hashes)
     hashes_2 = set(sig2.minhash.hashes)
 
-    num_common = len(hashes_1.intersection(hashes_2))
+    num_common = len(hashes_1 & hashes_2)
     disjoint_1 = len(hashes_1 - hashes_2)
     disjoint_2 = len(hashes_2 - hashes_1)
     num_union = len(hashes_1.union(hashes_2))

--- a/tests/test__minhash.py
+++ b/tests/test__minhash.py
@@ -1674,10 +1674,15 @@ def test_intersection_1_num():
     mh2.add_hash(2)
 
     mh3 = mh1.intersection(mh2)
-    print(set(mh3.hashes))
+    print("mh.intersection INTERSECTION HASHES:",set(mh3.hashes))
     assert len(mh3) == 1
     assert 0 in mh3.hashes
 
+    # test "&" operator
+    mh4 = mh1 & mh2
+    print("& INTERSECTION HASHES:", set(mh4.hashes))
+    assert len(mh4) == 1
+    assert 0 in mh4.hashes
 
 def test_intersection_2_scaled():
     mh1 = MinHash(0, 21, scaled=1)

--- a/tests/test_minhash.py
+++ b/tests/test_minhash.py
@@ -1902,7 +1902,7 @@ def test_add_is_symmetric():
 
 def test_or_equals_add():
     mh1 = MinHash(20, 21)
-    mh1.add_hash(5)  
+    mh1.add_hash(5)
     mh2 = MinHash(20, 21)
     mh2.add_hash(6)
     print("\n mh1 EQUALS ", mh1.hashes, "\n mh2 EQUALS", mh2.hashes)

--- a/tests/test_minhash.py
+++ b/tests/test_minhash.py
@@ -1878,7 +1878,7 @@ def test_merge_scaled():
     for k in mh2.hashes:
         assert k in mh3.hashes
 
-def add_is_symmetric():
+def test_add_is_symmetric():
     mh1 = MinHash(0, 21, scaled=100)
     mh2 = MinHash(0, 21, scaled=100)
 

--- a/tests/test_minhash.py
+++ b/tests/test_minhash.py
@@ -1679,11 +1679,14 @@ def test_intersection_1_num():
     assert len(mh3) == 1
     assert 0 in mh3.hashes
 
-    # test "&" operator
+def test_and_operator():
+    mh1 = MinHash(10, 21)
+    mh2 = MinHash(10, 21)
+
+    mh3 = mh1.intersection(mh2)
     mh4 = mh1 & mh2
     print("& INTERSECTION HASHES:", set(mh4.hashes))
-    assert len(mh4) == 1
-    assert 0 in mh4.hashes
+    assert mh3 == mh4
 
 def test_intersection_2_scaled():
     mh1 = MinHash(0, 21, scaled=1)
@@ -1865,12 +1868,8 @@ def test_merge_scaled():
     assert len(mh1) == 100
     assert len(mh2) == 100
 
-    # add is symmetric:
-    mh3 = mh1 + mh2
-    mh4 = mh2 + mh1
-    assert mh3 == mh4
-
     # merge contains all the things
+    mh3 = mh1 + mh2
     assert len(mh3) == 150
 
     # everything in either one is in union
@@ -1879,11 +1878,18 @@ def test_merge_scaled():
     for k in mh2.hashes:
         assert k in mh3.hashes
 
-def test_or_equals_and():
+def add_is_symmetric():
     mh1 = MinHash(0, 21, scaled=100)
     mh2 = MinHash(0, 21, scaled=100)
 
-    # add is eqivalent to "|"
+    mh3 = mh1 + mh2
+    mh4 = mh2 + mh1
+    assert mh3 == mh4
+
+def test_or_equals_add():
+    mh1 = MinHash(0, 21, scaled=100)
+    mh2 = MinHash(0, 21, scaled=100)
+
     mh3 = mh1 + mh2
     mh4 = mh1 | mh2
     assert mh3 == mh4

--- a/tests/test_minhash.py
+++ b/tests/test_minhash.py
@@ -1797,8 +1797,7 @@ def test_merge_abund():
     ret = mh1.merge(mh2)
     assert ret is None
 
-    ret= mh1 | mh2
-    assert ret is None
+    print("MH1 EQUALS ", mh1.hashes)
 
     hashcounts = mh1.hashes
     assert len(hashcounts) == 1
@@ -1870,6 +1869,10 @@ def test_merge_scaled():
     mh3 = mh1 + mh2
     mh4 = mh2 + mh1
     assert mh3 == mh4
+
+    # add is eqivalent to "|"
+    mh5 = mh1 | mh2
+    assert mh5 == mh3
 
     # merge contains all the things
     assert len(mh3) == 150

--- a/tests/test_minhash.py
+++ b/tests/test_minhash.py
@@ -1879,12 +1879,16 @@ def test_merge_scaled():
         assert k in mh3.hashes
 
 def test_add_is_symmetric():
-    mh1 = MinHash(0, 21, scaled=100)
-    mh2 = MinHash(0, 21, scaled=100)
-
+    mh1 = MinHash(20, 21)
+    mh1.add_hash(5)  
+    mh2 = MinHash(20, 21)
+    mh2.add_hash(6)
+    print("\n mh1 EQUALS ", mh1.hashes, "\n mh2 EQUALS", mh2.hashes)
     mh3 = mh1 + mh2
     mh4 = mh2 + mh1
+    print("\n mh3 EQUALS ", mh3.hashes, "\n mh4 EQUALS", mh4.hashes)
     assert mh3 == mh4
+
 
 def test_or_equals_add():
     mh1 = MinHash(0, 21, scaled=100)

--- a/tests/test_minhash.py
+++ b/tests/test_minhash.py
@@ -1889,7 +1889,7 @@ def test_merge_scaled():
 
 def test_add_is_symmetric():
     mh1 = MinHash(20, 21)
-    mh1.add_hash(5)  
+    mh1.add_hash(5)
     mh2 = MinHash(20, 21)
     mh2.add_hash(6)
     print("\n mh1 EQUALS ", mh1.hashes, "\n mh2 EQUALS", mh2.hashes)

--- a/tests/test_minhash.py
+++ b/tests/test_minhash.py
@@ -1900,13 +1900,16 @@ def test_add_is_symmetric():
     assert mh3
     assert mh3 == mh4
 
-
 def test_or_equals_add():
-    mh1 = MinHash(0, 21, scaled=100)
-    mh2 = MinHash(0, 21, scaled=100)
-
+    mh1 = MinHash(20, 21)
+    mh1.add_hash(5)  
+    mh2 = MinHash(20, 21)
+    mh2.add_hash(6)
+    print("\n mh1 EQUALS ", mh1.hashes, "\n mh2 EQUALS", mh2.hashes)
     mh3 = mh1 + mh2
     mh4 = mh1 | mh2
+    print("\n mh3 EQUALS ", mh3.hashes, "\n mh4 EQUALS", mh4.hashes)
+    assert mh3
     assert mh3 == mh4
 
 def test_max_containment():

--- a/tests/test_minhash.py
+++ b/tests/test_minhash.py
@@ -1682,7 +1682,7 @@ def test_intersection_1_num():
 def test_and_operator():
     mh1 = MinHash(20, 21)
     mh1.add_hash(5)
-    mh1.add_hash(6)  
+    mh1.add_hash(6)
     mh2 = MinHash(20, 21)
     mh2.add_hash(6)
     mh2.add_hash(7)

--- a/tests/test_minhash.py
+++ b/tests/test_minhash.py
@@ -1680,12 +1680,21 @@ def test_intersection_1_num():
     assert 0 in mh3.hashes
 
 def test_and_operator():
-    mh1 = MinHash(10, 21)
-    mh2 = MinHash(10, 21)
+    mh1 = MinHash(20, 21)
+    mh1.add_hash(5)
+    mh1.add_hash(6)  
+    mh2 = MinHash(20, 21)
+    mh2.add_hash(6)
+    mh2.add_hash(7)
+
+    print("\n \n mh1 EQUALS ", mh1.hashes, "\n mh2 EQUALS", mh2.hashes)
 
     mh3 = mh1.intersection(mh2)
     mh4 = mh1 & mh2
-    print("& INTERSECTION HASHES:", set(mh4.hashes))
+
+    print("\n Intersection hashes (mh3): ", mh3.hashes, "\n '&' hashes: (mh4)", mh4.hashes)
+
+    assert mh3
     assert mh3 == mh4
 
 def test_intersection_2_scaled():
@@ -1887,6 +1896,8 @@ def test_add_is_symmetric():
     mh3 = mh1 + mh2
     mh4 = mh2 + mh1
     print("\n mh3 EQUALS ", mh3.hashes, "\n mh4 EQUALS", mh4.hashes)
+    #if mh3 != 0, then it is "true", so it passes
+    assert mh3
     assert mh3 == mh4
 
 

--- a/tests/test_minhash.py
+++ b/tests/test_minhash.py
@@ -1797,6 +1797,9 @@ def test_merge_abund():
     ret = mh1.merge(mh2)
     assert ret is None
 
+    ret= mh1 | mh2
+    assert ret is None
+
     hashcounts = mh1.hashes
     assert len(hashcounts) == 1
     assert hashcounts[0] == 4

--- a/tests/test_minhash.py
+++ b/tests/test_minhash.py
@@ -1870,10 +1870,6 @@ def test_merge_scaled():
     mh4 = mh2 + mh1
     assert mh3 == mh4
 
-    # add is eqivalent to "|"
-    mh5 = mh1 | mh2
-    assert mh5 == mh3
-
     # merge contains all the things
     assert len(mh3) == 150
 
@@ -1883,6 +1879,14 @@ def test_merge_scaled():
     for k in mh2.hashes:
         assert k in mh3.hashes
 
+def test_or_equals_and():
+    mh1 = MinHash(0, 21, scaled=100)
+    mh2 = MinHash(0, 21, scaled=100)
+
+    # add is eqivalent to "|"
+    mh3 = mh1 + mh2
+    mh4 = mh1 | mh2
+    assert mh3 == mh4
 
 def test_max_containment():
     mh1 = MinHash(0, 21, scaled=1, track_abundance=False)


### PR DESCRIPTION
adds `&` operator option to minhash intersection, and `|` option to minhash merge (#1474 )
Fixes Issue #1479 
(replicate of pr #1523 that was removed due to github-branch mistakes)

