### PR TITLE
[MRG] unload data on iteration over SBT leaves

### DIFF
--- a/src/sourmash/sbt.py
+++ b/src/sourmash/sbt.py
@@ -1120,12 +1120,14 @@ class SBT(Index):
                 yield p.pos
                 p = self.parent(p.pos)
 
-    def leaves(self, with_pos=False):
+    def leaves(self, with_pos=False, unload_data=True):
         for pos, data in self._leaves.items():
             if with_pos:
                 yield (pos, data)
             else:
                 yield data
+            if unload_data:
+                data.unload()
 
     def combine(self, other):
         larger, smaller = self, other


### PR DESCRIPTION
In #1530, we observed high memory usage for `sourmash gather --linear` against indexed SBTs. This was caused by retention of loaded leaf nodes during the `SBT.signatures()` method call used by `--linear`. This PR calls `unload_data` after each leaf's signature is yielded by the `SBT.leaves()` method underlying `SBT.signatures()`.

## updated benchmarks for 45k indexed zipfile (SBT) with this PR:

|          | Time | Memory |
| -------- | -------- | -----------|
| no-linear/prefetch     | 10s     | 215mb       |
| no-linear/no-prefetch     | 22s     | 214mb       |
| **old** linear/prefetch     | 177s     | 1502mb       |
| **new** linear/prefetch     | 245s     | 81mb       |

## updated benchmarks for 280k indexed zipfile (SBT) with this PR:

|          | Time | Memory |
| -------- | -------- | -----------|
| no-linear/prefetch     | 4m 56s     | 1 GB       |
| no-linear/no-prefetch     | 1h 16m     | 1 GB       |
| **old** linear/prefetch     | 20m     | 8.8 GB       |
| **new** linear/prefetch     | 18m 46s     | 1 GB       |

---

Ready for review and merge @luizirber @bluegenes 