### PR TITLE
[MRG] fix SBT `FSStorage` to not create directory for .sbt.zip output

### DIFF
--- a/src/sourmash/sbt.py
+++ b/src/sourmash/sbt.py
@@ -577,7 +577,7 @@ class SBT(Index):
             backend = "FSStorage"
             name = os.path.basename(path[:-8])
             subdir = '.sbt.{}'.format(name)
-            storage_args = FSStorage("", subdir).init_args()
+            storage_args = FSStorage("", subdir, make_dirs=False).init_args()
             storage.save(subdir + "/", b"")
             storage.subdir = subdir
             index_filename = os.path.abspath(path)

--- a/src/sourmash/sbt_storage.py
+++ b/src/sourmash/sbt_storage.py
@@ -37,13 +37,14 @@ class Storage(ABC):
 
 class FSStorage(Storage):
 
-    def __init__(self, location, subdir):
+    def __init__(self, location, subdir, make_dirs=True):
         self.location = location
         self.subdir = subdir
 
-        fullpath = os.path.join(location, subdir)
-        if not os.path.exists(fullpath):
-            os.makedirs(fullpath)
+        if make_dirs:
+            fullpath = os.path.join(location, subdir)
+            if not os.path.exists(fullpath):
+                os.makedirs(fullpath)
 
     def init_args(self):
         return {'path': self.subdir}

--- a/tests/test_sbt.py
+++ b/tests/test_sbt.py
@@ -783,8 +783,9 @@ def test_gather_single_return(c):
     assert results[0][0] == 1.0
 
 
-@utils.in_tempdir
-def test_sbt_protein_command_index(c):
+def test_sbt_protein_command_index(runtmp):
+    c = runtmp
+
     # test command-line creation of SBT database with protein sigs
     sigfile1 = utils.get_test_data('prot/protein/GCA_001593925.1_ASM159392v1_protein.faa.gz.sig')
     sigfile2 = utils.get_test_data('prot/protein/GCA_001593935.1_ASM159393v1_protein.faa.gz.sig')
@@ -793,6 +794,9 @@ def test_sbt_protein_command_index(c):
 
     c.run_sourmash('index', db_out, sigfile1, sigfile2,
                    '--scaled', '100', '-k', '19', '--protein')
+
+    # check to make sure .sbt.protein directory doesn't get created
+    assert not os.path.exists(c.output('.sbt.protein'))
 
     db2 = load_sbt_index(db_out)
 


### PR DESCRIPTION
When you create an xyz.sbt.zip with `sourmash index`, a `.sbt.xyz` directory is created too - this is a holdover from before SBT zipfiles. This PR updates the `FSStorage` constructor to take an option to not make that subdirectory.

Fixes https://github.com/dib-lab/sourmash/issues/1351

Ready for review @luizirber @bluegenes 