### PR TITLE
[WIP] improve identifier & taxonomy parsing for `lca index`

### DIFF
--- a/src/sourmash/cli/lca/index.py
+++ b/src/sourmash/cli/lca/index.py
@@ -42,7 +42,11 @@ def subparser(subparsers):
     )
     subparser.add_argument(
         '--split-identifiers', action='store_true',
-        help='split names in signatures on whitspace and period'
+        help='split names in signatures on whitespace'
+    )
+    subparser.add_argument(
+        '--keep-identifier-versions', action='store_true',
+        help='do not remove accession versions'
     )
     subparser.add_argument('-f', '--force', action='store_true')
     subparser.add_argument(
@@ -51,6 +55,10 @@ def subparser(subparsers):
     subparser.add_argument(
         '--require-taxonomy', action='store_true',
         help='ignore signatures with no taxonomy entry'
+    )
+    subparser.add_argument(
+        '--fail-on-missing-taxonomy', action='store_true',
+        help='fail quickly if taxonomy is not available for an identifier',
     )
 
 

--- a/src/sourmash/lca/command_index.py
+++ b/src/sourmash/lca/command_index.py
@@ -15,8 +15,10 @@ from .lca_db import LCA_Database
 from sourmash.sourmash_args import DEFAULT_LOAD_K
 
 
-def load_taxonomy_assignments(filename, delimiter=',', start_column=2,
-                              use_headers=True, force=False):
+def load_taxonomy_assignments(filename, *, delimiter=',', start_column=2,
+                              use_headers=True, force=False,
+                              split_identifiers=False,
+                              keep_identifier_versions=False):
     """
     Load a taxonomy assignment spreadsheet into a dictionary.
 
@@ -64,6 +66,13 @@ def load_taxonomy_assignments(filename, delimiter=',', start_column=2,
 
             ident = lineage[0][1]
             lineage = lineage[1:]
+
+            # fold, spindle, and mutilate ident?
+            if split_identifiers:
+                ident = ident.split(' ')[0]
+
+                if not keep_identifier_versions:
+                    ident = ident.split('.')[0]
 
             # clean lineage of null names, replace with 'unassigned'
             lineage = [ (a, lca_utils.filter_null(b)) for (a,b) in lineage ]
@@ -157,7 +166,10 @@ def index(args):
                                                delimiter=delimiter,
                                                start_column=args.start_column,
                                                use_headers=not args.no_headers,
-                                               force=args.force)
+                                               force=args.force,
+                                               split_identifiers=args.split_identifiers,
+                                               keep_identifier_versions=args.keep_identifier_versions
+    )
 
     notify('{} distinct identities in spreadsheet out of {} rows.',
            len(assignments), num_rows)

--- a/src/sourmash/lca/command_index.py
+++ b/src/sourmash/lca/command_index.py
@@ -210,16 +210,24 @@ def index(args):
             else:
                 ident = sig.filename
 
+            orig_ident = ident
             if args.split_identifiers: # hack for NCBI-style names, etc.
                 # split on space...
                 ident = ident.split(' ')[0]
-                # ...and on period.
-                ident = ident.split('.')[0]
+
+                if not args.keep_identifier_versions:
+                    # ...and on period.
+                    ident = ident.split('.')[0]
 
             lineage = assignments.get(ident)
 
             # punt if no lineage and --require-taxonomy
             if lineage is None and args.require_taxonomy:
+                if args.fail_on_missing_taxonomy:
+                    notify(f"ERROR: no taxonomy found for identifier '{ident}'")
+                    if args.split_identifiers:
+                        notify(f"(Identifier extracted from name: '{orig_ident})')")
+                    sys.exit(-1)
                 debug('(skipping, because --require-taxonomy was specified)')
                 n_skipped += 1
                 continue


### PR DESCRIPTION
As our `sourmash_databases` fu continues to evolve, we are doing a better job of providing versioned accessions on signature names, but this is also changing the requirements for taxonomy spreadsheets.

This PR provides a bunch of options to `lca index` to improve the UX and slightly improve the overall situation, while also highlighting how silly the current code and UX is :).

