### PR TITLE
[MRG] empty zipfile collections should not raise assertion errors when loaded 

### DIFF
--- a/src/sourmash/sourmash_args.py
+++ b/src/sourmash/sourmash_args.py
@@ -333,7 +333,7 @@ def _load_database(filename, traverse_yield_all, *, cache_size=None):
         raise ValueError(f"Error while reading signatures from '{filename}'.")
 
     if loaded:                  # this is a bit redundant but safe > sorry
-        assert db
+        assert db is not None
 
     return db
 

--- a/tests/test_sourmash_args.py
+++ b/tests/test_sourmash_args.py
@@ -202,3 +202,12 @@ def test_save_signatures_to_location_1_dirout_duplicate(runtmp):
     assert ss2 in saved
     assert ss47 in saved
     assert len(saved) == 4
+
+
+def test_load_empty_zipfile(runtmp):
+    outloc = runtmp.output('empty.zip')
+    with sourmash_args.SaveSignaturesToLocation(outloc) as save_sig:
+        pass
+
+    sigiter = sourmash.load_file_as_signatures(outloc)
+    assert list(sigiter) == []


### PR DESCRIPTION
Over in https://github.com/dib-lab/charcoal/pull/171, @taylorreiter had to add checks for AssertionError in `load_file_as_signatures(...)`. It turns out this is because empty zipfile collections evaluate to empty, and there is a better-safe-than-sorry assertion in `_load_database` that checks for empty databases.

This PR changes that assertion to checking for unset database objections (`db is None`) and adds a test.

Fixes https://github.com/dib-lab/sourmash/issues/1545

@taylorreiter @bluegenes ready for review!
