### PR TITLE
[MRG] Provide a .copy() method for both `SourmashSignature()` and `MinHash`

### DIFF
--- a/src/sourmash/minhash.py
+++ b/src/sourmash/minhash.py
@@ -222,6 +222,8 @@ class MinHash(RustObject):
         a.merge(self)
         return a
 
+    copy = __copy__
+
     def __getstate__(self):
         "support pickling via __getstate__/__setstate__"
         return (
@@ -749,3 +751,4 @@ class FrozenMinHash(MinHash):
 
     def __copy__(self):
         return self
+    copy = __copy__

--- a/src/sourmash/signature.py
+++ b/src/sourmash/signature.py
@@ -194,6 +194,7 @@ class SourmashSignature(RustObject):
 
     def __copy__(self):
         mh=self.minhash
+        mh = mh.to_frozen()
         a = SourmashSignature(
             mh,
             name=self.name,

--- a/src/sourmash/signature.py
+++ b/src/sourmash/signature.py
@@ -192,6 +192,16 @@ class SourmashSignature(RustObject):
             ),
         )
 
+    def __copy__(self):
+        a = SourmashSignature(
+            mh=self.minhash,
+            self.name,
+            filename=self.filename,
+        )
+        a.merge(self)
+        return a
+
+    copy = __copy__
 
 def _detect_input_type(data):
     """\

--- a/src/sourmash/signature.py
+++ b/src/sourmash/signature.py
@@ -5,7 +5,7 @@ Save and load MinHash sketches in a JSON format, along with some metadata.
 import sys
 import os
 import weakref
-import copy
+from sourmash.signature import SourmashSignature
 from enum import Enum
 
 from .logging import error
@@ -194,12 +194,12 @@ class SourmashSignature(RustObject):
         )
 
     def __copy__(self):
+        mh=self.minhash
         a = SourmashSignature(
-            mh=self.minhash,
-            self.name,
+            mh,
+            name=self.name,
             filename=self.filename,
         )
-        a.merge(self)
         return a
 
     copy = __copy__

--- a/src/sourmash/signature.py
+++ b/src/sourmash/signature.py
@@ -193,7 +193,7 @@ class SourmashSignature(RustObject):
         )
 
     def __copy__(self):
-        mh=self.minhash
+        mh = self.minhash
         mh = mh.to_frozen()
         a = SourmashSignature(
             mh,

--- a/src/sourmash/signature.py
+++ b/src/sourmash/signature.py
@@ -5,7 +5,6 @@ Save and load MinHash sketches in a JSON format, along with some metadata.
 import sys
 import os
 import weakref
-from sourmash.signature import SourmashSignature
 from enum import Enum
 
 from .logging import error

--- a/src/sourmash/signature.py
+++ b/src/sourmash/signature.py
@@ -5,6 +5,7 @@ Save and load MinHash sketches in a JSON format, along with some metadata.
 import sys
 import os
 import weakref
+import copy
 from enum import Enum
 
 from .logging import error

--- a/tests/test_minhash.py
+++ b/tests/test_minhash.py
@@ -567,6 +567,15 @@ def test_copy(track_abundance):
     assert a == b
 
 
+def test_frozen_copy(track_abundance):
+    a = MinHash(20, 21, track_abundance=track_abundance)
+    a.add_hash(5)
+    b = a.to_frozen()
+    assert 5 in b.hashes
+    a.add_hash(6)
+    assert 6 not in b.hashes
+
+
 def test_mh_copy(track_abundance):
     a = MinHash(20, 10, track_abundance=track_abundance)
 

--- a/tests/test_minhash.py
+++ b/tests/test_minhash.py
@@ -571,7 +571,7 @@ def test_copy(track_abundance):
 def test_frozen_copy(track_abundance):
     a = MinHash(20, 21, track_abundance=track_abundance)
     a.add_hash(5)
-    b = a.to_frozen()
+    b = a.copy()
     assert 5 in b.hashes
     a.add_hash(6)
     assert 6 not in b.hashes

--- a/tests/test_minhash.py
+++ b/tests/test_minhash.py
@@ -559,6 +559,14 @@ def test_similarity_1(track_abundance):
     assert round(b.similarity(b), 3) == 1.0
 
 
+def test_copy(track_abundance):
+    a = MinHash(20, 21, track_abundance=track_abundance)
+    a.add_hash(5)
+    a.add_hash(6)
+    b = a.copy()
+    assert a == b
+
+
 def test_mh_copy(track_abundance):
     a = MinHash(20, 10, track_abundance=track_abundance)
 

--- a/tests/test_minhash.py
+++ b/tests/test_minhash.py
@@ -562,9 +562,10 @@ def test_similarity_1(track_abundance):
 def test_copy(track_abundance):
     a = MinHash(20, 21, track_abundance=track_abundance)
     a.add_hash(5)
-    a.add_hash(6)
     b = a.copy()
     assert a == b
+    a.add_hash(6)
+    assert a != b
 
 
 def test_frozen_copy(track_abundance):

--- a/tests/test_signature.py
+++ b/tests/test_signature.py
@@ -9,6 +9,14 @@ import sourmash_tst_utils as utils
 from sourmash import MinHash
 
 
+def test_sig_copy(track_abundance):
+    e = MinHash(n=1, ksize=20, track_abundance=track_abundance)
+    e.add_kmer("AT" * 10)
+    sig1 = SourmashSignature(e, name='foo')
+    f = e.copy()
+    assert e == f
+
+
 def test_compare(track_abundance):
     # same content, same name -> equal
     e = MinHash(n=1, ksize=20, track_abundance=track_abundance)

--- a/tests/test_signature.py
+++ b/tests/test_signature.py
@@ -40,11 +40,11 @@ def test_sig_copy_frozen_mutable(track_abundance):
     e = MinHash(n=1, ksize=20, track_abundance=track_abundance)
     e.add_kmer("AT" * 10)
     sig1 = SourmashSignature(e, name='foo')
-    sig1.minhash.to_mutable()
+    sig1.minhash = sig1.minhash.to_mutable()
     sig2 = sig1.copy()
     assert sig1 == sig2
     with pytest.raises(TypeError) as e:
-        sig1.minhash.add_hash(5)
+        sig2.minhash.add_hash(5)
     assert 'FrozenMinHash does not support modification' in str(e.value)
 
 

--- a/tests/test_signature.py
+++ b/tests/test_signature.py
@@ -9,12 +9,43 @@ import sourmash_tst_utils as utils
 from sourmash import MinHash
 
 
+def test_minhash_copy(track_abundance):
+    e = MinHash(n=1, ksize=20, track_abundance=track_abundance)
+    e.add_kmer("AT" * 10)
+    sig = SourmashSignature(e, name='foo')
+    f = e.copy()
+    assert e == f
+
+
 def test_sig_copy(track_abundance):
     e = MinHash(n=1, ksize=20, track_abundance=track_abundance)
     e.add_kmer("AT" * 10)
     sig1 = SourmashSignature(e, name='foo')
-    f = e.copy()
-    assert e == f
+    sig2 = sig1.copy()
+    assert sig1 == sig2
+
+
+def test_sig_copy_frozen(track_abundance):
+    e = MinHash(n=1, ksize=20, track_abundance=track_abundance)
+    e.add_kmer("AT" * 10)
+    sig1 = SourmashSignature(e, name='foo')
+    sig2 = sig1.copy()
+    assert sig1 == sig2
+    with pytest.raises(TypeError) as e:
+        sig2.minhash.add_hash(5)
+    assert 'FrozenMinHash does not support modification' in str(e.value)
+
+
+def test_sig_copy_frozen_mutable(track_abundance):
+    e = MinHash(n=1, ksize=20, track_abundance=track_abundance)
+    e.add_kmer("AT" * 10)
+    sig1 = SourmashSignature(e, name='foo')
+    sig1.minhash.to_mutable()
+    sig2 = sig1.copy()
+    assert sig1 == sig2
+    with pytest.raises(TypeError) as e:
+        sig1.minhash.add_hash(5)
+    assert 'FrozenMinHash does not support modification' in str(e.value)
 
 
 def test_compare(track_abundance):


### PR DESCRIPTION
Partly fixes #1485 

Done:
- define `__copy__(...)` and `copy(...)` methods on `MinHash` subclasses in `src/sourmash/minhash.py`
- define `__copy__(...)` and `copy(...)` methods on `SourmashSignature` in `src/sourmash/signature.py`
- write tests in `tests/test_minhash.py`
- write tests in `tests/test_signature.py`