### PR TITLE
[MRG] Updates for coverage tracking

### DIFF
--- a/doc/api-example.md
+++ b/doc/api-example.md
@@ -596,8 +596,8 @@ Now, let's load in all of the signatures from the test directory:
 ...    hashes_inserted = db.insert(sig)
 ...    print(f"Inserted {hashes_inserted} hashes into db.")
 Inserted 493 hashes into db.
-Inserted 525 hashes into db.
 Inserted 490 hashes into db.
+Inserted 525 hashes into db.
 
 ```
 

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://github.com/nmattia/niv",
         "owner": "nmattia",
         "repo": "niv",
-        "rev": "af958e8057f345ee1aca714c1247ef3ba1c15f5e",
-        "sha256": "1qjavxabbrsh73yck5dcq8jggvh3r2jkbr6b5nlz5d9yrqm9255n",
+        "rev": "1819632b5823e0527da28ad82fecd6be5136c1e9",
+        "sha256": "08jz17756qchq0zrqmapcm33nr4ms9f630mycc06i6zkfwl5yh5i",
         "type": "tarball",
-        "url": "https://github.com/nmattia/niv/archive/af958e8057f345ee1aca714c1247ef3ba1c15f5e.tar.gz",
+        "url": "https://github.com/nmattia/niv/archive/1819632b5823e0527da28ad82fecd6be5136c1e9.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e62feb3bf4a603e26755238303bda0c24651e155",
-        "sha256": "1gkamm044jrksjrisr7h9grg8p2y6rk01x6391asrx988hm2rh9s",
+        "rev": "84aa23742f6c72501f9cc209f29c438766f5352d",
+        "sha256": "0h7xl6q0yjrbl9vm3h6lkxw692nm8bg3wy65gm95a2mivhrdjpxp",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/e62feb3bf4a603e26755238303bda0c24651e155.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/84aa23742f6c72501f9cc209f29c438766f5352d.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "rust-overlay": {
@@ -29,10 +29,10 @@
         "homepage": null,
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "d8efe70dc561c4bea0b7bf440d36ce98c497e054",
-        "sha256": "0hdj5d635dq6zwj8d4ady1kyl9mwmsxvy6vqyd3xq0p2w18ffi4r",
+        "rev": "7368784b67f963508b67064ee758537b7c8e40c8",
+        "sha256": "1sr0lsk5m6c0dqp3429c0fj0picrvsaw1hjn6nd83pzxm54g7fcr",
         "type": "tarball",
-        "url": "https://github.com/oxalica/rust-overlay/archive/d8efe70dc561c4bea0b7bf440d36ce98c497e054.tar.gz",
+        "url": "https://github.com/oxalica/rust-overlay/archive/7368784b67f963508b67064ee758537b7c8e40c8.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,8 +55,8 @@ where = src
 # this syntax may change in the future
 [options.extras_require]
 test =
-    pytest>=6
-    pytest-cov<2.6
+    pytest~=6.2.4
+    pytest-cov~=2.12
     recommonmark
     hypothesis
 demo =

--- a/setup.cfg
+++ b/setup.cfg
@@ -94,9 +94,6 @@ norecursedirs =
     .tox
     .asv
     .eggs
-python_files =
-    src/sourmash/*.py
-    tests/*.py
 testpaths =
     tests
     doc

--- a/src/sourmash/sourmash_args.py
+++ b/src/sourmash/sourmash_args.py
@@ -137,7 +137,7 @@ def traverse_find_sigs(filenames, yield_all_files=False):
         # filename is a directory -- traverse beneath!
         elif os.path.isdir(filename):
             for root, dirs, files in os.walk(filename):
-                for name in files:
+                for name in sorted(files):
                     fullname = os.path.join(root, name)
                     if yield_all_files or _check_suffix(fullname, endings):
                         yield fullname

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ skip_missing_interpreters = true
 description = run the tests with pytest under {basepython}
 setenv =
     PIP_DISABLE_VERSION_CHECK = 1
-    COVERAGE_FILE = {toxworkdir}/.coverage.{envname}
+    COVERAGE_FILE = {env:COVERAGE_FILE:{toxworkdir}/.coverage.{envname}}
     VIRTUALENV_NO_DOWNLOAD = 1
     PIP_EXTRA_INDEX_URL = https://antocuni.github.io/pypy-wheels/manylinux2010
 passenv =
@@ -33,18 +33,14 @@ passenv =
     PYTEST_*
     PIP_CACHE_DIR
     CI
-    TRAVIS
-    TRAVIS_*
     PYTHONDEVMODE
 deps =
-    pip>=19.3.1
+    pip >= 19.3.1
 extras =
     test
     storage
-changedir = tests
 commands = pytest \
            --cov "{envsitepackagesdir}/sourmash" \
-           --cov . \
            --cov-config "{toxinidir}/tox.ini" \
            --cov-report= \
            --junitxml {toxworkdir}/junit.{envname}.xml \
@@ -58,7 +54,6 @@ deps =
 [testenv:hypothesis]
 commands = pytest \
            --cov "{envsitepackagesdir}/sourmash" \
-           --cov . \
            --cov-config "{toxinidir}/tox.ini" \
            --cov-report= \
            --junitxml {toxworkdir}/junit.{envname}.xml \
@@ -72,7 +67,6 @@ deps =
   khmer
 commands = pytest \
            --cov "{envsitepackagesdir}/sourmash" \
-           --cov . \
            --cov-config "{toxinidir}/tox.ini" \
            --cov-report= \
            --junitxml {toxworkdir}/junit.{envname}.xml \
@@ -84,7 +78,6 @@ deps =
   -e git+https://github.com/dib-lab/khmer.git#egg=khmer
 commands = pytest \
            --cov "{envsitepackagesdir}/sourmash" \
-           --cov . \
            --cov-config "{toxinidir}/tox.ini" \
            --cov-report= \
            --junitxml {toxworkdir}/junit.{envname}.xml \
@@ -149,9 +142,9 @@ passenv = {[testenv]passenv}
           DIFF_AGAINST
 setenv = COVERAGE_FILE={toxworkdir}/.coverage
 commands = coverage combine
-           coverage report -i -m
-           coverage xml -i -o {toxworkdir}/coverage.xml
-           coverage html -i -d {toxworkdir}/htmlcov
+           coverage report -m
+           coverage xml -o {toxworkdir}/coverage.xml
+           coverage html -d {toxworkdir}/htmlcov
            diff-cover --compare-branch {env:DIFF_AGAINST:origin/latest} {toxworkdir}/coverage.xml
 depends = py39, py38, py37, pypy3
 parallel_show_output = True

--- a/tox.ini
+++ b/tox.ini
@@ -142,9 +142,9 @@ passenv = {[testenv]passenv}
           DIFF_AGAINST
 setenv = COVERAGE_FILE={toxworkdir}/.coverage
 commands = coverage combine
-           coverage report -m
-           coverage xml -o {toxworkdir}/coverage.xml
-           coverage html -d {toxworkdir}/htmlcov
+           coverage report -i -m
+           coverage xml -i -o {toxworkdir}/coverage.xml
+           coverage html -i -d {toxworkdir}/htmlcov
            diff-cover --compare-branch {env:DIFF_AGAINST:origin/latest} {toxworkdir}/coverage.xml
 depends = py39, py38, py37, pypy3
 parallel_show_output = True


### PR DESCRIPTION
This turned out to be an adventure:

- Updating `pytest-cov` version (we are using an old one) because the old one is triggering `INTERNALERROR` in pytest :grimacing: 
- This led to updates to tox configuration (to track coverage properly) and `pytest`, including adding back the missing `doc/` tests
- Which showed that one test was failing, because it depends on the order of the output (fixed with a `sorted()` call)

Also updates nix files (`niv update`), so we have updated versions when using Nix for development.