### PR TITLE
add util script to take output of tax and format for krona viz

### DIFF
--- a/src/sourmash/tax/tax_utils.py
+++ b/src/sourmash/tax/tax_utils.py
@@ -88,3 +88,22 @@ def find_missing_identities(gather_results, tax_assign):
 
     print(f'of {len(gather_results)}, missed {n_missed} lineage assignments.')
     return n_missed, ident_missed
+
+def format_for_krona(rank, csv_in, tsv_out):
+    rank = rank.lower()
+    krona_results = [('fraction', 'superkingdom', "phylum", "class", "order", "family", "genus", "species")]
+    if rank not in krona_results[0][1:]:
+        raise ValueError(f"Rank {rank} not present in header!")
+        
+    summarize_tax_results = csv_in
+    with open(summarize_tax_results, 'r') as fp:
+        r = csv.DictReader(fp)
+        for n, row in enumerate(r):
+            if row["rank"] == rank:
+                lineage = row["lineage"].split(";")
+                krona_results.append((row["fraction"], *lineage))
+    
+    with open(tsv_out, 'w', newline='') as f_output:
+        tsv_output = csv.writer(f_output, delimiter='\t')
+        for row in krona_results:
+            tsv_output.writerow(row)


### PR DESCRIPTION
The included script will take a `sourmash tax summarize` output file like:

```
rank,fraction,lineage
superkingdom,0.131,d__Bacteria
phylum,0.073,d__Bacteria;p__Bacteroidota
phylum,0.058,d__Bacteria;p__Proteobacteria
class,0.073,d__Bacteria;p__Bacteroidota;c__Bacteroidia
class,0.058,d__Bacteria;p__Proteobacteria;c__Gammaproteobacteria
order,0.073,d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Bacteroidales
order,0.058,d__Bacteria;p__Proteobacteria;c__Gammaproteobacteria;o__Enterobacterales
family,0.073,d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Bacteroidales;f__Bacteroidaceae
family,0.058,d__Bacteria;p__Proteobacteria;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae
genus,0.058,d__Bacteria;p__Proteobacteria;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Escherichia
genus,0.057,d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Bacteroidales;f__Bacteroidaceae;g__Prevotella
genus,0.016,d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Bacteroidales;f__Bacteroidaceae;g__Phocaeicola
species,0.058,d__Bacteria;p__Proteobacteria;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Escherichia;s__Escherichia coli
species,0.057,d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Bacteroidales;f__Bacteroidaceae;g__Prevotella;s__Prevotella copri
species,0.016,d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Bacteroidales;f__Bacteroidaceae;g__Phocaeicola;s__Phocaeicola vulgatus
```
and format it for use by krona's `ktImportText` that creates a krona html plot


