### PR TITLE
[WIP] Replace milksnake with setuptools-rust

### DIFF
--- a/.github/workflows/asv.yml
+++ b/.github/workflows/asv.yml
@@ -22,10 +22,14 @@ jobs:
         git checkout latest
         git checkout -
 
-    - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+    - uses: conda-incubator/setup-miniconda@v2
       with:
-        python-version: 3.7
+        python-version: 3.9
+        mamba-version: "*"
+        miniforge-variant: Mambaforge
+        use-mamba: true
+        channels: conda-forge,bioconda,defaults
+        channel-priority: true
 
     - uses: actions-rs/toolchain@v1
       with:
@@ -35,7 +39,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install tox
+        pip install tox-conda
 
     - name: Runs benchmarks against latest
       run: tox -e asv

--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,7 @@ sourmash.egg-info
 src/sourmash/version.py
 *.DS_Store
 .tox
-src/sourmash/_lowlevel*.py
+src/sourmash/_lowlevel__*.py
 .env
 Pipfile
 Pipfile.lock

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -5,15 +5,16 @@
     "repo": ".",
     "branches": ["latest"],
     "dvcs": "git",
-    "environment_type": "virtualenv",
-    "pythons": ["3.7"],
+    "environment_type": "conda",
+    "pythons": ["3.9"],
     "env_dir": ".asv/env",
     "results_dir": ".asv/results",
     "html_dir": ".asv/html",
     "build_cache_size": 8,
+    "conda_channels": ["conda-forge", "bioconda", "defaults"],
     "build_command": [
-      "python -m pip install 'setuptools_scm[toml]>=4,<6' setuptools_rust cffi>=1.14.0",
-      "python setup.py build",
-      "PIP_NO_BUILD_ISOLATION=false python -mpip wheel --no-deps --no-index -w {build_cache_dir} {build_dir}"
+       "python -m pip install 'setuptools_scm[toml]>=4,<6' setuptools_rust cffi>=1.14.0",
+       "python setup.py build -j4",
+       "PIP_NO_BUILD_ISOLATION=false python -mpip wheel --no-deps --no-index -w {build_cache_dir} {build_dir}"
     ]
 }

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -12,7 +12,7 @@
     "html_dir": ".asv/html",
     "build_cache_size": 8,
     "build_command": [
-      "python -m pip install 'setuptools_scm[toml]>=4,<6' milksnake",
+      "python -m pip install 'setuptools_scm[toml]>=4,<6' setuptools_rust",
       "python setup.py build",
       "PIP_NO_BUILD_ISOLATION=false python -mpip wheel --no-deps --no-index -w {build_cache_dir} {build_dir}"
     ]

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -12,7 +12,7 @@
     "html_dir": ".asv/html",
     "build_cache_size": 8,
     "build_command": [
-      "python -m pip install 'setuptools_scm[toml]>=4,<6' setuptools_rust",
+      "python -m pip install 'setuptools_scm[toml]>=4,<6' setuptools_rust cffi>=1.14.0",
       "python setup.py build",
       "PIP_NO_BUILD_ISOLATION=false python -mpip wheel --no-deps --no-index -w {build_cache_dir} {build_dir}"
     ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [
     "setuptools_scm_git_archive",
     "setuptools_rust",
     "wheel >= 0.29.0",
-    "cffi>=1.0.0",
+    "cffi>=1.14.0",
 ]
 build-backend = 'setuptools.build_meta'
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,9 @@ requires = [
     "setuptools >= 48",
     "setuptools_scm[toml] >= 4, <6",
     "setuptools_scm_git_archive",
-    "milksnake",
+    "setuptools_rust",
     "wheel >= 0.29.0",
+    "cffi>=1.0.0",
 ]
 build-backend = 'setuptools.build_meta'
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -80,10 +80,6 @@ all =
     %(doc)s
     %(storage)s
 
-[options.entry_points]
-console_scripts =
-    sourmash = sourmash.__main__:main
-
 [tool:pytest]
 addopts =
     --doctest-glob='doc/*.md'

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,14 @@ DEBUG_BUILD = True if os.environ.get("SOURMASH_DEBUG") == "1" else None
 
 setup(
   package_dir={"": "src"},
+  entry_points={
+    'console_scripts': [
+      'sourmash = sourmash.__main__:main'
+    ],
+    'distutils.setup_keywords': [
+      'universal_wheel = sourmash.dist:universal_wheel',
+    ],
+  },
   rust_extensions=[
     RustExtension("sourmash._lowlevel__lib",
                   py_limited_api="auto",
@@ -20,4 +28,5 @@ setup(
                   ),
   ],
   cffi_modules=["src/sourmash/ffi_build.py:ffibuilder"],
+  universal_wheel=True
 )

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,13 @@
+import os
+
 from setuptools import setup
 from setuptools_rust import RustExtension, Binding
+
+
+# "None" will use setuptools_rust autodetection
+# (debug for develop, release for install)
+DEBUG_BUILD = True if os.environ.get("SOURMASH_DEBUG") == "1" else None
+
 
 setup(
   package_dir={"": "src"},
@@ -7,7 +15,9 @@ setup(
     RustExtension("sourmash._lowlevel__lib",
                   py_limited_api="auto",
                   path="src/core/Cargo.toml",
-                  binding=Binding.NoBinding),
+                  binding=Binding.NoBinding,
+                  debug=DEBUG_BUILD,
+                  ),
   ],
   cffi_modules=["src/sourmash/ffi_build.py:ffibuilder"],
 )

--- a/src/core/src/ffi/mod.rs
+++ b/src/core/src/ffi/mod.rs
@@ -1,6 +1,6 @@
 //! # Foreign Function Interface for calling sourmash from a C API
 //!
-//! Primary client for now is the Python version, using CFFI and milksnake.
+//! Primary client for now is the Python version, using CFFI.
 #![allow(clippy::missing_safety_doc)]
 
 #[macro_use]

--- a/src/sourmash/_lowlevel.py
+++ b/src/sourmash/_lowlevel.py
@@ -1,0 +1,7 @@
+__all__ = ['lib', 'ffi']
+
+import os
+from sourmash._lowlevel__ffi import ffi
+
+lib = ffi.dlopen(os.path.join(os.path.dirname(__file__), '_lowlevel__lib.abi3.so'), 2)
+del os

--- a/src/sourmash/dist.py
+++ b/src/sourmash/dist.py
@@ -1,0 +1,24 @@
+try:
+    from wheel.bdist_wheel import bdist_wheel
+except ImportError:
+    bdist_wheel = None
+
+
+def universal_wheel(dist, attr, value):
+    value = getattr(dist, 'universal_wheel', None)
+    if value is None:
+        dist.universal_wheel = True
+
+    base_bdist_wheel = dist.cmdclass.get('bdist_wheel', bdist_wheel)
+
+    if base_bdist_wheel is None:
+        return
+
+    class UniversalBdistWheel(base_bdist_wheel):
+        def get_tag(self):
+            rv = base_bdist_wheel.get_tag(self)
+            if not dist.universal_wheel:
+                return rv
+            return ('py3', 'none',) + rv[2:]
+
+    dist.cmdclass['bdist_wheel'] = UniversalBdistWheel

--- a/src/sourmash/ffi_build.py
+++ b/src/sourmash/ffi_build.py
@@ -1,0 +1,16 @@
+import re
+import pathlib
+
+import cffi
+
+_directive_re = re.compile(r'^\s*#.*?$(?m)')
+
+header = (pathlib.Path(__file__).parent.parent.parent / pathlib.Path("include/sourmash.h")).read_text()
+header = _directive_re.sub('', header)
+
+ffibuilder = cffi.FFI()
+ffibuilder.set_source("sourmash._lowlevel__ffi", None)
+ffibuilder.cdef(header)
+
+if __name__ == "__main__":
+    ffibuilder.compile()

--- a/tox.ini
+++ b/tox.ini
@@ -88,8 +88,6 @@ commands = pytest \
 description = run asv for benchmarking (compare current commit with latest)
 deps =
   asv==0.4.2
-  virtualenv==16.7.9
-  setuptools >= 46.1
 changedir = {toxinidir}
 commands =
   asv machine --yes

--- a/tox.ini
+++ b/tox.ini
@@ -89,6 +89,7 @@ description = run asv for benchmarking (compare current commit with latest)
 deps =
   asv==0.4.2
   virtualenv==16.7.9
+  setuptools >= 46.1
 changedir = {toxinidir}
 commands =
   asv machine --yes


### PR DESCRIPTION
[milksnake](https://github.com/getsentry/milksnake) is kind of inactive, which would be OK if Apple hadn't released the `universal2` format, which requires changes to how Rust shared libs are compiled (and used here with `CFFI`).

[setuptools-rust](https://setuptools-rust.readthedocs.io/) is another approach for generating Rust extensions, one of the building blocks from the [PyO3](https://github.com/PyO3/) project. It has more activity, it supports `universal2` wheels, and has good integration with `cibuildwheel`.

This PR replaces `milksnake` with `setuptools-rust`, with the goal of making #1334 easier to implement.

## TODO

- [ ] Consider the library naming, can we use `libsourmash.so` and make @camillescott life easier? =] https://github.com/dib-lab/sourmash/issues/1378