### PR TITLE
Fix missing bracket in docs (cosmetic)

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -104,7 +104,7 @@ many other software programs used for genome search and taxonomic
 classification.
 
 `sourmash search` and `sourmash gather` can be used to search 100k
-genbank microbial genomes ([using our prepared databases](databases.md)
+genbank microbial genomes ([using our prepared databases](databases.md))
 with about 20 GB of disk and in under 1 GB of RAM.
 Typically a search for a single genome takes about 30 seconds on a laptop.
 


### PR DESCRIPTION
Fix a cosmetic issue in the docs https://sourmash.readthedocs.io/en/latest/

If you want it, I am https://orcid.org/0000-0001-9513-9993
