### PR TITLE
[WIP] Fixes for asv benchmarks

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -88,7 +88,7 @@ commands = pytest \
 description = run asv for benchmarking (compare current commit with latest)
 deps =
   asv==0.4.2
-  virtualenv==16.7.9
+  virtualenv
 changedir = {toxinidir}
 commands =
   asv machine --yes


### PR DESCRIPTION
In #1571 @mr-eyes mentioned he couldn't run the `asv` benchmarks. I also had problems fixing them for #1564. It seems that one of the main issues is that `virtualenv` was using a very old version (because `asv` had issues with newer versions), but it seemed to be fixed and it is working with newer `virtualenv` again).

This PR avoid pinning the `virtualenv` version, and is enough to make it work in my system.

@mr-eyes, can you try this branch and see if benchmarks (with `tox -e asv`) work?