### PR TITLE
[WIP] Updating developer information with docs building instructions 

### DIFF
--- a/doc/developer.md
+++ b/doc/developer.md
@@ -132,7 +132,7 @@ cargo doc --no-deps # --no-deps for excluding the 3rd party libs' docs from bein
 For interactive docs building we use [`cargo-watch`](https://crates.io/crates/cargo-watch). Open a terminal and run `cargo watch -x  "doc --no-deps"`, you will need to keep this command running while changing the docs. Refresh the browser for rendering the changes.
 
 .. warning::
-    Although Rust is the backbone of Sourmash, it does not have all the functionalities that are provided in the main [Sourmash docs](https://sourmash.bio).
+    Although Rust is the backbone of sourmash, it does not have all the functionalities that are provided in the Python [sourmash API](https://sourmash.bio).
 
 
 ## Code organization

--- a/doc/developer.md
+++ b/doc/developer.md
@@ -132,7 +132,7 @@ cargo doc --no-deps # --no-deps for excluding the 3rd party libs' docs from bein
 For interactive docs building we use [`cargo-watch`](https://crates.io/crates/cargo-watch). Open a terminal and run `cargo watch -x  "doc --no-deps"`, you will need to keep this command running while changing the docs. Refresh the browser for rendering the changes.
 
 .. warning::
-    Although Rust is the backbone of Sourmash, it does not have all the functionalities that is provided in the main [Sourmash docs](https://sourmash.bio).
+    Although Rust is the backbone of Sourmash, it does not have all the functionalities that are provided in the main [Sourmash docs](https://sourmash.bio).
 
 
 ## Code organization

--- a/doc/developer.md
+++ b/doc/developer.md
@@ -76,6 +76,14 @@ To update rust to the latest version, use `rustup update`.
 
 To update your Python dependencies to the latest required for sourmash, you can run `pip install -r requirements.txt`.
 
+## Installing Sourmash in the editable mode
+
+In order to use Sourmash in the command line interface or the API while developing, you will need to install it in your enviornment in editable mode by running
+
+```
+pip install -e .
+```
+
 ## Running tests and checks
 
 We use [`tox`](https://tox.readthedocs.io) for managing dependencies and

--- a/doc/developer.md
+++ b/doc/developer.md
@@ -158,7 +158,7 @@ A short description of the high-level files and dirs in the sourmash repo:
 src/sourmash
 ├── cli/                | Command-line parsing, help messages and overall infrastucture
 ├── command_compute.py  | compute command implementation
-├── command_compute.py  | sketch command implementation
+├── command_sketch.py   | sketch command implementation
 ├── commands.py         | implementation for other CLI commands
 ├── compare.py          | Signature comparison functions
 ├── _compat.py          | Py2/3 compatibility functions

--- a/doc/developer.md
+++ b/doc/developer.md
@@ -78,7 +78,7 @@ To update your Python dependencies to the latest required for sourmash, you can 
 
 ## Installing sourmash in the editable mode
 
-In order to use Sourmash in the command line interface or the API while developing, you will need to install it in your enviornment in editable mode by running
+In order to use sourmash in the command line interface or the API while developing, you will need to install it in your environment in editable mode by running
 
 ```
 pip install -e .

--- a/doc/developer.md
+++ b/doc/developer.md
@@ -105,6 +105,28 @@ Code coverage can be viewed interactively at [codecov.io][1].
 [1]: https://codecov.io/gh/dib-lab/sourmash/
 [2]: https://github.com/dib-lab/sourmash/actions
 
+## Building docs
+
+We are using [Sphinx](https://www.sphinx-doc.org/en/master/) for Sourmash main docs hosted on [readthedocs](https://sourmash.bio). For Rust, we use [rustdoc](https://doc.rust-lang.org/rustdoc/what-is-rustdoc.html).
+
+To build the Sourmash docs run the following command. Then, inside the `html_docs` docs you will find an `index.html` file for the docs homepage.
+
+```
+sphinx-build -b html doc html_docs
+```
+
+For building Rust docs you will need to change the current working directory to `sourmash/src/core` then run the following command. The docs will be generated in `sourmash/target/docs/Sourmash`
+
+```
+cargo doc --no-deps # --no-deps for excluding the 3rd party libs' docs from being built.
+``` 
+
+For interactive docs building we use [`cargo-watch`](https://crates.io/crates/cargo-watch). Open a terminal and run `cargo watch -x  "doc --no-deps"`, you will need to keep this command running while changing the docs. Refresh the browser for rendering the changes.
+
+
+## Rust docs
+
+
 ## Code organization
 
 There are three main components in the sourmash repo:

--- a/doc/developer.md
+++ b/doc/developer.md
@@ -131,8 +131,8 @@ cargo doc --no-deps # --no-deps for excluding the 3rd party libs' docs from bein
 
 For interactive docs building we use [`cargo-watch`](https://crates.io/crates/cargo-watch). Open a terminal and run `cargo watch -x  "doc --no-deps"`, you will need to keep this command running while changing the docs. Refresh the browser for rendering the changes.
 
-
-## Rust docs
+.. warning::
+    Although Rust is the backbone of Sourmash, it does not have all the functionalities that is provided in the main [Sourmash docs](https://sourmash.bio).
 
 
 ## Code organization

--- a/doc/developer.md
+++ b/doc/developer.md
@@ -117,7 +117,7 @@ Code coverage can be viewed interactively at [codecov.io][1].
 
 We are using [Sphinx](https://www.sphinx-doc.org/en/master/) for sourmash main docs hosted on [readthedocs](https://sourmash.bio). For Rust, we use [rustdoc](https://doc.rust-lang.org/rustdoc/what-is-rustdoc.html).
 
-To build the Sourmash docs run the following command. Then, inside the `html_docs` docs you will find an `index.html` file for the docs homepage.
+To build the sourmash docs run the following command. Then, inside the `html_docs` docs you will find an `index.html` file for the docs homepage.
 
 ```
 sphinx-build -b html doc html_docs

--- a/doc/developer.md
+++ b/doc/developer.md
@@ -76,7 +76,7 @@ To update rust to the latest version, use `rustup update`.
 
 To update your Python dependencies to the latest required for sourmash, you can run `pip install -r requirements.txt`.
 
-## Installing Sourmash in the editable mode
+## Installing sourmash in the editable mode
 
 In order to use Sourmash in the command line interface or the API while developing, you will need to install it in your enviornment in editable mode by running
 

--- a/doc/developer.md
+++ b/doc/developer.md
@@ -115,7 +115,7 @@ Code coverage can be viewed interactively at [codecov.io][1].
 
 ## Building docs
 
-We are using [Sphinx](https://www.sphinx-doc.org/en/master/) for Sourmash main docs hosted on [readthedocs](https://sourmash.bio). For Rust, we use [rustdoc](https://doc.rust-lang.org/rustdoc/what-is-rustdoc.html).
+We are using [Sphinx](https://www.sphinx-doc.org/en/master/) for sourmash main docs hosted on [readthedocs](https://sourmash.bio). For Rust, we use [rustdoc](https://doc.rust-lang.org/rustdoc/what-is-rustdoc.html).
 
 To build the Sourmash docs run the following command. Then, inside the `html_docs` docs you will find an `index.html` file for the docs homepage.
 

--- a/doc/developer.md
+++ b/doc/developer.md
@@ -123,7 +123,7 @@ To build the sourmash docs run the following command. Then, inside the `html_doc
 sphinx-build -b html doc html_docs
 ```
 
-For building Rust docs you will need to change the current working directory to `sourmash/src/core` then run the following command. The docs will be generated in `sourmash/target/docs/Sourmash`
+For building Rust docs you will need to change the current working directory to `sourmash/src/core` then run the following command. The docs will be generated in `sourmash/target/docs/sourmash`
 
 ```
 cargo doc --no-deps # --no-deps for excluding the 3rd party libs' docs from being built.


### PR DESCRIPTION
This PR to update the developer information page with:
	- How to build Python and Rust docs?
	- How to install Sourmash in editable mode?