### PR TITLE
[MRG] minor cleanup in minhash module

### DIFF
--- a/src/sourmash/minhash.py
+++ b/src/sourmash/minhash.py
@@ -1,12 +1,23 @@
 # -*- coding: UTF-8 -*-
+"""
+sourmash submodule that provides MinHash class and utility functions.
+
+class MinHash - core MinHash class.
+class FrozenMinHash - read-only MinHash class.
+"""
 from __future__ import unicode_literals, division
 
-import math
+__all__ = ['get_minhash_default_seed',
+           'get_minhash_max_hash',
+           'hash_murmur',
+           'MinHash',
+           'FrozenMinHash']
+
 from collections.abc import Mapping
 
 from . import VERSION
 from ._lowlevel import ffi, lib
-from .utils import RustObject, rustcall, decode_str
+from .utils import RustObject, rustcall
 from .exceptions import SourmashError
 from deprecation import deprecated
 
@@ -692,9 +703,6 @@ class FrozenMinHash(MinHash):
         raise TypeError('FrozenMinHash does not support modification')
 
     def clear(self, *args, **kwargs):
-        raise TypeError('FrozenMinHash does not support modification')
-
-    def remove_many(self, *args, **kwargs):
         raise TypeError('FrozenMinHash does not support modification')
 
     def set_abundances(self, *args, **kwargs):


### PR DESCRIPTION
This PR cleans up several minor issues in the `sourmash.minhash` Python module:
* adds a docstring and `__all__` attribute
* removes an unused import
* removes a redundant method

Ready for review @luizirber @mr-eyes @bluegenes @keyabarve @taylorreiter 