### PR TITLE
[MRG] add basic picklist functionality to `sourmash sig extract`

### DIFF
--- a/doc/command-line.md
+++ b/doc/command-line.md
@@ -818,6 +818,40 @@ sourmash signature extract tests/test-data/*.fa.sig --name NC_009665
 will extract the same signature, which has an accession number of
 `NC_009665.1`.
 
+#### Using picklists with `sourmash sig extract`
+
+As of sourmash 4.2.0, `extract` also supports picklists, a feature by
+which you can select signatures based on values in a CSV file.
+
+For example,
+```
+sourmash sig extract --picklist list.csv:md5:md5sum <signatures>
+```
+will extract only the signatures that have md5sums matching the
+column `md5sum` in the CSV file `list.csv`.
+
+The `--picklist` argument string must be of the format
+`pickfile:colname:coltype`, where `pickfile` is the path to a CSV
+file, `colname` is the name of the column to select from the CSV
+file (based on the headers in the first line of the CSV file),
+and `coltype` is the type of match.
+
+The following `coltype`s are currently supported by `sourmash sig extract`:
+
+* `name` - exact match to signature's name
+* `md5` - exact match to signature's md5sum
+* `md5prefix8` - match to 8-character prefix of signature's md5sum
+* `md5short` - same as `md5prefix8`
+* `ident` - exact match to signature's identifier
+* `identprefix` - match to signature's identifier, before '.'
+
+Identifiers are constructed by using the first space delimited word in
+the signature name.
+
+One way to build a picklist is to use `sourmash sig describe --csv
+out.csv <signatures>` to construct an initial CSV file that you can
+then edit further.
+
 ### `sourmash signature flatten` - remove abundance information from signatures
 
 Flatten the specified signature(s), removing abundances and setting

--- a/src/sourmash/cli/sig/extract.py
+++ b/src/sourmash/cli/sig/extract.py
@@ -25,6 +25,10 @@ def subparser(subparsers):
         '--name', default=None,
         help='select signatures whose name contains this substring'
     )
+    subparser.add_argument(
+        '--picklist', default=None,
+        help="select signatures based on a picklist, i.e. 'file.csv:colname:coltype'"
+    )
     add_ksize_arg(subparser, 31)
     add_moltype_args(subparser)
 

--- a/src/sourmash/cli/sig/extract.py
+++ b/src/sourmash/cli/sig/extract.py
@@ -29,6 +29,10 @@ def subparser(subparsers):
         '--picklist', default=None,
         help="select signatures based on a picklist, i.e. 'file.csv:colname:coltype'"
     )
+    subparser.add_argument(
+        '--picklist-require-all', default=False, action='store_true',
+        help="require that all picklist values be found or else fail"
+    )
     add_ksize_arg(subparser, 31)
     add_moltype_args(subparser)
 

--- a/src/sourmash/sig/__main__.py
+++ b/src/sourmash/sig/__main__.py
@@ -603,7 +603,7 @@ def extract(args):
     notify("extracted {} signatures from {} file(s)", len(save_sigs),
            len(args.signatures))
     if picklist:
-        notify(f"for given picklist, found {len(picklist.found)} matches of {len(picklist.pickset)} total")
+        notify(f"for given picklist, found {len(picklist.found)} matches to {len(picklist.pickset)} distinct values")
         n_missing = len(picklist.pickset - picklist.found)
         if n_missing:
             notify(f"WARNING: {n_missing} missing picklist values.")

--- a/src/sourmash/sig/__main__.py
+++ b/src/sourmash/sig/__main__.py
@@ -549,7 +549,7 @@ def extract(args):
 
         notify(f"picking column '{picklist.column_name}' of type '{picklist.coltype}' from '{picklist.pickfile}'")
 
-        n_empty_val, dup_vals = picklist.load()
+        n_empty_val, dup_vals = picklist.load(picklist.pickfile)
 
         notify(f"loaded {len(picklist.pickset)} distinct values into picklist.")
         if n_empty_val:

--- a/src/sourmash/sig/__main__.py
+++ b/src/sourmash/sig/__main__.py
@@ -549,7 +549,7 @@ def extract(args):
 
         notify(f"picking column '{picklist.column_name}' of type '{picklist.coltype}' from '{picklist.pickfile}'")
 
-        n_empty_val, dup_vals = picklist.load(picklist.pickfile)
+        n_empty_val, dup_vals = picklist.load(picklist.pickfile, picklist.column_name)
 
         notify(f"loaded {len(picklist.pickset)} distinct values into picklist.")
         if n_empty_val:

--- a/src/sourmash/sig/__main__.py
+++ b/src/sourmash/sig/__main__.py
@@ -10,7 +10,7 @@ from collections import defaultdict
 import sourmash
 from sourmash.sourmash_args import FileOutput
 
-from sourmash.logging import set_quiet, error, notify, set_quiet, print_results, debug
+from sourmash.logging import set_quiet, error, notify, print_results, debug
 from sourmash import sourmash_args
 from sourmash.minhash import _get_max_hash_for_scaled
 
@@ -122,7 +122,6 @@ def split(args):
 
     progress = sourmash_args.SignatureLoadingProgress()
 
-    total = 0
     for sigfile in args.signatures:
         # load signatures from input file:
         this_siglist = sourmash_args.load_file_as_signatures(sigfile,
@@ -175,9 +174,8 @@ def split(args):
 
         notify('loaded {} signatures from {}...', n_signatures, sigfile,
                end='\r')
-        total += n_signatures
 
-    notify('loaded and split {} signatures total.', total)
+    notify(f'loaded and split {len(progress)} signatures total.')
 
 
 def describe(args):
@@ -201,14 +199,11 @@ def describe(args):
     # load signatures and display info.
     progress = sourmash_args.SignatureLoadingProgress()
 
-    n_loaded = 0
     for signature_file in args.signatures:
         try:
             loader = sourmash_args.load_file_as_signatures(signature_file,
                                                            progress=progress)
             for sig in loader:
-                n_loaded += 1
-
                 # extract info, write as appropriate.
                 mh = sig.minhash
                 ksize = mh.ksize
@@ -245,7 +240,7 @@ signature license: {license}
             error('(continuing)')
             raise
 
-    notify('loaded {} signatures total.', n_loaded)
+    notify(f'loaded {len(progress)} signatures total.')
 
     if csv_fp:
         csv_fp.close()
@@ -377,7 +372,7 @@ def merge(args):
         if this_n:
             notify('loaded and merged {} signatures from {}...', this_n, sigfile, end='\r')
 
-    if not total_loaded:
+    if not len(progress):
         error("no signatures to merge!?")
         sys.exit(-1)
 
@@ -386,7 +381,7 @@ def merge(args):
     with FileOutput(args.output, 'wt') as fp:
         sourmash.save_signatures([merged_sigobj], fp=fp)
 
-    notify('loaded and merged {} signatures', total_loaded)
+    notify(f'loaded and merged {len(progress)} signatures')
 
 
 def intersect(args):
@@ -400,7 +395,6 @@ def intersect(args):
 
     first_sig = None
     mins = None
-    total_loaded = 0
 
     progress = sourmash_args.SignatureLoadingProgress()
 
@@ -419,10 +413,9 @@ def intersect(args):
                     sys.exit(-1)
 
             mins.intersection_update(sigobj.minhash.hashes)
-            total_loaded += 1
         notify('loaded and intersected signatures from {}...', sigfile, end='\r')
 
-    if total_loaded == 0:
+    if len(progress) == 0:
         error("no signatures to merge!?")
         sys.exit(-1)
 
@@ -454,7 +447,7 @@ def intersect(args):
     with FileOutput(args.output, 'wt') as fp:
         sourmash.save_signatures([intersect_sigobj], fp=fp)
 
-    notify('loaded and intersected {} signatures', total_loaded)
+    notify(f'loaded and intersected {len(progress)} signatures')
 
 
 def subtract(args):
@@ -478,7 +471,6 @@ def subtract(args):
 
     progress = sourmash_args.SignatureLoadingProgress()
 
-    total_loaded = 0
     for sigfile in args.subtraction_sigs:
         for sigobj in sourmash_args.load_file_as_signatures(sigfile,
                                                         ksize=args.ksize,
@@ -495,9 +487,8 @@ def subtract(args):
             subtract_mins -= set(sigobj.minhash.hashes)
 
             notify('loaded and subtracted signatures from {}...', sigfile, end='\r')
-            total_loaded += 1
 
-    if not total_loaded:
+    if not len(progress):
         error("no signatures to subtract!?")
         sys.exit(-1)
 
@@ -510,7 +501,7 @@ def subtract(args):
     with FileOutput(args.output, 'wt') as fp:
         sourmash.save_signatures([subtract_sigobj], fp=fp)
 
-    notify('loaded and subtracted {} signatures', total_loaded)
+    notify(f'loaded and subtracted {len(progress)} signatures')
 
 
 def rename(args):
@@ -538,7 +529,7 @@ def rename(args):
 
     save_sigs.close()
 
-    notify("set name to '{}' on {} signatures", args.name, len(save_sigs))
+    notify(f"set name to '{args.name}' on {len(save_sigs)} signatures")
 
 
 def extract(args):
@@ -553,15 +544,12 @@ def extract(args):
     save_sigs = sourmash_args.SaveSignaturesToLocation(args.output)
     save_sigs.open()
 
-    total_loaded = 0
     for filename in args.signatures:
         siglist = sourmash_args.load_file_as_signatures(filename,
                                                         ksize=args.ksize,
                                                         select_moltype=moltype,
                                                         progress=progress)
         siglist = list(siglist)
-
-        total_loaded += len(siglist)
 
         # select!
         if args.md5 is not None:
@@ -572,8 +560,7 @@ def extract(args):
         for ss in siglist:
             save_sigs.add(ss)
 
-    notify("loaded {} total that matched ksize & molecule type",
-           total_loaded)
+    notify(f"loaded {len(progress)} total that matched ksize & molecule type")
     if not save_sigs:
         error("no matching signatures!")
         sys.exit(-1)
@@ -596,15 +583,12 @@ def filter(args):
     save_sigs = sourmash_args.SaveSignaturesToLocation(args.output)
     save_sigs.open()
 
-    total_loaded = 0
     for filename in args.signatures:
         siglist = sourmash_args.load_file_as_signatures(filename,
                                                         ksize=args.ksize,
                                                         select_moltype=moltype,
                                                         progress=progress)
         siglist = list(siglist)
-
-        total_loaded += len(siglist)
 
         # select!
         if args.md5 is not None:
@@ -636,8 +620,7 @@ def filter(args):
 
     save_sigs.close()
 
-    notify("loaded {} total that matched ksize & molecule type",
-           total_loaded)
+    notify(f"loaded {len(progress)} total that matched ksize & molecule type")
     notify("extracted {} signatures from {} file(s)", len(save_sigs),
            len(args.signatures))
 
@@ -654,15 +637,12 @@ def flatten(args):
     save_sigs = sourmash_args.SaveSignaturesToLocation(args.output)
     save_sigs.open()
 
-    total_loaded = 0
     for filename in args.signatures:
         siglist = sourmash_args.load_file_as_signatures(filename,
                                                         ksize=args.ksize,
                                                         select_moltype=moltype,
                                                         progress=progress)
         siglist = list(siglist)
-
-        total_loaded += len(siglist)
 
         # select!
         if args.md5 is not None:
@@ -676,8 +656,7 @@ def flatten(args):
 
     save_sigs.close()
 
-    notify("loaded {} total that matched ksize & molecule type",
-           total_loaded)
+    notify(f"loaded {len(progress)} total that matched ksize & molecule type")
     notify("extracted {} signatures from {} file(s)", len(save_sigs),
            len(args.signatures))
 
@@ -702,7 +681,6 @@ def downsample(args):
 
     progress = sourmash_args.SignatureLoadingProgress()
 
-    total_loaded = 0
     for sigfile in args.signatures:
         siglist = sourmash_args.load_file_as_signatures(sigfile,
                                                         ksize=args.ksize,
@@ -713,7 +691,6 @@ def downsample(args):
             mh = sigobj.minhash
 
             notify('loading and downsampling signature from {}...', sigfile, end='\r')
-            total_loaded += 1
             if args.scaled:
                 if mh.scaled:
                     mh_new = mh.downsample(scaled=args.scaled)
@@ -743,7 +720,7 @@ def downsample(args):
 
     save_sigs.close()
 
-    notify("loaded and downsampled {} signatures", total_loaded)
+    notify(f"loaded and downsampled {len(progress)} signatures")
 
 
 def sig_import(args):

--- a/src/sourmash/sig/__main__.py
+++ b/src/sourmash/sig/__main__.py
@@ -216,8 +216,10 @@ def describe(args):
                 if mh.track_abundance:
                     with_abundance = 1
                 md5 = sig.md5sum()
-                name = sig.name or "** no name **"
-                filename = sig.filename or "** no name **"
+                name = sig.name
+                p_name = name or "** no name **"
+                filename = sig.filename
+                p_filename = filename or "** no name **"
                 license = sig.license
 
                 if w:
@@ -226,8 +228,8 @@ def describe(args):
                 print_results('''\
 ---
 signature filename: {signature_file}
-signature: {name}
-source file: {filename}
+signature: {p_name}
+source file: {p_filename}
 md5: {md5}
 k={ksize} molecule={moltype} num={num} scaled={scaled} seed={seed} track_abundance={with_abundance}
 size: {n_hashes}
@@ -549,6 +551,7 @@ def extract(args):
                                                         ksize=args.ksize,
                                                         select_moltype=moltype,
                                                         progress=progress)
+        # CTB: make streaming!
         siglist = list(siglist)
 
         # select!

--- a/src/sourmash/sig/__main__.py
+++ b/src/sourmash/sig/__main__.py
@@ -602,6 +602,11 @@ def extract(args):
 
     notify("extracted {} signatures from {} file(s)", len(save_sigs),
            len(args.signatures))
+    if picklist:
+        notify(f"for given picklist, found {len(picklist.found)} matches of {len(picklist.pickset)} total")
+        n_missing = len(picklist.pickset - picklist.found)
+        if n_missing:
+            notify(f"WARNING: {n_missing} missing picklist values.")
 
 
 def filter(args):

--- a/src/sourmash/sig/__main__.py
+++ b/src/sourmash/sig/__main__.py
@@ -553,9 +553,9 @@ def extract(args):
 
         notify(f"loaded {len(picklist.pickset)} distinct values into picklist.")
         if n_empty_val:
-            notify(f"WARNING: {n_empty_val} empty values in column '{picklist.column_name}' in CSV file")
+            notify(f"WARNING: {n_empty_val} empty values in column '{picklist.column_name}' in picklist file")
         if dup_vals:
-            notify(f"WARNING: {len(dup_vals)} values in column '{picklist.column_name}' were not distinct")
+            notify(f"WARNING: {len(dup_vals)} values in picklist column '{picklist.column_name}' were not distinct")
         picklist_filter_fn = picklist.filter
     else:
         def picklist_filter_fn(it):

--- a/src/sourmash/sig/__main__.py
+++ b/src/sourmash/sig/__main__.py
@@ -545,7 +545,12 @@ def extract(args):
 
     picklist = None
     if args.picklist:
-        picklist = SignaturePicklist.from_picklist_args(args.picklist)
+        try:
+            picklist = SignaturePicklist.from_picklist_args(args.picklist)
+        except ValueError as exc:
+            error("ERROR: could not load picklist.")
+            error(str(exc))
+            sys.exit(-1)
 
         notify(f"picking column '{picklist.column_name}' of type '{picklist.coltype}' from '{picklist.pickfile}'")
 

--- a/src/sourmash/sig/__main__.py
+++ b/src/sourmash/sig/__main__.py
@@ -607,6 +607,9 @@ def extract(args):
         n_missing = len(picklist.pickset - picklist.found)
         if n_missing:
             notify(f"WARNING: {n_missing} missing picklist values.")
+            if args.picklist_require_all:
+                error("ERROR: failing because --picklist-require-all was set")
+                sys.exit(-1)
 
 
 def filter(args):

--- a/src/sourmash/sig/picklist.py
+++ b/src/sourmash/sig/picklist.py
@@ -10,8 +10,8 @@ preprocess['name'] = lambda x: x
 preprocess['md5'] = lambda x: x
 
 # identifier matches/prefix foo - space delimited identifiers
-preprocess['ident'] = lambda x: x.split(' ')[0].split('.')[0]
-preprocess['ident.'] = lambda x: x.split(' ')[0]
+preprocess['ident.'] = lambda x: x.split(' ')[0].split('.')[0]
+preprocess['ident'] = lambda x: x.split(' ')[0]
 
 # match 8 characters
 preprocess['md5prefix8'] = lambda x: x[:8]

--- a/src/sourmash/sig/picklist.py
+++ b/src/sourmash/sig/picklist.py
@@ -1,0 +1,115 @@
+"Picklist code for extracting subsets of signatures."
+import csv
+
+
+# set up preprocessing functions for column stuff
+preprocess = {}
+
+# exact matches
+preprocess['name'] = lambda x: x
+preprocess['md5'] = lambda x: x
+
+# identifier matches/prefix foo - space delimited identifiers
+preprocess['ident'] = lambda x: x.split(' ')[0].split('.')[0]
+preprocess['ident.'] = lambda x: x.split(' ')[0]
+
+# match 8 characters
+preprocess['md5prefix8'] = lambda x: x[:8]
+
+
+class SignaturePicklist:
+    """Picklist class for subsetting collections of signatures.
+
+    Initialize using ``SignaturePicklist.from_picklist_args(argstr)``,
+    which takes an argument str like so: 'pickfile:column:coltype'.
+
+    Here, 'pickfile' is the path to a CSV file; 'column' is the name of
+    the column to select from the CSV file; and 'coltype' is the type of
+    matching to do on that column.
+
+    'coltype's that are currently supported:
+    * 'name' - exact match to signature's name
+    * 'md5' - exact match to signature's md5sum
+    * 'md5prefix8' - match to 8-character prefix of signature's md5sum
+    * 'ident' - exact match to signature's identifier
+    * 'ident.' - match to signature's identifier, before '.'
+
+    Identifiers are constructed by using the first space delimited word in
+    the signature name.
+    """
+    def __init__(self, pickfile, column_name, coltype):
+        self.pickfile = pickfile
+        self.column_name = column_name
+        self.coltype = coltype
+
+        if coltype not in ('md5', 'md5prefix8', 'name', 'ident', 'ident.'):
+            raise ValueError(f"invalid picklist column type '{coltype}'")
+
+        self.preprocess_fn = preprocess[coltype]
+        self.pickset = None
+
+    @classmethod
+    def from_picklist_args(cls, argstr):
+        "load a picklist from an argument string 'pickfile:column:coltype'"
+        picklist = argstr.split(':')
+        if len(picklist) != 3:
+            raise ValueError(f"invalid picklist argument '{argstr}'")
+
+        assert len(picklist) == 3
+        pickfile, column, coltype = picklist
+
+        return cls(pickfile, column, coltype)
+
+    def _get_sig_attribute(self, ss):
+        "for a given SourmashSignature, return attribute for this picklist."
+        coltype = self.coltype
+        if coltype == 'md5':
+            q = ss.md5sum()
+        elif coltype == 'md5prefix8':
+            q = ss.md5sum()
+        elif coltype == 'name':
+            q = ss.name
+        elif coltype == 'ident':
+            q = ss.name
+        elif coltype == 'ident.':
+            q = ss.name
+
+        return q
+
+    def load(self):
+        "load pickset, return num empty vals, and set of duplicate vals."
+        pickset = set()
+        n_empty_val = 0
+        dup_vals = set()
+        with open(self.pickfile, newline='') as csvfile:
+            r = csv.DictReader(csvfile)
+
+            if self.column_name not in r.fieldnames:
+                raise ValueError("column '{self.column_name}' not in pickfile '{self.pickfile}'")
+
+            for row in r:
+                # pick out values from column
+                col = row[self.column_name]
+                if not col:
+                    n_empty_val += 1
+                    continue
+
+                col = self.preprocess_fn(col)
+
+                # look for duplicate values or empty values
+                if col in pickset:
+                    dup_vals.add(col)
+                else:
+                    pickset.add(col)
+
+        self.pickset = pickset
+        return n_empty_val, dup_vals
+
+    def __contains__(self, ss):
+        "does this signature match anything in the picklist?"
+        q = self._get_sig_attribute(ss)
+        q = self.preprocess_fn(q)
+
+        if q in self.pickset:
+            return True
+        return False

--- a/src/sourmash/sig/picklist.py
+++ b/src/sourmash/sig/picklist.py
@@ -9,7 +9,7 @@ preprocess['name'] = lambda x: x
 preprocess['md5'] = lambda x: x
 
 # identifier matches/prefix foo - space delimited identifiers
-preprocess['ident.'] = lambda x: x.split(' ')[0].split('.')[0]
+preprocess['identprefix'] = lambda x: x.split(' ')[0].split('.')[0]
 preprocess['ident'] = lambda x: x.split(' ')[0]
 
 # match 8 characters
@@ -79,8 +79,10 @@ class SignaturePicklist:
             q = ss.name
         elif coltype == 'ident':
             q = ss.name
-        elif coltype == 'ident.':
+        elif coltype == 'identprefix':
             q = ss.name
+        else:
+            assert 0
 
         return q
 

--- a/src/sourmash/sig/picklist.py
+++ b/src/sourmash/sig/picklist.py
@@ -113,3 +113,8 @@ class SignaturePicklist:
         if q in self.pickset:
             return True
         return False
+
+    def filter(self, it):
+        for ss in it:
+            if self.__contains__(ss):
+                yield ss

--- a/src/sourmash/sig/picklist.py
+++ b/src/sourmash/sig/picklist.py
@@ -71,15 +71,9 @@ class SignaturePicklist:
     def _get_sig_attribute(self, ss):
         "for a given SourmashSignature, return attribute for this picklist."
         coltype = self.coltype
-        if coltype == 'md5':
+        if coltype in ('md5', 'md5prefix8', 'md5short'):
             q = ss.md5sum()
-        elif coltype == 'md5prefix8':
-            q = ss.md5sum()
-        elif coltype == 'name':
-            q = ss.name
-        elif coltype == 'ident':
-            q = ss.name
-        elif coltype == 'identprefix':
+        elif coltype in ('name', 'ident', 'identprefix'):
             q = ss.name
         else:
             assert 0

--- a/src/sourmash/sig/picklist.py
+++ b/src/sourmash/sig/picklist.py
@@ -40,7 +40,7 @@ class SignaturePicklist:
     """
     def __init__(self, pickfile, column_name, coltype):
         self.pickfile = pickfile # note: can be None
-        self.column_name = column_name
+        self.column_name = column_name # note: can be None
         self.coltype = coltype
 
         if coltype not in ('md5', 'md5prefix8', 'name', 'ident', 'ident.'):
@@ -79,7 +79,12 @@ class SignaturePicklist:
 
         return q
 
-    def load(self, pickfile):
+    def init(self, values=[]):
+        if self.pickset is not None:
+            raise ValueError("already initialized?")
+        self.pickset = set(values)
+
+    def load(self, pickfile, column_name):
         "load pickset, return num empty vals, and set of duplicate vals."
         pickset = self.pickset
         if pickset is None:
@@ -90,12 +95,12 @@ class SignaturePicklist:
         with open(pickfile, newline='') as csvfile:
             r = csv.DictReader(csvfile)
 
-            if self.column_name not in r.fieldnames:
-                raise ValueError("column '{self.column_name}' not in pickfile '{pickfile}'")
+            if column_name not in r.fieldnames:
+                raise ValueError("column '{column_name}' not in pickfile '{pickfile}'")
 
             for row in r:
                 # pick out values from column
-                col = row[self.column_name]
+                col = row[column_name]
                 if not col:
                     n_empty_val += 1
                     continue
@@ -110,6 +115,9 @@ class SignaturePicklist:
 
         self.pickset = pickset
         return n_empty_val, dup_vals
+
+    def add(self, value):
+        self.pickset.add(value)
 
     def __contains__(self, ss):
         "does this signature match anything in the picklist?"

--- a/src/sourmash/sig/picklist.py
+++ b/src/sourmash/sig/picklist.py
@@ -85,12 +85,11 @@ class SignaturePicklist:
         if self.pickset is not None:
             raise ValueError("already initialized?")
         self.pickset = set(values)
+        return self.pickset
 
     def load(self, pickfile, column_name):
         "load pickset, return num empty vals, and set of duplicate vals."
-        pickset = self.pickset
-        if pickset is None:
-            pickset = set()
+        pickset = self.init()
 
         n_empty_val = 0
         dup_vals = set()
@@ -98,7 +97,7 @@ class SignaturePicklist:
             r = csv.DictReader(csvfile)
 
             if column_name not in r.fieldnames:
-                raise ValueError("column '{column_name}' not in pickfile '{pickfile}'")
+                raise ValueError(f"column '{column_name}' not in pickfile '{pickfile}'")
 
             for row in r:
                 # pick out values from column
@@ -113,9 +112,8 @@ class SignaturePicklist:
                 if col in pickset:
                     dup_vals.add(col)
                 else:
-                    pickset.add(col)
+                    self.add(col)
 
-        self.pickset = pickset
         return n_empty_val, dup_vals
 
     def add(self, value):

--- a/src/sourmash/sig/picklist.py
+++ b/src/sourmash/sig/picklist.py
@@ -47,6 +47,8 @@ class SignaturePicklist:
 
         self.preprocess_fn = preprocess[coltype]
         self.pickset = None
+        self.found = set()
+        self.n_queries = 0
 
     @classmethod
     def from_picklist_args(cls, argstr):
@@ -110,7 +112,9 @@ class SignaturePicklist:
         q = self._get_sig_attribute(ss)
         q = self.preprocess_fn(q)
 
+        self.n_queries += 1
         if q in self.pickset:
+            self.found.add(q)
             return True
         return False
 

--- a/src/sourmash/sig/picklist.py
+++ b/src/sourmash/sig/picklist.py
@@ -23,6 +23,7 @@ class SignaturePicklist:
     Initialize using ``SignaturePicklist.from_picklist_args(argstr)``,
     which takes an argument str like so: 'pickfile:column:coltype'.
 
+    # CTB pickfile or pickset?
     Here, 'pickfile' is the path to a CSV file; 'column' is the name of
     the column to select from the CSV file; and 'coltype' is the type of
     matching to do on that column.
@@ -38,7 +39,7 @@ class SignaturePicklist:
     the signature name.
     """
     def __init__(self, pickfile, column_name, coltype):
-        self.pickfile = pickfile
+        self.pickfile = pickfile # note: can be None
         self.column_name = column_name
         self.coltype = coltype
 
@@ -78,16 +79,19 @@ class SignaturePicklist:
 
         return q
 
-    def load(self):
+    def load(self, pickfile):
         "load pickset, return num empty vals, and set of duplicate vals."
-        pickset = set()
+        pickset = self.pickset
+        if pickset is None:
+            pickset = set()
+
         n_empty_val = 0
         dup_vals = set()
-        with open(self.pickfile, newline='') as csvfile:
+        with open(pickfile, newline='') as csvfile:
             r = csv.DictReader(csvfile)
 
             if self.column_name not in r.fieldnames:
-                raise ValueError("column '{self.column_name}' not in pickfile '{self.pickfile}'")
+                raise ValueError("column '{self.column_name}' not in pickfile '{pickfile}'")
 
             for row in r:
                 # pick out values from column

--- a/src/sourmash/sourmash_args.py
+++ b/src/sourmash/sourmash_args.py
@@ -338,7 +338,7 @@ def _load_database(filename, traverse_yield_all, *, cache_size=None):
     return db
 
 
-def load_file_as_index(filename, yield_all_files=False):
+def load_file_as_index(filename, *, yield_all_files=False):
     """Load 'filename' as a database; generic database loader.
 
     If 'filename' contains an SBT or LCA indexed database, or a regular
@@ -356,7 +356,7 @@ def load_file_as_index(filename, yield_all_files=False):
     return _load_database(filename, yield_all_files)
 
 
-def load_file_as_signatures(filename, select_moltype=None, ksize=None,
+def load_file_as_signatures(filename, *, select_moltype=None, ksize=None,
                             yield_all_files=False,
                             progress=None):
     """Load 'filename' as a collection of signatures. Return an iterable.
@@ -382,7 +382,7 @@ def load_file_as_signatures(filename, select_moltype=None, ksize=None,
     db = db.select(moltype=select_moltype, ksize=ksize)
     loader = db.signatures()
 
-    if progress:
+    if progress is not None:
         return progress.start_file(filename, loader)
     else:
         return loader
@@ -500,6 +500,9 @@ class SignatureLoadingProgress(object):
         self.n_sig = 0
         self.interval = reporting_interval
         self.screen_width = 79
+
+    def __len__(self):
+        return self.n_sig
 
     def short_notify(self, msg_template, *args, **kwargs):
         """Shorten the notification message so that it fits on one line.
@@ -689,7 +692,8 @@ class SaveSignatures_ZipFile(_BaseSaveSignaturesToLocation):
             return False
 
     def add(self, ss):
-        assert self.zf
+        if not self.zf:
+            raise ValueError("this output is not open")
         super().add(ss)
 
         md5 = ss.md5sum()

--- a/src/sourmash/sourmash_args.py
+++ b/src/sourmash/sourmash_args.py
@@ -3,28 +3,22 @@ Utility functions for sourmash CLI commands.
 """
 import sys
 import os
-import argparse
-import itertools
 from enum import Enum
 import traceback
 import gzip
 import zipfile
 
 import screed
+import sourmash
 
 from sourmash.sbtmh import load_sbt_index
 from sourmash.lca.lca_db import load_single_database
 import sourmash.exceptions
 
-from . import signature
 from .logging import notify, error, debug_literal
 
 from .index import (LinearIndex, ZipFileLinearIndex, MultiIndex)
-from . import signature as sig
-from .sbt import SBT
-from .sbtmh import SigLeaf
-from .lca import LCA_Database
-import sourmash
+from . import signature as sigmod
 
 DEFAULT_LOAD_K = 31
 
@@ -304,7 +298,7 @@ def _load_database(filename, traverse_yield_all, *, cache_size=None):
             db = load_fn(filename,
                          traverse_yield_all=traverse_yield_all,
                          cache_size=cache_size)
-        except ValueError as exc:
+        except ValueError:
             debug_literal(f"_load_databases: FAIL on fn {desc}.")
             debug_literal(traceback.format_exc())
 
@@ -321,7 +315,7 @@ def _load_database(filename, traverse_yield_all, *, cache_size=None):
             # CTB: could be kind of time consuming for a big record, but at the
             # moment screed doesn't expose format detection cleanly.
             with screed.open(filename) as it:
-                record = next(iter(it))
+                _ = next(iter(it))
             successful_screed_load = True
         except:
             pass
@@ -629,7 +623,7 @@ class SaveSignatures_Directory(_BaseSaveSignaturesToLocation):
                 i += 1
 
         with gzip.open(outname, "wb") as fp:
-            sig.save_signatures([ss], fp, compression=1)
+            sigmod.save_signatures([ss], fp, compression=1)
 
 
 class SaveSignatures_SigFile(_BaseSaveSignaturesToLocation):

--- a/tests/test_cmd_signature.py
+++ b/tests/test_cmd_signature.py
@@ -1149,6 +1149,53 @@ def test_sig_extract_8_picklist_md5(runtmp):
     assert "for given picklist, found 1 matches to 1 distinct values" in err
 
 
+def test_sig_extract_8_picklist_md5_require_all(runtmp):
+    # extract 47 from 47, using a picklist w/full md5;
+    # confirm that check missing picklist val errors out on --picklist-require
+    sig47 = utils.get_test_data('47.fa.sig')
+    sig63 = utils.get_test_data('63.fa.sig')
+
+    # select on any of these attributes
+    row = dict(exactName='NC_009665.1 Shewanella baltica OS185, complete genome',
+               md5full='09a08691ce52952152f0e866a59f6261',
+               md5short='09a08691ce5295215',
+               fullIdent='NC_009665.1',
+               nodotIdent='NC_009665')
+
+    # make picklist
+    picklist_csv = runtmp.output('pick.csv')
+    with open(picklist_csv, 'w', newline='') as csvfp:
+        w = csv.DictWriter(csvfp, fieldnames=row.keys())
+        w.writeheader()
+        w.writerow(row)
+        w.writerow(dict(exactName='', md5full='BAD MD5',
+                        md5short='', fullIdent='', nodotIdent=''))
+
+    picklist_arg = f"{picklist_csv}:md5full:md5"
+    with pytest.raises(ValueError):
+        runtmp.sourmash('sig', 'extract', sig47, sig63,
+                        '--picklist', picklist_arg,
+                        '--picklist-require-all')
+
+    # stdout should be new signature
+    out = runtmp.last_result.out
+
+    test_extract_sig = sourmash.load_one_signature(sig47)
+    actual_extract_sig = sourmash.load_one_signature(out)
+
+    assert actual_extract_sig == test_extract_sig
+
+    err = runtmp.last_result.err
+
+    print(err)
+    assert "loaded 2 distinct values into picklist." in err
+    assert "loaded 2 total that matched ksize & molecule type" in err
+    assert "extracted 1 signatures from 2 file(s)" in err
+    assert "for given picklist, found 1 matches to 2 distinct values" in err
+    assert 'WARNING: 1 missing picklist values.' in err
+    assert 'ERROR: failing because --picklist-require-all was set' in err
+
+
 def test_sig_extract_8_picklist_name(runtmp):
     # extract 47 from 47, using a picklist w/full md5
     sig47 = utils.get_test_data('47.fa.sig')

--- a/tests/test_cmd_signature.py
+++ b/tests/test_cmd_signature.py
@@ -1513,7 +1513,7 @@ def test_sig_extract_11_picklist_bad_coltype(runtmp):
 
     err = runtmp.last_result.err
     print(err)
-    assert "ValueError: invalid picklist column type 'BADCOLTYPE'" in err
+    assert "invalid picklist column type 'BADCOLTYPE'" in err
 
 
 def test_sig_extract_12_picklist_bad_argstr(runtmp):
@@ -1557,7 +1557,7 @@ def test_sig_extract_12_picklist_bad_colname(runtmp):
 
     err = runtmp.last_result.err
     print(err)
-    assert "ValueError: column 'BADCOLNAME' not in pickfile" in err
+    assert "column 'BADCOLNAME' not in pickfile" in err
 
 
 @utils.in_tempdir

--- a/tests/test_cmd_signature.py
+++ b/tests/test_cmd_signature.py
@@ -1110,6 +1110,161 @@ def test_sig_extract_7_no_ksize(c):
     assert len(siglist) == 3
 
 
+def test_sig_extract_8_picklist_md5(runtmp):
+    # extract 47 from 47, using a picklist w/full md5
+    sig47 = utils.get_test_data('47.fa.sig')
+    sig63 = utils.get_test_data('63.fa.sig')
+
+    # select on any of these attributes
+    row = dict(exactName='NC_009665.1 Shewanella baltica OS185, complete genome',
+               md5full='09a08691ce52952152f0e866a59f6261',
+               md5short='09a08691ce5295215',
+               fullIdent='NC_009665.1',
+               nodotIdent='NC_009665')
+
+    # make picklist
+    picklist_csv = runtmp.output('pick.csv')
+    with open(picklist_csv, 'w', newline='') as csvfp:
+        w = csv.DictWriter(csvfp, fieldnames=row.keys())
+        w.writeheader()
+        w.writerow(row)
+
+    picklist_arg = f"{picklist_csv}:md5full:md5"
+    runtmp.sourmash('sig', 'extract', sig47, sig63, '--picklist', picklist_arg)
+
+    # stdout should be new signature
+    out = runtmp.last_result.out
+
+    test_extract_sig = sourmash.load_one_signature(sig47)
+    actual_extract_sig = sourmash.load_one_signature(out)
+
+    assert actual_extract_sig == test_extract_sig
+
+
+def test_sig_extract_8_picklist_name(runtmp):
+    # extract 47 from 47, using a picklist w/full md5
+    sig47 = utils.get_test_data('47.fa.sig')
+    sig63 = utils.get_test_data('63.fa.sig')
+
+    # select on any of these attributes
+    row = dict(exactName='NC_009665.1 Shewanella baltica OS185, complete genome',
+               md5full='09a08691ce52952152f0e866a59f6261',
+               md5short='09a08691ce5295215',
+               fullIdent='NC_009665.1',
+               nodotIdent='NC_009665')
+
+    # make picklist
+    picklist_csv = runtmp.output('pick.csv')
+    with open(picklist_csv, 'w', newline='') as csvfp:
+        w = csv.DictWriter(csvfp, fieldnames=row.keys())
+        w.writeheader()
+        w.writerow(row)
+
+    picklist_arg = f"{picklist_csv}:exactName:name"
+    runtmp.sourmash('sig', 'extract', sig47, sig63, '--picklist', picklist_arg)
+
+    # stdout should be new signature
+    out = runtmp.last_result.out
+
+    test_extract_sig = sourmash.load_one_signature(sig47)
+    actual_extract_sig = sourmash.load_one_signature(out)
+
+    assert actual_extract_sig == test_extract_sig
+
+
+def test_sig_extract_8_picklist_ident(runtmp):
+    # extract 47 from 47, using a picklist w/full md5
+    sig47 = utils.get_test_data('47.fa.sig')
+    sig63 = utils.get_test_data('63.fa.sig')
+
+    # select on any of these attributes
+    row = dict(exactName='NC_009665.1 Shewanella baltica OS185, complete genome',
+               md5full='09a08691ce52952152f0e866a59f6261',
+               md5short='09a08691ce5295215',
+               fullIdent='NC_009665.1',
+               nodotIdent='NC_009665')
+
+    # make picklist
+    picklist_csv = runtmp.output('pick.csv')
+    with open(picklist_csv, 'w', newline='') as csvfp:
+        w = csv.DictWriter(csvfp, fieldnames=row.keys())
+        w.writeheader()
+        w.writerow(row)
+
+    picklist_arg = f"{picklist_csv}:fullIdent:ident"
+    runtmp.sourmash('sig', 'extract', sig47, sig63, '--picklist', picklist_arg)
+
+    # stdout should be new signature
+    out = runtmp.last_result.out
+
+    test_extract_sig = sourmash.load_one_signature(sig47)
+    actual_extract_sig = sourmash.load_one_signature(out)
+
+    assert actual_extract_sig == test_extract_sig
+
+
+def test_sig_extract_8_picklist_ident_dot(runtmp):
+    # extract 47 from 47, using a picklist w/full md5
+    sig47 = utils.get_test_data('47.fa.sig')
+    sig63 = utils.get_test_data('63.fa.sig')
+
+    # select on any of these attributes
+    row = dict(exactName='NC_009665.1 Shewanella baltica OS185, complete genome',
+               md5full='09a08691ce52952152f0e866a59f6261',
+               md5short='09a08691ce5295215',
+               fullIdent='NC_009665.1',
+               nodotIdent='NC_009665')
+
+    # make picklist
+    picklist_csv = runtmp.output('pick.csv')
+    with open(picklist_csv, 'w', newline='') as csvfp:
+        w = csv.DictWriter(csvfp, fieldnames=row.keys())
+        w.writeheader()
+        w.writerow(row)
+
+    picklist_arg = f"{picklist_csv}:nodotIdent:ident."
+    runtmp.sourmash('sig', 'extract', sig47, sig63, '--picklist', picklist_arg)
+
+    # stdout should be new signature
+    out = runtmp.last_result.out
+
+    test_extract_sig = sourmash.load_one_signature(sig47)
+    actual_extract_sig = sourmash.load_one_signature(out)
+
+    assert actual_extract_sig == test_extract_sig
+
+
+def test_sig_extract_8_picklist_md5_short(runtmp):
+    # extract 47 from 47, using a picklist w/full md5
+    sig47 = utils.get_test_data('47.fa.sig')
+    sig63 = utils.get_test_data('63.fa.sig')
+
+    # select on any of these attributes
+    row = dict(exactName='NC_009665.1 Shewanella baltica OS185, complete genome',
+               md5full='09a08691ce52952152f0e866a59f6261',
+               md5short='09a08691ce5295215',
+               fullIdent='NC_009665.1',
+               nodotIdent='NC_009665')
+
+    # make picklist
+    picklist_csv = runtmp.output('pick.csv')
+    with open(picklist_csv, 'w', newline='') as csvfp:
+        w = csv.DictWriter(csvfp, fieldnames=row.keys())
+        w.writeheader()
+        w.writerow(row)
+
+    picklist_arg = f"{picklist_csv}:md5short:md5prefix8"
+    runtmp.sourmash('sig', 'extract', sig47, sig63, '--picklist', picklist_arg)
+
+    # stdout should be new signature
+    out = runtmp.last_result.out
+
+    test_extract_sig = sourmash.load_one_signature(sig47)
+    actual_extract_sig = sourmash.load_one_signature(out)
+
+    assert actual_extract_sig == test_extract_sig
+
+
 @utils.in_tempdir
 def test_sig_flatten_1(c):
     # extract matches to several names from among several signatures & flatten

--- a/tests/test_cmd_signature.py
+++ b/tests/test_cmd_signature.py
@@ -1222,7 +1222,7 @@ def test_sig_extract_8_picklist_ident_dot(runtmp):
         w.writeheader()
         w.writerow(row)
 
-    picklist_arg = f"{picklist_csv}:nodotIdent:ident."
+    picklist_arg = f"{picklist_csv}:nodotIdent:identprefix"
     runtmp.sourmash('sig', 'extract', sig47, sig63, '--picklist', picklist_arg)
 
     # stdout should be new signature

--- a/tests/test_cmd_signature.py
+++ b/tests/test_cmd_signature.py
@@ -1140,6 +1140,14 @@ def test_sig_extract_8_picklist_md5(runtmp):
 
     assert actual_extract_sig == test_extract_sig
 
+    err = runtmp.last_result.err
+
+    print(err)
+    assert "loaded 1 distinct values into picklist." in err
+    assert "loaded 2 total that matched ksize & molecule type" in err
+    assert "extracted 1 signatures from 2 file(s)" in err
+    assert "for given picklist, found 1 matches to 1 distinct values" in err
+
 
 def test_sig_extract_8_picklist_name(runtmp):
     # extract 47 from 47, using a picklist w/full md5


### PR DESCRIPTION
This PR defines a `SignaturePicklist` class for subsetting collections of signatures, and adds associated functionality to `sourmash sig extract` with the `--picklist` argument.

So, for example, you can do
```
sourmash sig extract --picklist list.csv:md5:md5sum
```
and `sig extract` will pick out only the subset of signatures whose md5sums perfectly match the column named `md5` in the CSV file `list.csv`.

The argument string is of the following format: `pickfile:column:coltype`

Here, `pickfile` is the path to a CSV file; `column` is the name of the column to select from the CSV file; and `coltype` is the type of matching to do on that column.

`coltype`s that are currently supported:
* `name` - exact match to signature's name
* `md5` - exact match to signature's md5sum
* `md5prefix8` - match to 8-character prefix of signature's md5sum
* `md5short` - same as `md5prefix8`
* `ident` - exact match to signature's identifier
* `identprefix` - match to signature's identifier, before '.'

Identifiers are constructed by using the first space delimited word in the signature name.

For now, picklists iterate across all of the signatures, which will be slow for large collections. But, once the various APIs are defined we can enable faster lookup for various Index types types - e.g. Zipfile collections, SBTs, LCAs, and anything with a manifest should be able to pick things much faster than linear time. (See #1590 and beyond!)

Additional notes:
* this PR breaks backwards compatibility for `sourmash sig describe --csv <out.csv>`; the CSV file now contains empty columns for empty name/filename, as opposed to `** no name **`, because that just makes more sense.
* this PR makes `sourmash sig extract` streaming in both input and output, which could significantly reduce memory usage in certain circumstances (e.g. large collections being extracted/subsetted to zip files or directories)

This PR is on the path to some functionality discussed in more detail in a few places, wrt manifests, picklists, and lazy loading:
- enabling picking of signatures from within collections https://github.com/dib-lab/sourmash/issues/1365
- related to manifests https://github.com/dib-lab/sourmash/issues/1352
- we want to make sure we support the kind of lazy loading described in https://github.com/dib-lab/sourmash/issues/1097

TODO:
- [x] add tests for nomatch
- [x] add tests for extract w/--name, --md5
- [x] add tests for extract w/ksize, moltype selectors
- [x] add functionality for n_found, --require-all
- [ ] maybe add functionality to negate picklists?
- [x] maybe disambiguate number of signatures from number of matches more, e.g. "found 64 of 64"
- [x] add some documentation

## Example

### building picklists with sourmash sig describe

Here I built a picklist for a collection of test signatures like so:
```
% sourmash sig describe podar-ref/ --csv out.csv -q
```

(In this case the picklist actually contains information for all the signatures, but it could be a subset.)

### some example output

Here is some output of the picklist extraction:

---

Using exact md5sum matches; note, duplicate md5!

```
% sourmash sig extract podar-ref --picklist out.csv:md5:md5 -o xyz.zip
picking column 'md5' of type 'md5' from 'out.csv'
loaded 194 distinct values into picklist.
WARNING: 194 values in column 'md5' were not distinct
loaded 455 sigs from 'podar-ref'
loaded 455 total that matched ksize & molecule type
extracted 455 signatures from 1 file(s)
for given picklist, found 194 matches of 194 total
+ sourmash sig extract podar-ref --picklist out.csv:name:name -o xyz.zip
```

Using exact name matches; note, duplicate and empty names!
```
% sourmash sig extract podar-ref --picklist out.csv:name:name -o xyz.zip
picking column 'name' of type 'name' from 'out.csv'
loaded 64 distinct values into picklist.
WARNING: 196 empty values in column 'name' in CSV file
WARNING: 64 values in column 'name' were not distinct
loaded 455 sigs from 'podar-ref'
loaded 455 total that matched ksize & molecule type
extracted 259 signatures from 1 file(s)
for given picklist, found 64 matches of 64 total
```

Using md5sum 8-character prefix:
```
% sourmash sig extract podar-ref --picklist out.csv:md5:md5prefix8 -o xyz.zip
picking column 'md5' of type 'md5prefix8' from 'out.csv'
loaded 194 distinct values into picklist.
WARNING: 194 values in column 'md5' were not distinct
loaded 455 sigs from 'podar-ref'
loaded 455 total that matched ksize & molecule type
extracted 455 signatures from 1 file(s)
for given picklist, found 194 matches of 194 total
```

Using identifiers:
```
% sourmash sig extract podar-ref --picklist out.csv:name:ident -o xyz.zip
picking column 'name' of type 'ident' from 'out.csv'
loaded 64 distinct values into picklist.
WARNING: 196 empty values in column 'name' in CSV file
WARNING: 64 values in column 'name' were not distinct
loaded 455 sigs from 'podar-ref'
loaded 455 total that matched ksize & molecule type
extracted 259 signatures from 1 file(s)
for given picklist, found 64 matches of 64 total
```

Using identifiers with prefixes:
```
% sourmash sig extract podar-ref --picklist picking column 'name' of type 'ident.' from 'out.csv'
loaded 64 distinct values into picklist.
WARNING: 196 empty values in column 'name' in CSV file
WARNING: 64 values in column 'name' were not distinct
loaded 455 sigs from 'podar-ref'
loaded 455 total that matched ksize & molecule type
extracted 259 signatures from 1 file(s)
for given picklist, found 64 matches of 64 total
```

Picking signatures with combinatorial restrictions (e.g. ksize):
```
+ sourmash sig extract podar-ref --picklist out.csv:name:ident -o xyz.zip -k 31

== This is sourmash version 4.1.2. ==
== Please cite Brown and Irber (2016), doi:10.21105/joss.00027. ==

picking column 'name' of type 'ident' from 'out.csv'
loaded 64 distinct values into picklist.
WARNING: 196 empty values in column 'name' in CSV file
WARNING: 64 values in column 'name' were not distinct
loaded 197 sigs from 'podar-ref'
loaded 197 total that matched ksize & molecule type
extracted 129 signatures from 1 file(s)
for given picklist, found 64 matches of 64 total
```
