### PR TITLE
[EXP] add support for rapid signature selection from Zipfile collections by md5 picklists

### DIFF
--- a/src/sourmash/index.py
+++ b/src/sourmash/index.py
@@ -509,6 +509,15 @@ class ZipFileLinearIndex(Index):
                             print(f"({p} found!")
                             yield self.zf.open(zipinfo)
                             break
+        elif picklist and picklist.coltype == 'md5prefix8':
+            def yield_fp():
+                for zipinfo in self.zf.infolist():
+                    if zipinfo.filename.startswith('signatures/'):
+                        fn = zipinfo.filename[len('signatures/'):]
+                        prefix = fn[:8]
+                        if prefix in picklist.pickset:
+                            print(f"({prefix} q found)")
+                            yield self.zf.open(zipinfo)
         else:
             def yield_fp():
                 for zipinfo in self.zf.infolist():


### PR DESCRIPTION
NOTE: PR into https://github.com/dib-lab/sourmash/pull/1588

This PR is an experimental PR that does some terrible things to `ZipfileLinearIndex` in order to support rapid picklist extraction.  In exchange for those terrible things, it enables cool stuff like rapid extraction of signatures from large collections per https://github.com/dib-lab/sourmash/issues/1365.

## a demonstration

Below, we run a prefetch of a signature against 48,000 signatures in a zipfile collection, which yields 13 matches (for this query). We then use the picklist functionality in `sourmash sig extract` with the `match_md5` column from the prefetch results to  extract just the relevant signatures.

With this PR, the `sourmash sig extract` takes about 2 seconds. With #1588 (which supports picklists but not any special zipfile interaction), it takes a few minutes.

```
% sourmash prefetch podar-ref/63.fa.sig gtdb-r202.genomic-reps.k31.zip -o 63.prefetch.csv
...
(takes a few minutes, yields a prefetch.csv with 13 results)
...
% sourmash sig extract --picklist 63.prefetch.csv:match_md5:md5prefix8 \
         gtdb-r202.genomic-reps.k31.zip -o /tmp/abc.zip
picking column 'match_md5' of type 'md5prefix8' from '63.prefetch.csv'
loaded 13 distinct values into picklist.
loaded 13 sigs from 'gtdb-r202.genomic-reps.k31.zip'
loaded 13 total that matched ksize & molecule type
extracted 13 signatures from 1 file(s)
for given picklist, found 13 matches of 13 total
```


