### PR TITLE
[MRG] Fix Rust 1.59 lints

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -136,15 +136,24 @@ jobs:
   lints:
     name: Lints
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        build: [beta, stable]
+        include:
+          - build: beta
+            rust: beta
+          - build: stable
+            rust: stable
     steps:
       - name: Checkout sources
         uses: actions/checkout@v1
 
-      - name: Install stable toolchain
+      - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: ${{ matrix.rust }}
           override: true
           components: rustfmt, clippy
 

--- a/src/core/src/ffi/utils.rs
+++ b/src/core/src/ffi/utils.rs
@@ -18,7 +18,7 @@ thread_local! {
     pub static LAST_ERROR: RefCell<Option<Error>> = RefCell::new(None);
 }
 
-#[allow(clippy::clippy::wrong_self_convention)]
+#[allow(clippy::wrong_self_convention)]
 pub trait ForeignObject: Sized {
     type RustObject;
 

--- a/src/core/src/sketch/nodegraph.rs
+++ b/src/core/src/sketch/nodegraph.rs
@@ -241,22 +241,19 @@ impl Nodegraph {
             let byte_size = tablesize / 8 + 1;
 
             let rem = byte_size % 4;
-            let blocks: Vec<u32> = if rem == 0 {
+            let blocks: Vec<u32> = {
                 let mut blocks = vec![0; byte_size / 4];
                 rdr.read_u32_into::<LittleEndian>(&mut blocks)?;
-                blocks
-            } else {
-                let mut blocks = vec![0; byte_size / 4];
-                rdr.read_u32_into::<LittleEndian>(&mut blocks)?;
-
-                let mut values = [0u8; 4];
-                for item in values.iter_mut().take(rem) {
-                    let byte = rdr.read_u8().expect("error reading bins");
-                    *item = byte;
+                if rem != 0 {
+                    let mut values = [0u8; 4];
+                    for item in values.iter_mut().take(rem) {
+                        let byte = rdr.read_u8().expect("error reading bins");
+                        *item = byte;
+                    }
+                    let mut block = vec![0u32; 1];
+                    LittleEndian::read_u32_into(&values, &mut block);
+                    blocks.push(block[0]);
                 }
-                let mut block = vec![0u32; 1];
-                LittleEndian::read_u32_into(&values, &mut block);
-                blocks.push(block[0]);
                 blocks
             };
 


### PR DESCRIPTION
`clippy` uses a top-level value now. Also run the `lints` checks in `beta`, not only `stable`, to avoid picking these errors only when a new stable release shows up.