### PR TITLE
[MRG] Speed up `sourmash gather` by ignoring unidentifiable hashes

### DIFF
--- a/src/sourmash/commands.py
+++ b/src/sourmash/commands.py
@@ -1193,7 +1193,7 @@ def prefetch(args):
             match = result.match
 
             # track remaining "untouched" hashes.
-            noident_mh.remove_many(match.minhash.hashes)
+            noident_mh.remove_many(match.minhash)
 
             # output match info as we go
             if csvout_fp:
@@ -1230,7 +1230,7 @@ def prefetch(args):
         csvout_fp.close()
 
     matched_query_mh = query_mh.to_mutable()
-    matched_query_mh.remove_many(noident_mh.hashes)
+    matched_query_mh.remove_many(noident_mh)
     notify(f"of {len(query_mh)} distinct query hashes, {len(matched_query_mh)} were found in matches above threshold.")
     notify(f"a total of {len(noident_mh)} query hashes remain unmatched.")
 

--- a/src/sourmash/commands.py
+++ b/src/sourmash/commands.py
@@ -1229,15 +1229,14 @@ def prefetch(args):
         notify(f"saved {matches_out.count} matches to CSV file '{args.output}'")
         csvout_fp.close()
 
-    print('XXX converting to mutable')
-    matched_query_mh = query_mh.to_mutable()
-    print('XXX running remove_many')
-    matched_query_mh.remove_many(noident_mh)
-    notify(f"of {len(query_mh)} distinct query hashes, {len(matched_query_mh)} were found in matches above threshold.")
+    matched_num = len(query_mh) - len(noident_mh)
+    notify(f"of {len(query_mh)} distinct query hashes, {matched_num} were found in matches above threshold.")
     notify(f"a total of {len(noident_mh)} query hashes remain unmatched.")
 
     if args.save_matching_hashes:
         filename = args.save_matching_hashes
+        matched_query_mh = query_mh.to_mutable()
+        matched_query_mh.remove_many(noident_mh)
         notify(f"saving {len(matched_query_mh)} matched hashes to '{filename}'")
         ss = sig.SourmashSignature(matched_query_mh)
         with open(filename, "wt") as fp:

--- a/src/sourmash/commands.py
+++ b/src/sourmash/commands.py
@@ -737,6 +737,11 @@ def gather(args):
             break
 
 
+    # report on thresholding -
+    if gather_iter.query:
+        # if still a query, then we failed the threshold.
+        notify(f'found less than {format_bp(args.threshold_bp)} in common. => exiting')
+
     # basic reporting:
     print_results(f'\nfound {len(found)} matches total;')
     if args.num_results and len(found) == args.num_results:
@@ -897,6 +902,10 @@ def multigather(args):
                               name)
                 found.append(result)
 
+            # report on thresholding -
+            if gather_iter.query.minhash:
+                # if still a query, then we failed the threshold.
+                notify(f'found less than {format_bp(args.threshold_bp)} in common. => exiting')
 
             # basic reporting
             print_results('\nfound {} matches total;', len(found))

--- a/src/sourmash/commands.py
+++ b/src/sourmash/commands.py
@@ -701,8 +701,9 @@ def gather(args):
     weighted_missed = 1
     is_abundance = query.minhash.track_abundance and not args.ignore_abundance
     orig_query_mh = query.minhash
-    gather_iter = GatherDatabases(query, counters, args.threshold_bp,
-                                  args.ignore_abundance)
+    gather_iter = GatherDatabases(query, counters,
+                                  threshold_bp=args.threshold_bp,
+                                  ignore_abundance=args.ignore_abundance)
     for result, weighted_missed in gather_iter:
         if not len(found):                # first result? print header.
             if is_abundance:
@@ -874,8 +875,9 @@ def multigather(args):
             found = []
             weighted_missed = 1
             is_abundance = query.minhash.track_abundance and not args.ignore_abundance
-            gather_iter = GatherDatabases(query, counters, args.threshold_bp,
-                                          args.ignore_abundance)
+            gather_iter = GatherDatabases(query, counters,
+                                          threshold_bp=args.threshold_bp,
+                                          ignore_abundance=args.ignore_abundance)
             for result, weighted_missed in gather_iter:
                 if not len(found):                # first result? print header.
                     if is_abundance:

--- a/src/sourmash/commands.py
+++ b/src/sourmash/commands.py
@@ -750,6 +750,9 @@ def gather(args):
     p_covered = (1 - weighted_missed) * 100
     print_results(f'the recovered matches hit {p_covered:.1f}% of the query')
     print_results('')
+    if gather_iter.scaled != query.minhash.scaled:
+        # @CTB check in tests
+        print_results(f'WARNING: final scaled was {gather_iter.scaled}, vs query scaled of {query.minhash.scaled}')
 
     # save CSV?
     if found and args.output:

--- a/src/sourmash/commands.py
+++ b/src/sourmash/commands.py
@@ -891,8 +891,6 @@ def multigather(args):
                 for found_sig in counter.siglist:
                     noident_mh.remove_many(found_sig.minhash)
                 counters.append(counter)
-                # @CTB add test for valueerror thing
-
 
             found = []
             weighted_missed = 1

--- a/src/sourmash/commands.py
+++ b/src/sourmash/commands.py
@@ -1229,7 +1229,9 @@ def prefetch(args):
         notify(f"saved {matches_out.count} matches to CSV file '{args.output}'")
         csvout_fp.close()
 
+    print('XXX converting to mutable')
     matched_query_mh = query_mh.to_mutable()
+    print('XXX running remove_many')
     matched_query_mh.remove_many(noident_mh)
     notify(f"of {len(query_mh)} distinct query hashes, {len(matched_query_mh)} were found in matches above threshold.")
     notify(f"a total of {len(noident_mh)} query hashes remain unmatched.")

--- a/src/sourmash/commands.py
+++ b/src/sourmash/commands.py
@@ -762,7 +762,6 @@ def gather(args):
     print_results(f'the recovered matches hit {p_covered:.1f}% of the query')
     print_results('')
     if gather_iter.scaled != query.minhash.scaled:
-        # @CTB check in tests
         print_results(f'WARNING: final scaled was {gather_iter.scaled}, vs query scaled of {query.minhash.scaled}')
 
     # save CSV?

--- a/src/sourmash/commands.py
+++ b/src/sourmash/commands.py
@@ -626,7 +626,7 @@ def categorize(args):
 
 
 def gather(args):
-    from .search import gather_databases, format_bp
+    from .search import GatherDatabases, format_bp
 
     set_quiet(args.quiet, args.debug)
     moltype = sourmash_args.calculate_moltype(args)
@@ -703,8 +703,8 @@ def gather(args):
     orig_query_mh = query.minhash
     next_query = query
 
-    gather_iter = gather_databases(query, counters, args.threshold_bp,
-                                   args.ignore_abundance)
+    gather_iter = GatherDatabases(query, counters, args.threshold_bp,
+                                  args.ignore_abundance)
     for result, weighted_missed, next_query in gather_iter:
         if not len(found):                # first result? print header.
             if is_abundance:
@@ -800,7 +800,7 @@ def gather(args):
 
 def multigather(args):
     "Gather many signatures against multiple databases."
-    from .search import gather_databases, format_bp
+    from .search import GatherDatabases, format_bp
 
     set_quiet(args.quiet)
     moltype = sourmash_args.calculate_moltype(args)
@@ -867,7 +867,9 @@ def multigather(args):
             found = []
             weighted_missed = 1
             is_abundance = query.minhash.track_abundance and not args.ignore_abundance
-            for result, weighted_missed, next_query in gather_databases(query, counters, args.threshold_bp, args.ignore_abundance):
+            gather_iter = GatherDatabases(query, counters, args.threshold_bp,
+                                          args.ignore_abundance)
+            for result, weighted_missed, next_query in gather_iter:
                 if not len(found):                # first result? print header.
                     if is_abundance:
                         print_results("")

--- a/src/sourmash/commands.py
+++ b/src/sourmash/commands.py
@@ -786,10 +786,15 @@ def gather(args):
     # save unassigned hashes?
     if args.output_unassigned:
         remaining_query = gather_iter.query
-        if not len(remaining_query.minhash):
+        if not (remaining_query.minhash or noident_mh):
             notify('no unassigned hashes to save with --output-unassigned!')
         else:
             notify(f"saving unassigned hashes to '{args.output_unassigned}'")
+
+            if noident_mh:
+                remaining_mh = remaining_query.minhash.to_mutable()
+                remaining_mh += noident_mh
+                remaining_query.minhash = remaining_mh
 
             if is_abundance:
                 # remaining_query is flattened; reinflate abundances

--- a/src/sourmash/commands.py
+++ b/src/sourmash/commands.py
@@ -971,6 +971,11 @@ def multigather(args):
             output_unassigned = output_base + '.unassigned.sig'
             with open(output_unassigned, 'wt') as fp:
                 remaining_query = gather_iter.query
+                if noident_mh:
+                    remaining_mh = remaining_query.minhash.to_mutable()
+                    remaining_mh += noident_mh.downsample(scaled=remaining_mh.scaled)
+                    remaining_query.minhash = remaining_mh
+
                 if not found:
                     notify('nothing found - entire query signature unassigned.')
                 elif not remaining_query:

--- a/src/sourmash/search.py
+++ b/src/sourmash/search.py
@@ -319,6 +319,10 @@ class GatherDatabases:
             return max_scaled
         return max_scaled
 
+    @property
+    def scaled(self):
+        return self.cmp_scaled
+
     def __iter__(self):
         return self
 

--- a/src/sourmash/search.py
+++ b/src/sourmash/search.py
@@ -7,7 +7,6 @@ import os
 from enum import Enum
 import numpy as np
 
-from .logging import notify, error
 from .signature import SourmashSignature
 from .minhash import _get_max_hash_for_scaled
 
@@ -313,24 +312,20 @@ class GatherDatabases:
         if not self.query.minhash:
             raise StopIteration
 
-        # changeable
+        # may be changed:
         counters = self.counters
         cmp_scaled = self.cmp_scaled
 
-        # will not be updated:
+        # will not be changed::
         track_abundance = self.track_abundance
         threshold_bp = self.threshold_bp
         orig_query_abunds = self.orig_query_abunds
         orig_query_mh = self.orig_query_mh
 
-        # go forward!
-
         # find the best match!
         best_result, intersect_mh = _find_best(counters, query, threshold_bp)
 
         if not best_result:          # no matches at all for this cutoff!
-            # @CTB can we remove this notify?
-            notify(f'found less than {format_bp(threshold_bp)} in common. => exiting')
             raise StopIteration
 
         best_match = best_result.signature

--- a/src/sourmash/search.py
+++ b/src/sourmash/search.py
@@ -416,7 +416,7 @@ class GatherDatabases:
 
         # construct a new query, subtracting hashes found in previous one.
         new_query_mh = query_mh.to_mutable()
-        new_query_mh.remove_many(found_mh.hashes)
+        new_query_mh.remove_many(found_mh)
         new_query = SourmashSignature(new_query_mh)
 
         remaining_bp = scaled * len(new_query_mh)

--- a/src/sourmash/search.py
+++ b/src/sourmash/search.py
@@ -272,7 +272,8 @@ def _find_best(counters, query, threshold_bp):
 class GatherDatabases:
     "Iterator object for doing gather/min-set-cov."
 
-    def __init__(self, query, counters, threshold_bp, ignore_abundance):
+    def __init__(self, query, counters, *,
+                 threshold_bp=0, ignore_abundance=False, noident_mh=None):
         # track original query information for later usage?
         track_abundance = query.minhash.track_abundance and not ignore_abundance
         self.orig_query_bp = len(query.minhash) * query.minhash.scaled

--- a/src/sourmash/search.py
+++ b/src/sourmash/search.py
@@ -324,10 +324,11 @@ class GatherDatabases:
 
             # NOTE: orig_query_abunds can be used w/o downsampling
             orig_query_abunds = self.orig_query_abunds
+            self.noident_query_sum_abunds = sum(( orig_query_abunds[k] \
+                                                  for k in self.noident_mh.hashes ))
             self.sum_abunds = sum(( orig_query_abunds[k] \
                                     for k in self.orig_query_mh.hashes ))
-            self.sum_abunds += sum(( orig_query_abunds[k] \
-                                    for k in self.noident_mh.hashes ))
+            self.sum_abunds += self.noident_query_sum_abunds
 
         if max_scaled != scaled:
             return max_scaled
@@ -422,8 +423,9 @@ class GatherDatabases:
 
         # compute weighted_missed for remaining query hashes
         query_hashes = set(query_mh.hashes) - set(found_mh.hashes)
-        weighted_missed = sum((orig_query_abunds[k] for k in query_hashes)) \
-             / sum_abunds
+        weighted_missed = sum((orig_query_abunds[k] for k in query_hashes))
+        weighted_missed += self.noident_query_sum_abunds
+        weighted_missed /= sum_abunds
 
         # build a result namedtuple
         result = GatherResult(intersect_bp=intersect_bp,

--- a/src/sourmash/search.py
+++ b/src/sourmash/search.py
@@ -372,8 +372,7 @@ class GatherDatabases:
         f_unique_to_query = len(intersect_mh) / len(orig_query_mh)
 
         # calculate fraction of subject match with orig query
-        f_match_orig = best_match.minhash.contained_by(orig_query_mh,
-                                                       downsample=True)
+        f_match_orig = found_mh.contained_by(orig_query_mh)
 
         # calculate scores weighted by abundances
         f_unique_weighted = sum((orig_query_abunds[k] for k in intersect_mh.hashes ))
@@ -390,12 +389,8 @@ class GatherDatabases:
             std_abund = np.std(intersect_abunds)
 
         # construct a new query, subtracting hashes found in previous one.
-        # @CTB use query_mh here? should be same.
-        #new_query_mh = query_mh
-        #assert new_query_mh == query_mh
-
         new_query_mh = query_mh.to_mutable()
-        new_query_mh.remove_many(set(found_mh.hashes))
+        new_query_mh.remove_many(found_mh.hashes)
         new_query = SourmashSignature(new_query_mh)
 
         remaining_bp = scaled * len(new_query_mh)

--- a/src/sourmash/search.py
+++ b/src/sourmash/search.py
@@ -435,7 +435,7 @@ class GatherDatabases:
         self.query = new_query
         self.orig_query_mh = orig_query_mh
 
-        return result, weighted_missed, new_query
+        return result, weighted_missed
 
 
 ###

--- a/src/sourmash/search.py
+++ b/src/sourmash/search.py
@@ -2,13 +2,10 @@
 Code for searching collections of signatures.
 """
 from collections import namedtuple
-import sys
-import os
 from enum import Enum
 import numpy as np
 
 from .signature import SourmashSignature
-from .minhash import _get_max_hash_for_scaled
 
 
 class SearchType(Enum):
@@ -249,8 +246,6 @@ def _find_best(counters, query, threshold_bp):
     """
     Search for the best containment, return precisely one match.
     """
-    results = []
-
     best_result = None
     best_intersect_mh = None
 

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -920,7 +920,10 @@ def test_gather_lca_db(runtmp, linear_gather, prefetch_gather):
 
     runtmp.sourmash('gather', query, lca_db, linear_gather, prefetch_gather)
     print(runtmp)
-    assert 'NC_009665.1 Shewanella baltica OS185' in str(runtmp.last_result.out)
+    out = runtmp.last_result.out
+
+    assert 'NC_009665.1 Shewanella baltica OS185' in out
+    assert 'WARNING: final scaled was 10000, vs query scaled of 1000' in out
 
 
 def test_gather_csv_output_filename_bug(runtmp, linear_gather, prefetch_gather):
@@ -3984,6 +3987,8 @@ def test_gather_query_downsample(linear_gather, prefetch_gather):
         assert 'loaded 12 signatures' in err
         assert all(('4.9 Mbp      100.0%  100.0%' in out,
                     'NC_003197.2' in out))
+
+        assert 'WARNING: final scaled was 10000, vs query scaled of 500' in out
 
 
 def test_gather_query_downsample_explicit(linear_gather, prefetch_gather):


### PR DESCRIPTION
This PR refactors the `search.gather_databases(...)` generator into an iterator class `GatherDatabases(...)` that should be much faster.

The three main optimizations are:
* when a prefetch is done and we know what the unidentifiable query hashes are, remove them from consideration before doing the gather; this will speed up gather on mostly unidentifiable queries.
* actually use the newly refactored `MinHash.remove_many(...)` method from #1571.
* only downsample the original query and recalculate the numbers when scaled actually changes; this should speed up gather on large queries.

Should fix #1552 but @bluegenes will need to confirm.