### PR TITLE
[MRG] check compatibility in MinHash.intersection_and_union

### DIFF
--- a/src/sourmash/minhash.py
+++ b/src/sourmash/minhash.py
@@ -473,6 +473,8 @@ class MinHash(RustObject):
         "Calculate intersection and union sizes between `self` and `other`."
         if not isinstance(other, MinHash):
             raise TypeError("Must be a MinHash!")
+        if not self.is_compatible(other):
+            raise TypeError("incompatible MinHash objects")
 
         usize = ffi.new("uint64_t *")
         common = self._methodcall(lib.kmerminhash_intersection_union_size,

--- a/tests/test_minhash.py
+++ b/tests/test_minhash.py
@@ -1855,6 +1855,16 @@ def test_intersection_7_full_scaled():
     assert mh1.intersection_and_union_size(mh2) == (50, 150)
 
 
+def test_intersection_and_union_8_incompatible_ksize():
+    # cannot intersect different ksizes
+    mh1 = MinHash(0, 21, scaled=1)
+    mh2 = MinHash(0, 31, scaled=1)
+
+    with pytest.raises(TypeError) as exc:
+        mh1.intersection_and_union_size(mh2)
+    assert "incompatible MinHash objects" in str(exc)
+
+
 def test_merge_abund():
     mh1 = MinHash(10, 21, track_abundance=True)
     mh2 = MinHash(10, 21, track_abundance=True)


### PR DESCRIPTION
In https://github.com/sourmash-bio/sourmash/pull/1475, we added `MinHash.intersection_and_union(...)`. However, we didn't properly check whether the two signatures are compatible before doing the calculation. This PR fixes that!
