### PR TITLE
[MRG] minor updates to tax docs

### DIFF
--- a/src/sourmash/tax/__main__.py
+++ b/src/sourmash/tax/__main__.py
@@ -203,7 +203,7 @@ def genome(args):
             matched_queries.add(sg.query_name)
             if "krona" in args.output_format:
                 lin_list = display_lineage(sg.lineage).split(';')
-                krona_results.append((sg.query_name, sg.fraction, *lin_list))
+                krona_results.append((sg.fraction, *lin_list))
     else:
         # classify to the match that passes the containment threshold.
         # To do - do we want to store anything for this match if nothing >= containment threshold?
@@ -225,7 +225,7 @@ def genome(args):
                     matched_queries.add(sg.query_name)
                     if "krona" in args.output_format:
                         lin_list = display_lineage(sg.lineage).split(';')
-                        krona_results.append((sg.query_name, sg.fraction, *lin_list))
+                        krona_results.append((sg.fraction, *lin_list))
                     break
                 if rank == "superkingdom" and status == "nomatch":
                     status="below_threshold"

--- a/tests/test_tax.py
+++ b/tests/test_tax.py
@@ -628,7 +628,7 @@ def test_genome_rank_krona(runtmp):
     kr_results = [x.rstrip().split('\t') for x in open(csvout)]
     print(kr_results)
     assert ['fraction', 'superkingdom', 'phylum', 'class', 'order', 'family', 'genus', 'species'] == kr_results[0]
-    assert ['test1', '0.05815279361459521', 'd__Bacteria', 'p__Proteobacteria', 'c__Gammaproteobacteria', 'o__Enterobacterales', 'f__Enterobacteriaceae', 'g__Escherichia', 's__Escherichia coli'] == kr_results[1]
+    assert ['0.05815279361459521', 'd__Bacteria', 'p__Proteobacteria', 'c__Gammaproteobacteria', 'o__Enterobacterales', 'f__Enterobacteriaceae', 'g__Escherichia', 's__Escherichia coli'] == kr_results[1]
 
 
 def test_genome_gather_from_file_rank(runtmp):


### PR DESCRIPTION
- updates `tax` docs with `query_md5` and `query_filename` column info
- `genome` fix: avoid printing query name for proper `krona` output