### PR TITLE
[MRG] update docs with sourmash-bio

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@
 Quickly search, compare, and analyze genomic and metagenomic data sets.
 
 [![Documentation](https://readthedocs.org/projects/sourmash/badge/?version=latest)](http://sourmash.readthedocs.io/en/latest/)
-[![Build Status](https://github.com/dib-lab/sourmash/workflows/Python%20tests/badge.svg)](https://github.com/dib-lab/sourmash/actions/)
+[![Build Status](https://github.com/sourmash-bio/sourmash/workflows/Python%20tests/badge.svg)](https://github.com/sourmash-bio/sourmash/actions/)
 [![Bioconda install](https://img.shields.io/conda/dn/bioconda/sourmash.svg?style=flag&label=Bioconda)](https://anaconda.org/bioconda/sourmash)
 <a href="https://pypi.org/project/sourmash/"><img alt="PyPI" src="https://badge.fury.io/py/sourmash.svg"></a>
-[![codecov](https://codecov.io/gh/dib-lab/sourmash/branch/latest/graph/badge.svg)](https://codecov.io/gh/dib-lab/sourmash)
+[![codecov](https://codecov.io/gh/sourmash-bio/sourmash/branch/latest/graph/badge.svg)](https://codecov.io/gh/sourmash-bio/sourmash)
 [![DOI](http://joss.theoj.org/papers/10.21105/joss.00027/status.svg)](http://joss.theoj.org/papers/10.21105/joss.00027)
-<a href="https://github.com/dib-lab/sourmash/blob/latest/LICENSE"><img alt="License: 3-Clause BSD" src="https://img.shields.io/badge/License-BSD%203--Clause-blue.svg"></a>
+<a href="https://github.com/sourmash-bio/sourmash/blob/latest/LICENSE"><img alt="License: 3-Clause BSD" src="https://img.shields.io/badge/License-BSD%203--Clause-blue.svg"></a>
 
-<p align="center"><img src="https://raw.githubusercontent.com/dib-lab/sourmash/latest/doc/_static/logo.png" height="256" /></p>
+<p align="center"><img src="https://raw.githubusercontent.com/sourmash-bio/sourmash/latest/doc/_static/logo.png" height="256" /></p>
 
 Usage:
 
@@ -80,17 +80,17 @@ $ sourmash --help
 ```
 
 which will install
-[the latest released version](https://github.com/dib-lab/sourmash/releases).
+[the latest released version](https://github.com/sourmash-bio/sourmash/releases).
 
 ## Support
 
 Please ask questions and files issues
-[on Github](https://github.com/dib-lab/sourmash/issues).
+[on Github](https://github.com/sourmash-bio/sourmash/issues).
 
 ## Development
 
 Development happens on github at
-[dib-lab/sourmash](https://github.com/dib-lab/sourmash).
+[sourmash-bio/sourmash](https://github.com/sourmash-bio/sourmash).
 
 sourmash is developed in Python and Rust, and you will need a Rust
 environment to build it; see [the developer notes](doc/developer.md)

--- a/doc/api-example.md
+++ b/doc/api-example.md
@@ -395,7 +395,7 @@ True
 
 (Beware, these are confusing techniques for working with hashes that
 are easy to get wrong! We suggest
-[posting questions in the issue tracker](https://github.com/dib-lab/sourmash/issues)
+[posting questions in the issue tracker](https://github.com/sourmash-bio/sourmash/issues)
 as you go, if you are interested in exploring this area!)
 
 The hashing function used is identical between num and scaled signatures,

--- a/doc/classifying-signatures.md
+++ b/doc/classifying-signatures.md
@@ -139,7 +139,7 @@ Please see Appendix B, below, for some actual numbers and output.
 
 **Buyer beware:** There are substantial challenges in doing this kind
 of analysis on real metagenomic samples, relating to genome representation
-and strain overlap; see [this issue](https://github.com/dib-lab/sourmash/issues/461) for a discussion.
+and strain overlap; see [this issue](https://github.com/sourmash-bio/sourmash/issues/461) for a discussion.
 
 ### Computing signature similarity with angular similarity.
 
@@ -173,7 +173,7 @@ We suggest the following approach:
 
 * explore the available databases;
 
-* then ask questions [via the issue tracker](https://github.com/dib-lab/sourmash/issues) and we will do our best to help you out!
+* then ask questions [via the issue tracker](https://github.com/sourmash-bio/sourmash/issues) and we will do our best to help you out!
 
 This helps us figure out what people are actually interested in doing, and
 any help we provide via the issue tracker will eventually be added into the

--- a/doc/command-line.md
+++ b/doc/command-line.md
@@ -1373,5 +1373,5 @@ signatures that were just created.
 
 (This is a relatively new feature as of 3.4 and our testing may need
 some work, so please
-[let us know](https://github.com/dib-lab/sourmash/issues) if there's
+[let us know](https://github.com/sourmash-bio/sourmash/issues) if there's
 something that doesn't work and we will fix it :).

--- a/doc/developer.md
+++ b/doc/developer.md
@@ -4,7 +4,7 @@
 
 You can get the latest development branch with:
 ```
-git clone https://github.com/dib-lab/sourmash.git
+git clone https://github.com/sourmash-bio/sourmash.git
 ```
 sourmash runs under Python 3.7 and later.
 
@@ -102,8 +102,8 @@ We use [GitHub Actions][2] for continuous integration.
 
 Code coverage can be viewed interactively at [codecov.io][1].
 
-[1]: https://codecov.io/gh/dib-lab/sourmash/
-[2]: https://github.com/dib-lab/sourmash/actions
+[1]: https://codecov.io/gh/sourmash-bio/sourmash/
+[2]: https://github.com/sourmash-bio/sourmash/actions
 
 ## Code organization
 

--- a/doc/index.md
+++ b/doc/index.md
@@ -24,7 +24,7 @@ Please also see the `mash` [software](http://mash.readthedocs.io/en/latest/) and
 [paper (Ondov et al., 2016)](http://dx.doi.org/10.1186/s13059-016-0997-x) for
 background information on how and why MinHash works.
 
-**Questions? Thoughts?** Ask us on the [sourmash issue tracker](https://github.com/dib-lab/sourmash/issues/)!
+**Questions? Thoughts?** Ask us on the [sourmash issue tracker](https://github.com/sourmash-bio/sourmash/issues/)!
 
 **Want to migrate to sourmash v4?** sourmash v4 is now available, and
 has a number of incompatibilites with v2 and v3. Please see 
@@ -71,15 +71,15 @@ be stored, searched, explored, and taxonomically annotated.
 
 * `sourmash` relies on an underlying Rust core for performance.
 
-* `sourmash` is developed [on GitHub](https://github.com/dib-lab/sourmash)
+* `sourmash` is developed [on GitHub](https://github.com/sourmash-bio/sourmash)
   and is **freely and openly available** under the BSD 3-clause license.
-  Please see [the README](https://github.com/dib-lab/sourmash/blob/latest/README.md)
+  Please see [the README](https://github.com/sourmash-bio/sourmash/blob/latest/README.md)
   for more information on development, support, and contributing.
 
 You can take a look at sourmash analyses on real data
-[in a saved Jupyter notebook](https://github.com/dib-lab/sourmash/blob/latest/doc/sourmash-examples.ipynb),
+[in a saved Jupyter notebook](https://github.com/sourmash-bio/sourmash/blob/latest/doc/sourmash-examples.ipynb),
 and experiment with it yourself
-[interactively in a Jupyter Notebook](https://mybinder.org/v2/gh/dib-lab/sourmash/latest?filepath=doc%2Fsourmash-examples.ipynb)
+[interactively in a Jupyter Notebook](https://mybinder.org/v2/gh/sourmash-bio/sourmash/latest?filepath=doc%2Fsourmash-examples.ipynb)
 at [mybinder.org](http://mybinder.org).
 
 ## Installing sourmash
@@ -94,7 +94,7 @@ or conda:
 $ conda install -c conda-forge -c bioconda sourmash
 ```
 
-Please see [the README file in github.com/dib-lab/sourmash](https://github.com/dib-lab/sourmash/blob/latest/README.md)
+Please see [the README file in github.com/sourmash-bio/sourmash](https://github.com/sourmash-bio/sourmash/blob/latest/README.md)
 for more information.
 
 ## Memory and speed

--- a/doc/legacy-databases.md
+++ b/doc/legacy-databases.md
@@ -5,7 +5,7 @@ We have changed how the database is stored (uncompressed `.zip`) and how we name
 All SBT databases below are in `.sbt.zip` format.
 Note that the SBT and LCA databases can be used with sourmash v3.5 and later, while Zipfile collections can only be used with sourmash v4.1.0 and up.
 We detail these changes below, and include links to legacy databases.
-See [github.com/dib-lab/sourmash_databases](https://github.com/dib-lab/sourmash_databases) for a Snakemake workflow that builds current and legacy databases.
+See [github.com/sourmash-bio/databases](https://github.com/sourmash-bio/databases) for a Snakemake workflow that builds current and legacy databases.
 
 ## Sourmash signature names
 

--- a/doc/more-info.md
+++ b/doc/more-info.md
@@ -112,7 +112,7 @@ tries to connect to X11 to use the Tkinter backend.
 
 The solution is to force the use of the 'Agg' backend in matplotlib;
 see [this stackoverflow answer](https://stackoverflow.com/a/34294056)
-or [this sourmash issue comment](https://github.com/dib-lab/sourmash/issues/254#issuecomment-304274590).
+or [this sourmash issue comment](https://github.com/sourmash-bio/sourmash/issues/254#issuecomment-304274590).
 
 Newer versions of matplotlib do not seem to have this problem.
 
@@ -120,7 +120,7 @@ Newer versions of matplotlib do not seem to have this problem.
 [1]:https://github.com/edawson/rkmh
 [2]:https://github.com/lskatz/mashtree/blob/master/README.md
 [3]:https://github.com/onecodex/finch-rs
-[4]:https://github.com/dib-lab/sourmash/blob/latest/utils/compute-dna-mh-another-way.py
+[4]:https://github.com/sourmash-bio/sourmash/blob/latest/utils/compute-dna-mh-another-way.py
 [5]:http://ivory.idyll.org/blog/2016-sourmash.html
 [6]:http://ivory.idyll.org/blog/2016-sourmash-signatures.html
 [7]:http://ivory.idyll.org/blog/2016-sourmash-sbt.html

--- a/doc/release.md
+++ b/doc/release.md
@@ -29,7 +29,7 @@ and also check if the [rendered docs] are updated.
 1\. The below should be done in a clean checkout:
 ```
 cd $(mktemp -d)
-git clone git@github.com:dib-lab/sourmash.git
+git clone git@github.com:sourmash-bio/sourmash.git
 cd sourmash
 ```
 
@@ -46,7 +46,7 @@ git tag -a v${new_version}${rc}
 git push --tags origin
 ```
 
-[the releases page]: https://github.com/dib-lab/sourmash/releases
+[the releases page]: https://github.com/sourmash-bio/sourmash/releases
 
 3\. Test the release candidate. Bonus: repeat on macOS:
 ```
@@ -62,7 +62,7 @@ python -m venv testenv4
 
 cd testenv1
 source bin/activate
-git clone --depth 1 --branch v${new_version}${rc} https://github.com/dib-lab/sourmash.git
+git clone --depth 1 --branch v${new_version}${rc} https://github.com/sourmash-bio/sourmash.git
 cd sourmash
 python -m pip install -U setuptools pip wheel setuptools_scm
 python -m pip install -r requirements.txt
@@ -74,7 +74,7 @@ cd ../../testenv2
 deactivate
 source bin/activate
 python -m pip install -U setuptools pip wheel setuptools_scm
-python -m pip install -e git+https://github.com/dib-lab/sourmash.git@v${new_version}${rc}#egg=sourmash[test]
+python -m pip install -e git+https://github.com/sourmash-bio/sourmash.git@v${new_version}${rc}#egg=sourmash[test]
 cd src/sourmash
 make test
 make dist
@@ -145,7 +145,7 @@ git push --delete origin v${new_version}${rc}
 
 3\. Upload wheels from GitHub Releases to PyPI
 
-[GitHub Actions will automatically build wheels and upload them to GitHub Releases](https://github.com/dib-lab/sourmash/actions?query=workflow%3Acibuildwheel).
+[GitHub Actions will automatically build wheels and upload them to GitHub Releases](https://github.com/sourmash-bio/sourmash/actions?query=workflow%3Acibuildwheel).
 This will take about 45 minutes, or more. After they're built, they must be
 copied over to PyPI manually.
 

--- a/doc/requirements.md
+++ b/doc/requirements.md
@@ -15,4 +15,4 @@ under Python 3.7 and later.  Please see [the development repository README][0]
 for
 information on source code, tests, and continuous integration.
 
-[0]:https://github.com/dib-lab/sourmash/blob/latest/README.md
+[0]:https://github.com/sourmash-bio/sourmash/blob/latest/README.md

--- a/doc/sourmash-sketch.md
+++ b/doc/sourmash-sketch.md
@@ -91,7 +91,7 @@ The output signature(s) will be saved in locations that depend on your input par
 
 `sourmash sketch protein` and `sourmash sketch translate` output protein sketches by default, but can also use the `dayhoff` and `hp` encodings.  The [Dayhoff encoding](https://bmcbioinformatics.biomedcentral.com/articles/10.1186/1471-2105-9-367/tables/1) collapses multiple amino acids into a smaller alphabet so that amino acids that share biochemical properties map to the same character. The hp encoding divides amino acids into hydrophobic and polar (hydrophilic) amino acids, collapsing amino acids with hydrophobic side chains together and doing the same for polar amino acids.
 
-We are still in the process of benchmarking these encodings; ask [on the issue tracker](https://github.com/dib-lab/sourmash/issues) if you are interested in updates.
+We are still in the process of benchmarking these encodings; ask [on the issue tracker](https://github.com/sourmash-bio/sourmash/issues) if you are interested in updates.
 
 ### Parameter strings
 
@@ -121,7 +121,7 @@ These were chosen by a committee of PhDs as being good defaults for an initial a
 
 More seriously, the DNA parameters were chosen based on the analyses done by Koslicki and Falush in [MetaPalette: a k-mer Painting Approach for Metagenomic Taxonomic Profiling and Quantification of Novel Strain Variation](https://msystems.asm.org/content/1/3/e00020-16).
 
-The protein, dayhoff, and hp parameters were selected based on unpublished research results and/or magic formulas. We are working on publishing the results! Please ask on the [issue tracker](https://github.com/dib-lab/sourmash/issues) if you are curious.
+The protein, dayhoff, and hp parameters were selected based on unpublished research results and/or magic formulas. We are working on publishing the results! Please ask on the [issue tracker](https://github.com/sourmash-bio/sourmash/issues) if you are curious.
 
 ### More complex parameter string examples
 
@@ -185,4 +185,4 @@ You can use `sourmash sig describe` to get detailed information about the conten
 
 We try to provide good documentation and error messages, but may not succeed in answer all your questions! So we're happy to help out!
 
-Please post questions [on the sourmash issue tracker](https://github.com/dib-lab/sourmash/issues). If you find something confusing or buggy about the documentation or about sourmash, we'd love to fix it -- for you *and* for everyone else!
+Please post questions [on the sourmash issue tracker](https://github.com/sourmash-bio/sourmash/issues). If you find something confusing or buggy about the documentation or about sourmash, we'd love to fix it -- for you *and* for everyone else!

--- a/doc/support.md
+++ b/doc/support.md
@@ -11,11 +11,11 @@ bugs, and some of our best features have come from user
 requests. Please help us improve sourmash for everyone by asking
 questions as you have them!
 
-Please ask questions and file bug descriptions [on the GitHub issue tracker for sourmash, dib-lab/sourmash/issues][0].
+Please ask questions and file bug descriptions [on the GitHub issue tracker for sourmash, sourmash-bio/sourmash/issues][0].
 
 You can also ask questions of Titus on Twitter at [@ctitusbrown][1].
 
-[0]:https://github.com/dib-lab/sourmash/issues
+[0]:https://github.com/sourmash-bio/sourmash/issues
 [1]:https://twitter.com/ctitusbrown/
 
 ## Versioning and stability of features and APIs
@@ -116,7 +116,7 @@ If you depend on sourmash, we recommend using the following process:
 
 * pin sourmash to the major version you developed against, e.g. `sourmash >=3,<4`.
 * when ready to upgrade sourmash, upgrade to the latest minor release within that major version (e.g. sourmash 3.5.x).
-* scan for deprecations that affect you, check [the release notes](https://github.com/dib-lab/sourmash/releases), 
+* scan for deprecations that affect you, check [the release notes](https://github.com/sourmash-bio/sourmash/releases), 
 and fix any major issues noted.
 * upgrade to the next major version (e.g. sourmash 4.0) and run your integration tests or workflow.
 * fix outstanding issues.
@@ -130,7 +130,7 @@ If you want to upgrade workflows and scripts from prior releases of
 sourmash to sourmash v4.0, we suggest doing this in two stages.
 
 First, upgrade to the latest version of sourmash 3.5.x (currently
-[v3.5.1](https://github.com/dib-lab/sourmash/releases/tag/v3.5.1)),
+[v3.5.1](https://github.com/sourmash-bio/sourmash/releases/tag/v3.5.1)),
 which is compatible with all files and command lines used in previous
 versions of sourmash (v2.x and v3.x). After upgrading to 3.5.x, scan
 the sourmash output for deprecation warnings and fix those.
@@ -178,12 +178,12 @@ Second, the `MinHash` class API has changed significantly!
 Third, `SourmashSignature` objects no longer have a `name()` method but instead a `name` property, which can be assigned to. This property is now `None` when no name has been assigned. Note that `str(sig)` should now be used to retrieve a display name, and should replace all previous uses of `sig.name()`.
 
 Fourth, a few top-level functions have been deprecated: `load_signatures(...)`, `load_one_signature(...)`, `create_sbt_index(...)`, and `load_sbt_index(...)`.
-* `load_signatures(...)`, `load_one_signature(...)` should be replaced with `load_file_as_signatures(...)`. Note there is currently no top-level way to load signatures from strings. For now, if you need that functionality, you can use `sourmash.signature.load_signatures(...)` and `sourmash.signature.load_one_signature(...)`, but please be aware that these are not considered part of the public API that is under semantic versioning, so they may change in the next minor point release; this is tracked in  https://github.com/dib-lab/sourmash/issues/1312.
+* `load_signatures(...)`, `load_one_signature(...)` should be replaced with `load_file_as_signatures(...)`. Note there is currently no top-level way to load signatures from strings. For now, if you need that functionality, you can use `sourmash.signature.load_signatures(...)` and `sourmash.signature.load_one_signature(...)`, but please be aware that these are not considered part of the public API that is under semantic versioning, so they may change in the next minor point release; this is tracked in  https://github.com/sourmash-bio/sourmash/issues/1312.
 * `load_sbt_index(...)` have been deprecated.  Please use `load_file_as_index(...)` instead.
 * `create_sbt_index(...)` has been deprecated. There is currently no replacement, although you can use it directly from `sourmash.sbtmh` if necessary.
 
 Fifth, directory traversal now happens by default when loading signatures, so remove `traverse=True` arguments to several functions in `sourmash_args` - `load_dbs_and_sigs`, `load_file_as_index`, `and load_file_as_signatures`.
 
 Please post questions and concerns to the
-[sourmash issue tracker](https://github.com/dib-lab/sourmash/issues)
+[sourmash issue tracker](https://github.com/sourmash-bio/sourmash/issues)
 and we'll be happy to help!

--- a/doc/tutorial-basic.md
+++ b/doc/tutorial-basic.md
@@ -121,7 +121,7 @@ Let's grab a sample collection of 50 E. coli genomes and unpack it --
 mkdir ecoli_many_sigs
 cd ecoli_many_sigs
 
-curl -O -L https://github.com/dib-lab/sourmash/raw/latest/data/eschericia-sigs.tar.gz
+curl -O -L https://github.com/sourmash-bio/sourmash/raw/latest/data/eschericia-sigs.tar.gz
 
 tar xzf eschericia-sigs.tar.gz
 rm eschericia-sigs.tar.gz
@@ -246,7 +246,7 @@ from the
 [Shakya et al. 2013 mock metagenome paper.][2]
 
 ```
-wget https://github.com/dib-lab/sourmash/raw/latest/doc/_static/shakya-unaligned-contigs.sig
+wget https://github.com/sourmash-bio/sourmash/raw/latest/doc/_static/shakya-unaligned-contigs.sig
 sourmash gather -k 31 shakya-unaligned-contigs.sig genbank-k31.lca.json.gz
 ```
 

--- a/doc/using-sourmash-a-guide.md
+++ b/doc/using-sourmash-a-guide.md
@@ -8,7 +8,7 @@ So! You've installed sourmash, run a few of the tutorials and commands,
 and now you actually want to *use* it.  This guide is here to answer some
 of your questions, and explain why we can't answer others.
 
-(If you have additional questions, please [file an issue!](https://github.com/dib-lab/sourmash/issues))
+(If you have additional questions, please [file an issue!](https://github.com/sourmash-bio/sourmash/issues))
 
 ## What k-mer size(s) should I use?
 


### PR DESCRIPTION
- replaces `dib-lab` with `sourmash-bio` in relevant places in `README.md` and `docs/*md`.

ref #1002 

I know github forwards for us, but I was going to change the named ref in the README, and then just decided to keep going 😂 