### PR TITLE
[MRG] compress manifests in .zip/.sbt.zip files, and set default file permissions in zip

### DIFF
--- a/src/sourmash/cli/utils.py
+++ b/src/sourmash/cli/utils.py
@@ -31,10 +31,10 @@ def add_moltype_args(parser):
     parser.set_defaults(hp=False)
 
     parser.add_argument(
-        '--dna', '--rna', dest='dna', default=None, action='store_true',
+        '--dna', '--rna', '--nucleotide', dest='dna', default=None, action='store_true',
         help='choose a nucleotide signature (default: True)')
     parser.add_argument(
-        '--no-dna', '--no-rna', dest='dna', action='store_false',
+        '--no-dna', '--no-rna', '--no-nucleotide', dest='dna', action='store_false',
         help='do not choose a nucleotide signature')
     parser.set_defaults(dna=None)
 

--- a/src/sourmash/sbt.py
+++ b/src/sourmash/sbt.py
@@ -744,7 +744,7 @@ class SBT(Index):
         if kind == "Zip":
             manifest_name = os.path.join(storage.subdir, manifest_name)
             manifest_path = storage.save(manifest_name, manifest_data,
-                                         overwrite=True)
+                                         overwrite=True, compress=True)
         elif kind == "FS":
             manifest_name = manifest_name
             manifest_path = storage.save(manifest_name, manifest_data,

--- a/src/sourmash/sourmash_args.py
+++ b/src/sourmash/sourmash_args.py
@@ -53,7 +53,7 @@ def calculate_moltype(args, default=None):
         n += 1
 
     if n > 1:
-        error("cannot specify more than one of --dna/--rna/--protein/--hp/--dayhoff")
+        error("cannot specify more than one of --dna/--rna/--nucleotide/--protein/--hp/--dayhoff")
         sys.exit(-1)
 
     return moltype

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -247,6 +247,32 @@ def test_do_basic_compare_using_rna_arg(c):
     assert (cmp_out == cmp_calc).all()
 
 
+def test_do_basic_compare_using_nucleotide_arg(runtmp):
+    # try doing a basic compare using --nucleotide instead of --dna/--rna
+    c=runtmp
+    import numpy
+    testsigs = utils.get_test_data('genome-s1*.sig')
+    testsigs = glob.glob(testsigs)
+
+    c.run_sourmash('compare', '-o', 'cmp', '-k', '21', '--nucleotide', *testsigs)
+
+    cmp_outfile = c.output('cmp')
+    assert os.path.exists(cmp_outfile)
+    cmp_out = numpy.load(cmp_outfile)
+
+    sigs = []
+    for fn in testsigs:
+        sigs.append(sourmash.load_one_signature(fn, ksize=21,
+                                                select_moltype='dna'))
+
+    cmp_calc = numpy.zeros([len(sigs), len(sigs)])
+    for i, si in enumerate(sigs):
+        for j, sj in enumerate(sigs):
+            cmp_calc[i][j] = si.similarity(sj)
+
+    assert (cmp_out == cmp_calc).all()
+
+
 @utils.in_tempdir
 def test_do_compare_quiet(c):
     testdata1 = utils.get_test_data('short.fa')
@@ -2112,7 +2138,7 @@ def test_do_sourmash_index_bad_args():
                                            in_directory=location, fail_ok=True)
 
         print(out, err)
-        assert 'cannot specify more than one of --dna/--rna/--protein/--hp/--dayhoff' in err
+        assert 'cannot specify more than one of --dna/--rna/--nucleotide/--protein/--hp/--dayhoff' in err
         assert status != 0
 
 


### PR DESCRIPTION
This is a PR into https://github.com/sourmash-bio/sourmash/pull/1590.

This PR:
* sets the default file permissions on files saved into zipfiles to be a+r, and for directories => u+rwx, og+rx; see [this link](https://stackoverflow.com/questions/434641/how-do-i-set-permissions-attributes-on-a-file-in-a-zip-file-using-pythons-zip) for more info on setting zipfile permissions.
* compresses the manifest upon storage into zip files.

See https://github.com/sourmash-bio/sourmash/pull/1590#issuecomment-867216458 for motivating observation :)

