### PR TITLE
[MRG] Fix picklist-induced error in `LCA_Database`

### DIFF
--- a/src/sourmash/lca/lca_db.py
+++ b/src/sourmash/lca/lca_db.py
@@ -470,7 +470,11 @@ class LCA_Database(Index):
             # NOTE: one future low-mem optimization could be to support doing
             # this piecemeal by iterating across all the hashes, instead.
 
-            subj = self._signatures[idx]
+            subj = self._signatures.get(idx)
+            if subj is None:    # must be because of a picklist exclusion
+                assert self.picklists
+                continue
+
             subj_mh = prepare_subject(subj.minhash)
 
             # all numbers calculated after downsampling --

--- a/tests/test_lca.py
+++ b/tests/test_lca.py
@@ -566,7 +566,8 @@ def test_lca_index_find_picklist_check_overlap():
     xx = db.select(picklist=picklist)
     assert xx == db
 
-    db.search(query_sig, threshold=0.1)
+    results = list(db.search(query_sig, threshold=0.1))
+    assert len(results) == 1
 
 
 def test_lca_index_select_picklist_exclude():

--- a/tests/test_lca.py
+++ b/tests/test_lca.py
@@ -550,6 +550,25 @@ def test_lca_index_select_picklist():
     assert ss.minhash.ksize == 31
 
 
+def test_lca_index_find_picklist_check_overlap():
+    # make sure 'find' works for picklists that exclude relevant signatures
+    # (bug #1638)
+
+    query_fn = utils.get_test_data('47.fa.sig')
+    query_sig = sourmash.load_one_signature(query_fn, ksize=31)
+    db_fn = utils.get_test_data('lca/47+63.lca.json')
+    db, ksize, scaled = lca_utils.load_single_database(db_fn)
+
+    # construct a picklist...
+    picklist = SignaturePicklist('ident')
+    picklist.init(['NC_009665.1'])
+
+    xx = db.select(picklist=picklist)
+    assert xx == db
+
+    db.search(query_sig, threshold=0.1)
+
+
 def test_lca_index_select_picklist_exclude():
     # test 'select' method from Index base class with a picklist.
 


### PR DESCRIPTION
Fixes #1638, by allowing signatures to not exist in the internal signatures dictionary if there is a picklist exclusion.
