### PR TITLE
[MRG] add signature names to known/unknown hash sigs output by `sourmash prefetch`

### DIFF
--- a/src/sourmash/commands.py
+++ b/src/sourmash/commands.py
@@ -1256,7 +1256,7 @@ def prefetch(args):
 
         sig_name = ''
         if query.name:
-            sig_name = f"{query.name}-known"
+            sig_name = f"{query.name}-unknown"
 
         notify(f"saving {len(noident_mh)} unmatched hashes to '{filename}'")
         ss = sig.SourmashSignature(noident_mh, name=sig_name)

--- a/src/sourmash/commands.py
+++ b/src/sourmash/commands.py
@@ -1242,14 +1242,24 @@ def prefetch(args):
     if args.save_matching_hashes:
         filename = args.save_matching_hashes
         notify(f"saving {len(ident_mh)} matched hashes to '{filename}'")
-        ss = sig.SourmashSignature(ident_mh)
+
+        sig_name = ''
+        if query.name:
+            sig_name = f"{query.name}-known"
+
+        ss = sig.SourmashSignature(ident_mh, name=sig_name)
         with open(filename, "wt") as fp:
             sig.save_signatures([ss], fp)
 
     if args.save_unmatched_hashes:
         filename = args.save_unmatched_hashes
+
+        sig_name = ''
+        if query.name:
+            sig_name = f"{query.name}-known"
+
         notify(f"saving {len(noident_mh)} unmatched hashes to '{filename}'")
-        ss = sig.SourmashSignature(noident_mh)
+        ss = sig.SourmashSignature(noident_mh, name=sig_name)
         with open(filename, "wt") as fp:
             sig.save_signatures([ss], fp)
 

--- a/tests/test_prefetch.py
+++ b/tests/test_prefetch.py
@@ -271,6 +271,7 @@ def test_prefetch_matching_hashes(runtmp, linear_gather):
     intersect.add_many(matches)
 
     ss = sourmash.load_one_signature(matches_out)
+    assert ss.name
     assert ss.minhash == intersect
 
 
@@ -300,6 +301,7 @@ def test_prefetch_nomatch_hashes(runtmp, linear_gather):
     remain.remove_many(ss63.minhash.hashes)
 
     ss = sourmash.load_one_signature(nomatch_out)
+    assert ss.name
     assert ss.minhash == remain
 
 

--- a/tests/test_prefetch.py
+++ b/tests/test_prefetch.py
@@ -271,7 +271,7 @@ def test_prefetch_matching_hashes(runtmp, linear_gather):
     intersect.add_many(matches)
 
     ss = sourmash.load_one_signature(matches_out)
-    assert ss.name
+    assert ss.name.endswith('-known')
     assert ss.minhash == intersect
 
 
@@ -301,7 +301,7 @@ def test_prefetch_nomatch_hashes(runtmp, linear_gather):
     remain.remove_many(ss63.minhash.hashes)
 
     ss = sourmash.load_one_signature(nomatch_out)
-    assert ss.name
+    assert ss.name.endswith('-unknown')
     assert ss.minhash == remain
 
 


### PR DESCRIPTION
When running genome-grist with the new picklist code over in https://github.com/dib-lab/genome-grist/pull/94, I noticed that `sourmash prefetch --save-matching-hashes` and `--save-unmatched-hashes` created signatures with empty names, which then led to the downstream gather output for those signatures having no names, either. This fixes that to set the names to `{query.name}-known` and `{query.name}-unknown` respectively.
