### PR TITLE
[MRG] Update `MultiIndex` to support manifests

### DIFF
--- a/src/sourmash/index.py
+++ b/src/sourmash/index.py
@@ -1,4 +1,35 @@
-"An Abstract Base Class for collections of signatures."
+"""An Abstract Base Class for collections of signatures, plus implementations.
+
+APIs and functionality
+----------------------
+
+Index classes support three sets of API functionality -
+
+'select(...)', which selects subsets of signatures based on ksize, moltype,
+and other criteria, including picklists.
+
+'find(...)', and the 'search', 'gather', and 'counter_gather' implementations
+built on top of 'find', which search for signatures that match a query.
+
+'signatures()', which yields all signatures in the Index subject to the
+selection criteria.
+
+Classes defined in this file
+----------------------------
+
+Index - abstract base class for all Index objects.
+
+LinearIndex - simple in-memory storage of signatures.
+
+LazyLinearIndex - lazy selection and linear search of signatures.
+
+ZipFileLinearIndex - simple on-disk storage of signatures.
+
+class MultiIndex - in-memory storage and selection of signatures from multiple
+index objects, using manifests.
+
+CounterGather - an ancillary class returned by the 'counter_gather()' method.
+"""
 
 import os
 import sourmash
@@ -17,6 +48,7 @@ IndexSearchResult = namedtuple('Result', 'score, signature, location')
 
 class Index(ABC):
     is_database = False
+    manifest = None
 
     @property
     def location(self):
@@ -343,7 +375,9 @@ def select_signature(ss, *, ksize=None, moltype=None, scaled=0, num=0,
 class LinearIndex(Index):
     """An Index for a collection of signatures. Can load from a .sig file.
 
-    Note: does not use manifests. See MultiIndex for that functionality.
+    Note: See MultiIndex for an in-memory class that uses manifests.
+
+    Concrete class; signatures held in memory; does not use manifests.
     """
     def __init__(self, _signatures=None, filename=None):
         self._signatures = []
@@ -395,9 +429,22 @@ class LinearIndex(Index):
 class LazyLinearIndex(Index):
     """An Index for lazy linear search of another database.
 
-    The defining feature of this class is that 'find' is inherited
-    from the base Index class, which does a linear search with
-    signatures().
+    Wrapper class; does not use manifests.
+
+    One of the main purposes of this class is to _force_ linear 'find'
+    on index objects. So if this class wraps an SBT, for example, the
+    SBT find method will be overriden with the linear 'find' from the
+    base class. There are very few situations where this is an improvement,
+    so use this class wisely!
+
+    A few notes:
+    * selection criteria defined by 'select' are only executed when
+      signatures are actually requested (hence, 'lazy').
+    * this class stores the provided index 'db' in memory. If you need
+      a class that does lazy loading of signatures from disk and does not
+      store signatures in memory, see LazyLoadedIndex.
+    * if you want efficient manifest-based selection, consider
+      MultiIndex (signatures in memory).
     """
 
     def __init__(self, db, selection_dict={}):
@@ -456,6 +503,8 @@ class ZipFileLinearIndex(Index):
     A read-only collection of signatures in a zip file.
 
     Does not support `insert` or `save`.
+
+    Concrete class; signatures dynamically loaded from disk; uses manifests.
     """
     is_database = True
 
@@ -479,7 +528,7 @@ class ZipFileLinearIndex(Index):
         if self.manifest is not None:
             assert not self.selection_dict, self.selection_dict
         if self.selection_dict:
-            assert manifest is None
+            assert self.manifest is None
 
     def _load_manifest(self):
         "Load a manifest if one exists"
@@ -779,22 +828,38 @@ class MultiIndex(Index):
 
     Note: this is an in-memory collection, and does not do lazy loading:
     all signatures are loaded upon instantiation and kept in memory.
+
+    Concrete class; signatures held in memory; builds and uses manifests.
     """
-    def __init__(self, manifest):
+    def __init__(self, manifest, parent=None):
         self.manifest = manifest
+        self.parent = parent
 
     def signatures(self):
         for row in self.manifest.rows:
             yield row['signature']
 
     def signatures_with_location(self):
+        for row in self.manifest.rows:
+            loc = row['internal_location']
+            # here, 'parent' may have been removed from internal_location
+            # for directories; if so, add it back in.
+            if self.parent:
+                loc = os.path.join(self.parent, loc)
+            yield row['signature'], loc
+
+    def _signatures_with_internal(self):
         """Return an iterator of tuples (ss, location)
 
         CTB note: here, 'internal_location' is the source file for the
         index. This is a special feature of this (in memory) class.
         """
+        parent = ""
+        if self.parent:
+            parent = self.parent
         for row in self.manifest.rows:
-            yield row['signature'], row['internal_location']
+            yield row['signature'], parent, row['internal_location']
+
 
     def __len__(self):
         return len(self.manifest)
@@ -803,7 +868,7 @@ class MultiIndex(Index):
         raise NotImplementedError
 
     @classmethod
-    def load(cls, index_list, source_list):
+    def load(cls, index_list, source_list, parent=None):
         """Create a MultiIndex from already-loaded indices.
 
         Takes two arguments: a list of Index objects, and a matching list
@@ -825,7 +890,43 @@ class MultiIndex(Index):
         manifest = CollectionManifest.create_manifest(sigloc_iter())
 
         # create!
-        return cls(manifest)
+        return cls(manifest, parent=parent)
+
+    @classmethod
+    def load_from_directory(cls, pathname, *, force=False):
+        """Create a MultiIndex from a directory.
+
+        Takes directory path plus optional boolean 'force'. Attempts to
+        load all files ending in .sig or .sig.gz, by default; if 'force' is
+        True, will attempt to load _all_ files, ignoring errors.
+        """
+        from .sourmash_args import traverse_find_sigs
+
+        if not os.path.isdir(pathname):
+            raise ValueError(f"'{pathname}' must be a directory.")
+
+        index_list = []
+        source_list = []
+
+        traversal = traverse_find_sigs([pathname], yield_all_files=force)
+        for thisfile in traversal:
+            try:
+                idx = LinearIndex.load(thisfile)
+                index_list.append(idx)
+
+                rel = os.path.relpath(thisfile, pathname)
+                source_list.append(rel)
+            except (IOError, sourmash.exceptions.SourmashError):
+                if force:
+                    continue    # ignore error
+                else:
+                    raise       # stop loading!
+
+        # did we load anything? if not, error
+        if not index_list:
+            raise ValueError(f"no signatures to load under directory '{pathname}'")
+
+        return cls.load(index_list, source_list, parent=pathname)
 
     @classmethod
     def load_from_path(cls, pathname, force=False):
@@ -835,29 +936,24 @@ class MultiIndex(Index):
         Note: this only uses LinearIndex.load(...), so will only load
         signature JSON files.
         """
-        from .sourmash_args import traverse_find_sigs
-        if not os.path.exists(pathname): # CTB consider changing to isdir...
+        if not os.path.exists(pathname):
             raise ValueError(f"'{pathname}' must exist.")
 
-        index_list = []
-        source_list = []
-        for thisfile in traverse_find_sigs([pathname], yield_all_files=force):
+        if os.path.isdir(pathname): # traverse
+            return cls.load_from_directory(pathname, force=force)
+        else:                   # load as a .sig/JSON file
+            index_list = []
+            source_list = []
             try:
-                idx = LinearIndex.load(thisfile)
-
-                if idx:
-                    index_list.append(idx)
-                    source_list.append(thisfile)
+                idx = LinearIndex.load(pathname)
+                index_list = [idx]
+                source_list = [pathname]
             except (IOError, sourmash.exceptions.SourmashError):
-                if force:
-                    continue    # ignore error
-                else:
-                    raise       # stop loading!
+                if not force:
+                    raise ValueError(f"no signatures to load from '{pathname}'")
+                return None
 
-        if not index_list:
-            raise ValueError(f"no signatures to load under directory '{pathname}'")
-
-        return cls.load(index_list, source_list)
+            return cls.load(index_list, source_list)
 
     @classmethod
     def load_from_pathlist(cls, filename):
@@ -888,4 +984,4 @@ class MultiIndex(Index):
     def select(self, **kwargs):
         "Run 'select' on the manifest."
         new_manifest = self.manifest.select_to_manifest(**kwargs)
-        return MultiIndex(new_manifest)
+        return MultiIndex(new_manifest, parent=self.parent)

--- a/src/sourmash/sbt.py
+++ b/src/sourmash/sbt.py
@@ -183,7 +183,7 @@ class SBT(Index):
                     yield ss
 
     def _signatures_with_internal(self):
-        """Return an iterator of tuples (ss, location, internal_location).
+        """Return an iterator of tuples (ss, storage_path, internal_location).
 
         Note: does not limit signatures to subsets.
         """

--- a/src/sourmash/sig/__main__.py
+++ b/src/sourmash/sig/__main__.py
@@ -205,9 +205,10 @@ def describe(args):
 
     for signature_file in args.signatures:
         try:
-            loader = sourmash_args.load_file_as_signatures(signature_file,
-                                                           progress=progress)
-            for sig in loader:
+            idx = sourmash_args.load_file_as_index(signature_file)
+            loader = idx.signatures_with_location()
+
+            for sig, location in progress.start_file(signature_file, loader):
                 # extract info, write as appropriate.
                 mh = sig.minhash
                 ksize = mh.ksize
@@ -231,7 +232,7 @@ def describe(args):
 
                 print_results('''\
 ---
-signature filename: {signature_file}
+signature filename: {location}
 signature: {p_name}
 source file: {p_filename}
 md5: {md5}

--- a/src/sourmash/sourmash_args.py
+++ b/src/sourmash/sourmash_args.py
@@ -278,19 +278,6 @@ def _multiindex_load_from_path(filename, **kwargs):
     return db
 
 
-def _load_sigfile(filename, **kwargs):
-    "Load collection from a signature JSON file"
-    # CTB: note, all .sig files are loaded by _multiindex_load_from_path,
-    # before this function is called; this effectively only loads
-    # files not named .sig.
-    try:
-        db = LinearIndex.load(filename)
-    except sourmash.exceptions.SourmashError as exc:
-        raise ValueError(exc)
-
-    return db
-
-
 def _load_sbt(filename, **kwargs):
     "Load collection from an SBT."
     cache_size = kwargs.get('cache_size')
@@ -322,8 +309,7 @@ def _load_zipfile(filename, **kwargs):
 # all loader functions, in order.
 _loader_functions = [
     ("load from stdin", _load_stdin),
-    ("load from directory", _multiindex_load_from_path),
-    ("load from sig file", _load_sigfile),
+    ("load from path (file or directory)", _multiindex_load_from_path),
     ("load from file list", _multiindex_load_from_pathlist),
     ("load SBT", _load_sbt),
     ("load revindex", _load_revindex),
@@ -342,14 +328,14 @@ def _load_database(filename, traverse_yield_all, *, cache_size=None):
 
     # iterate through loader functions, trying them all. Catch ValueError
     # but nothing else.
-    for (desc, load_fn) in _loader_functions:
+    for n, (desc, load_fn) in enumerate(_loader_functions):
         try:
-            debug_literal(f"_load_databases: trying loader fn {desc}")
+            debug_literal(f"_load_databases: trying loader fn {n} {desc}")
             db = load_fn(filename,
                          traverse_yield_all=traverse_yield_all,
                          cache_size=cache_size)
         except ValueError:
-            debug_literal(f"_load_databases: FAIL on fn {desc}.")
+            debug_literal(f"_load_databases: FAIL on fn {n} {desc}.")
             debug_literal(traceback.format_exc())
 
         if db is not None:
@@ -542,10 +528,10 @@ class SignatureLoadingProgress(object):
     Instantiate this class once, and then pass it to load_file_as_signatures
     with progress=<obj>.
 
-    Alternatively, call obj.start_file(filename, iter) each time you
+    Alternatively, call obj.start_file(location, iter) each time you
     start loading signatures from a new file via iter.
 
-    You can optionally notify of reading a file with `.notify(filename)`.
+    You can optionally notify of reading a file with `.notify(location)`.
     """
     def __init__(self, reporting_interval=10):
         self.n_sig = 0
@@ -571,11 +557,10 @@ class SignatureLoadingProgress(object):
 
         notify(msg, end=end)
 
-    def notify(self, filename):
-        self.short_notify("...reading from file '{}'",
-                          filename, end='\r')
+    def notify(self, location):
+        self.short_notify(f"...reading from file '{location}'", end='\r')
 
-    def start_file(self, filename, loader):
+    def start_file(self, location, loader):
         n_this = 0
         n_before = self.n_sig
 
@@ -586,7 +571,7 @@ class SignatureLoadingProgress(object):
                 n_total = n_before + n_this
                 if n_this and n_total % self.interval == 0:
                     self.short_notify("...loading from '{}' / {} sigs total",
-                                      filename, n_total, end='\r')
+                                      location, n_total, end='\r')
 
                 yield result
         except KeyboardInterrupt:
@@ -596,7 +581,7 @@ class SignatureLoadingProgress(object):
         finally:
             self.n_sig += n_this
 
-        self.short_notify("loaded {} sigs from '{}'", n_this, filename)
+        self.short_notify(f"loaded {n_this} sigs from '{location}'")
 
 
 #

--- a/tests/test_cmd_signature.py
+++ b/tests/test_cmd_signature.py
@@ -11,6 +11,7 @@ import pytest
 import sourmash_tst_utils as utils
 import sourmash
 from sourmash.signature import load_signatures
+from sourmash.manifest import CollectionManifest
 
 ## command line tests
 
@@ -2570,8 +2571,6 @@ def test_import_mash_csv_to_sig(runtmp):
 
 def test_sig_manifest_1_zipfile(runtmp):
     # make a manifest from a .zip file
-    from sourmash.index import CollectionManifest
-
     protzip = utils.get_test_data('prot/protein.zip')
     runtmp.sourmash('sig', 'manifest', protzip, '-o', 'SOURMASH-MANIFEST.csv')
 
@@ -2588,22 +2587,24 @@ def test_sig_manifest_1_zipfile(runtmp):
 def test_sig_manifest_2_sigfile(runtmp):
     # make a manifest from a .sig file
     sigfile = utils.get_test_data('prot/protein/GCA_001593925.1_ASM159392v1_protein.faa.gz.sig')
-    with pytest.raises(ValueError):
-        runtmp.sourmash('sig', 'manifest', sigfile, '-o',
-                        'SOURMASH-MANIFEST.csv')
+
+    runtmp.sourmash('sig', 'manifest', sigfile, '-o', 'SOURMASH-MANIFEST.csv')
 
     status = runtmp.last_result.status
     out = runtmp.last_result.out
     err = runtmp.last_result.err
 
-    assert status != 0
-    assert "ERROR: manifests cannot be generated for this file." in err
+    manifest_fn = runtmp.output('SOURMASH-MANIFEST.csv')
+    with open(manifest_fn, newline='') as csvfp:
+        manifest = CollectionManifest.load_from_csv(csvfp)
+
+    assert len(manifest) == 1
+    md5_list = [ row['md5'] for row in manifest.rows ]
+    assert '16869d2c8a1d29d1c8e56f5c561e585e' in md5_list
 
 
 def test_sig_manifest_3_sbt(runtmp):
     # make a manifest from an SBT
-    from sourmash.index import CollectionManifest
-
     protzip = utils.get_test_data('prot/protein.sbt.zip')
     runtmp.sourmash('sig', 'manifest', protzip, '-o', 'SOURMASH-MANIFEST.csv')
 
@@ -2635,16 +2636,20 @@ def test_sig_manifest_4_lca(runtmp):
 def test_sig_manifest_5_dir(runtmp):
     # make a manifest from a directory
     sigfile = utils.get_test_data('prot/protein/')
-    with pytest.raises(ValueError):
-        runtmp.sourmash('sig', 'manifest', sigfile, '-o',
-                        'SOURMASH-MANIFEST.csv')
+    runtmp.sourmash('sig', 'manifest', sigfile, '-o', 'SOURMASH-MANIFEST.csv')
 
     status = runtmp.last_result.status
     out = runtmp.last_result.out
     err = runtmp.last_result.err
 
-    assert status != 0
-    assert "ERROR: manifests cannot be generated for this file." in err
+    manifest_fn = runtmp.output('SOURMASH-MANIFEST.csv')
+    with open(manifest_fn, newline='') as csvfp:
+        manifest = CollectionManifest.load_from_csv(csvfp)
+
+    assert len(manifest) == 2
+    md5_list = [ row['md5'] for row in manifest.rows ]
+    assert '16869d2c8a1d29d1c8e56f5c561e585e' in md5_list
+    assert '120d311cc785cc9d0df9dc0646b2b857' in md5_list
 
 
 def test_sig_manifest_6_pathlist(runtmp):
@@ -2656,13 +2661,17 @@ def test_sig_manifest_6_pathlist(runtmp):
     with open(pathlist, 'wt') as fp:
         fp.write("\n".join(sigfiles))
 
-    with pytest.raises(ValueError):
-        runtmp.sourmash('sig', 'manifest', pathlist, '-o',
-                        'SOURMASH-MANIFEST.csv')
+    runtmp.sourmash('sig', 'manifest', pathlist, '-o', 'SOURMASH-MANIFEST.csv')
 
     status = runtmp.last_result.status
     out = runtmp.last_result.out
     err = runtmp.last_result.err
 
-    assert status != 0
-    assert "ERROR: manifests cannot be generated for this file." in err
+    manifest_fn = runtmp.output('SOURMASH-MANIFEST.csv')
+    with open(manifest_fn, newline='') as csvfp:
+        manifest = CollectionManifest.load_from_csv(csvfp)
+
+    assert len(manifest) == 2
+    md5_list = [ row['md5'] for row in manifest.rows ]
+    assert '16869d2c8a1d29d1c8e56f5c561e585e' in md5_list
+    assert '120d311cc785cc9d0df9dc0646b2b857' in md5_list

--- a/tests/test_cmd_signature.py
+++ b/tests/test_cmd_signature.py
@@ -2391,9 +2391,13 @@ def test_sig_describe_1_dir(c):
     out = c.last_result.out
     print(c.last_result)
 
+    # make sure signature names, as well as full path to .sig file under
+    # directory, show up in output.
     expected_output = """\
 signature: GCA_001593925
 signature: GCA_001593935
+prot/protein/GCA_001593925.1_ASM159392v1_protein.faa.gz.sig
+prot/protein/GCA_001593935.1_ASM159393v1_protein.faa.gz.sig
 """.splitlines()
     for line in expected_output:
         assert line.strip() in out

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -10,7 +10,6 @@ import copy
 
 import sourmash
 from sourmash import load_one_signature, SourmashSignature
-from sourmash import index
 from sourmash.index import (LinearIndex, ZipFileLinearIndex,
                             make_jaccard_search_query, CounterGather,
                             LazyLinearIndex, MultiIndex)

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -10,6 +10,7 @@ import copy
 
 import sourmash
 from sourmash import load_one_signature, SourmashSignature
+from sourmash import index
 from sourmash.index import (LinearIndex, ZipFileLinearIndex,
                             make_jaccard_search_query, CounterGather,
                             LazyLinearIndex, MultiIndex)
@@ -1158,11 +1159,32 @@ def test_multi_index_signatures():
 
 
 def test_multi_index_load_from_path():
+    # test MultiIndex loading from a directory. The full paths to the
+    # signature files should be available via 'signatures_with_location()'
     dirname = utils.get_test_data('prot/protein')
     mi = MultiIndex.load_from_path(dirname, force=False)
 
     sigs = list(mi.signatures())
     assert len(sigs) == 2
+
+    # check to make sure that full paths to expected sig files are returned
+    locs = [ x[1] for x in mi.signatures_with_location() ]
+
+    endings = ('GCA_001593925.1_ASM159392v1_protein.faa.gz.sig',
+               'GCA_001593935.1_ASM159393v1_protein.faa.gz.sig')
+    for loc in locs:
+        found = False
+        for end in endings:
+            if loc.endswith(end):
+                found = True
+        assert found, f"could not find full filename in locations for {end}"
+
+    # also check internal locations and parent value --
+    assert mi.parent.endswith('prot/protein')
+
+    ilocs = [ x[2] for x in mi._signatures_with_internal() ]
+    assert endings[0] in ilocs, ilocs
+    assert endings[1] in ilocs, ilocs
 
 
 def test_multi_index_load_from_path_2():
@@ -2180,3 +2202,4 @@ def test_lazy_index_wraps_multi_index_location():
     for (ss_tup, ss_lazy_tup) in zip(mi2.signatures_with_location(),
                                      lazy2.signatures_with_location()):
         assert ss_tup == ss_lazy_tup
+

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -1928,7 +1928,7 @@ def test_search_metagenome_traverse_check_csv():
             r = csv.DictReader(fp)
             for row in r:
                 filename = row['filename']
-                assert filename.startswith(testdata_dir)
+                assert filename.startswith(testdata_dir), filename
                 # should have full path to file sig was loaded from
                 assert len(filename) > prefix_len
 


### PR DESCRIPTION
With [sourmash 4.2](https://github.com/sourmash-bio/sourmash/releases/tag/v4.2.0), we added internal support for manifests on zip files and SBTs. This PR adds manifest support for `MultiIndex`, which is used to load files from paths and pathlists. These manifests are not saved, but can be used to generate manifests for directories etc. with `sourmash sig manifest`; this is forward-leaning functionality :).

A key part of adding manifests to `MultiIndex` was adding a distinction between the `parent` and `internal_location` for signatures loaded from a directory; previously these were in a single `location`. `parent` is now the top-level directory being loaded, while `internal_location` is the relative path of the signature underneath. This brings `MultiIndex` into line with how `ZipFileLinearIndex` and `SBT` use `internal_location` vs the location reported via `.signatures_with_location()`, and makes it possible for `MultiIndex` to use a `Storage` class for loading signatures in the future (see also #1598). Down the road this makes it possible to put a manifest in a directory, move that directory, and have the manifest still contain correct (relative) paths.

This PR also:
* updates module and class docstrings in `index.py`;
* adds a `manifest` attribute to all `Index` subclasses (defaults to None);
* removes the `_load_sigfile` database loading method, which was never used;

TODO:
- [x] document and test parent attribute
