### PR TITLE
[MRG] adjust `sourmash tax` usage strings to match man page guidelines

### DIFF
--- a/src/sourmash/cli/tax/annotate.py
+++ b/src/sourmash/cli/tax/annotate.py
@@ -2,7 +2,7 @@
 
 usage="""
 
-    sourmash tax annotate --gather-csv [gather_csv(s)] --taxonomy-csv [taxonomy-csv(s)]
+    sourmash tax annotate --gather-csv <gather_csv> [ ... ] --taxonomy-csv <taxonomy_csv> [ ... ]
 
 The 'tax annotate' command reads in gather results CSVs and annotates them
  with taxonomic information.

--- a/src/sourmash/cli/tax/genome.py
+++ b/src/sourmash/cli/tax/genome.py
@@ -2,7 +2,7 @@
 
 usage="""
 
-    sourmash tax genome --gather-csv [gather_csv(s)] --taxonomy-csv [taxonomy-csv(s)]
+    sourmash tax genome --gather-csv <gather_csv> [ ... ] --taxonomy-csv <taxonomy-csv> [ ... ]
 
 The 'tax genome' command reads in genome gather result CSVs and reports likely
 classification for each query genome.

--- a/src/sourmash/cli/tax/metagenome.py
+++ b/src/sourmash/cli/tax/metagenome.py
@@ -2,7 +2,7 @@
 
 usage="""
 
-    sourmash tax metagenome --gather-csv [gather_csv(s)] --taxonomy-csv [taxonomy-csv(s)]
+    sourmash tax metagenome --gather-csv <gather_csv> [ ... ] --taxonomy-csv <taxonomy-csv> [ ... ]
 
 The 'tax metagenome' command reads in metagenome gather result CSVs and
 summarizes by taxonomic lineage.


### PR DESCRIPTION
Noticed this in passing, thought I'd bring the usage strings into some sort of compliance with man page guidelines -- per https://linux.die.net/man/7/man-pages

>briefly describes the command or function's interface. For commands, this shows the syntax of the command and its arguments (including options); boldface is used for as-is text and italics are used to indicate replaceable arguments. **Brackets ([]) surround optional arguments**, vertical bars (|) separate choices, and ellipses (...) can be repeated.

ready for review & merge @bluegenes 