### PR TITLE
[MRG] support new picklist coltypes `gather`, `prefetch`, and `manifest`

### DIFF
--- a/doc/command-line.md
+++ b/doc/command-line.md
@@ -1263,13 +1263,20 @@ For example,
 sourmash sig extract --picklist list.csv:md5:md5sum <signatures>
 ```
 will extract only the signatures that have md5sums matching the
-column `md5sum` in the CSV file `list.csv`.
+column `md5sum` in the CSV file `list.csv`. The command
+```
+sourmash sig extract --picklist list.csv::prefetch <signatures>
+```
+will extract only the signatures found in the output
+of `sourmash prefetch ... -o list.csv`.
 
 The `--picklist` argument string must be of the format
-`pickfile:colname:coltype`, where `pickfile` is the path to a CSV
-file, `colname` is the name of the column to select from the CSV
-file (based on the headers in the first line of the CSV file),
-and `coltype` is the type of match.
+`pickfile:colname:coltype[:pickstyle]`, where `pickfile` is the path
+to a CSV file, `colname` is the name of the column to select from the
+CSV file (based on the headers in the first line of the CSV file), and
+`coltype` is the type of match.  An optional pickstyle argument,
+`:include` or `:exclude`, can be added as a fourth parameter; if
+omitted, the default is `:include`.
 
 The following `coltype`s are currently supported by `sourmash sig extract`:
 
@@ -1281,6 +1288,7 @@ The following `coltype`s are currently supported by `sourmash sig extract`:
 * `identprefix` - match to signature's identifier, before '.'
 * `gather` - use the CSV output of `sourmash gather` as a picklist
 * `prefetch` - use the CSV output of `sourmash prefetch` as a picklist
+* `search` - use the CSV output of `sourmash prefetch` as a picklist
 * `manifest` - use the CSV output of `sourmash sig manifest` as a picklist
 
 Identifiers are constructed by using the first space delimited word in

--- a/doc/command-line.md
+++ b/doc/command-line.md
@@ -1279,6 +1279,9 @@ The following `coltype`s are currently supported by `sourmash sig extract`:
 * `md5short` - same as `md5prefix8`
 * `ident` - exact match to signature's identifier
 * `identprefix` - match to signature's identifier, before '.'
+* `gather` - use the CSV output of `sourmash gather` as a picklist
+* `prefetch` - use the CSV output of `sourmash prefetch` as a picklist
+* `manifest` - use the CSV output of `sourmash sig manifest` as a picklist
 
 Identifiers are constructed by using the first space delimited word in
 the signature name.

--- a/src/sourmash/picklist.py
+++ b/src/sourmash/picklist.py
@@ -121,7 +121,7 @@ class SignaturePicklist:
     def _get_sig_attribute(self, ss):
         "for a given SourmashSignature, return attribute for this picklist."
         coltype = self.coltype
-        if coltype in ('md5', 'md5prefix8', 'md5short', 'manifest', 'gather'):
+        if coltype in ('md5', 'md5prefix8', 'md5short'):
             q = ss.md5sum()
         elif coltype in ('name', 'ident', 'identprefix'):
             q = ss.name

--- a/src/sourmash/picklist.py
+++ b/src/sourmash/picklist.py
@@ -44,7 +44,7 @@ class SignaturePicklist:
     Identifiers are constructed by using the first space delimited word in
     the signature name.
 
-    You can also use 'gather', 'prefetch', 'search'm and 'manifest' as
+    You can also use 'gather', 'prefetch', 'search' and 'manifest' as
     column types; these take the CSV output of 'gather', 'prefetch',
     'search', and 'sig manifest' as picklists. 'column' must be left
     blank in this case: e.g. use 'pickfile.csv::gather'.

--- a/src/sourmash/picklist.py
+++ b/src/sourmash/picklist.py
@@ -97,22 +97,26 @@ class SignaturePicklist:
     def from_picklist_args(cls, argstr):
         "load a picklist from an argument string 'pickfile:col:coltype:style'"
         picklist = argstr.split(':')
-        if len(picklist) != 3:
-            if len(picklist) == 4:
-                pickfile, column, coltype, pickstyle = picklist
-                if pickstyle == 'include':
-                    return cls(coltype, pickfile=pickfile, column_name=column, pickstyle=PickStyle.INCLUDE)
-                elif pickstyle == 'exclude':
-                    return cls(coltype, pickfile=pickfile, column_name=column, pickstyle=PickStyle.EXCLUDE)
-                else:
-                    raise ValueError(f"invalid picklist 'pickstyle' argument, '{pickstyle}': must be 'include' or 'exclude'")
+        pickstyle = PickStyle.INCLUDE
 
+        # pickstyle specified?
+        if len(picklist) == 4:
+            pickstyle_str = picklist.pop()
+            if pickstyle_str == 'include':
+                pickstyle = PickStyle.INCLUDE
+            elif pickstyle_str == 'exclude':
+                pickstyle = PickStyle.EXCLUDE
+            else:
+                raise ValueError(f"invalid picklist 'pickstyle' argument, '{pickstyle}': must be 'include' or 'exclude'")
+
+        if len(picklist) != 3:
             raise ValueError(f"invalid picklist argument '{argstr}'")
 
         assert len(picklist) == 3
         pickfile, column, coltype = picklist
 
-        return cls(coltype, pickfile=pickfile, column_name=column)
+        return cls(coltype, pickfile=pickfile, column_name=column,
+                   pickstyle=pickstyle)
 
     def _get_sig_attribute(self, ss):
         "for a given SourmashSignature, return attribute for this picklist."

--- a/src/sourmash/picklist.py
+++ b/src/sourmash/picklist.py
@@ -107,7 +107,7 @@ class SignaturePicklist:
             elif pickstyle_str == 'exclude':
                 pickstyle = PickStyle.EXCLUDE
             else:
-                raise ValueError(f"invalid picklist 'pickstyle' argument, '{pickstyle}': must be 'include' or 'exclude'")
+                raise ValueError(f"invalid picklist 'pickstyle' argument, '{pickstyle_str}': must be 'include' or 'exclude'")
 
         if len(picklist) != 3:
             raise ValueError(f"invalid picklist argument '{argstr}'")

--- a/src/sourmash/picklist.py
+++ b/src/sourmash/picklist.py
@@ -41,10 +41,13 @@ class SignaturePicklist:
     * 'ident' - exact match to signature's identifier
     * 'identprefix' - match to signature's identifier, before '.'
 
-    @CTB add something about meta_coltypes.
-
     Identifiers are constructed by using the first space delimited word in
     the signature name.
+
+    You can also use 'gather', 'prefetch', and 'manifest' as column types;
+    these take the CSV output of 'gather', 'prefetch', and 'sig manifest'
+    as picklists. 'column' must be left blank in this case: e.g. use
+    'pickfile.csv::gather'.
     """
     meta_coltypes = ('manifest', 'gather', 'prefetch')
     supported_coltypes = ('md5', 'md5prefix8', 'md5short',

--- a/src/sourmash/picklist.py
+++ b/src/sourmash/picklist.py
@@ -53,9 +53,10 @@ class SignaturePicklist:
     def __init__(self, coltype, *, pickfile=None, column_name=None,
                  pickstyle=PickStyle.INCLUDE):
         "create a picklist of column type 'coltype'."
+
+        # first, check coltype...
         valid_coltypes = set(self.meta_coltypes)
         valid_coltypes.update(self.supported_coltypes)
-
         if coltype not in valid_coltypes:
             raise ValueError(f"invalid picklist column type '{coltype}'")
 

--- a/src/sourmash/picklist.py
+++ b/src/sourmash/picklist.py
@@ -44,12 +44,12 @@ class SignaturePicklist:
     Identifiers are constructed by using the first space delimited word in
     the signature name.
 
-    You can also use 'gather', 'prefetch', and 'manifest' as column types;
-    these take the CSV output of 'gather', 'prefetch', and 'sig manifest'
-    as picklists. 'column' must be left blank in this case: e.g. use
-    'pickfile.csv::gather'.
+    You can also use 'gather', 'prefetch', 'search'm and 'manifest' as
+    column types; these take the CSV output of 'gather', 'prefetch',
+    'search', and 'sig manifest' as picklists. 'column' must be left
+    blank in this case: e.g. use 'pickfile.csv::gather'.
     """
-    meta_coltypes = ('manifest', 'gather', 'prefetch')
+    meta_coltypes = ('manifest', 'gather', 'prefetch', 'search')
     supported_coltypes = ('md5', 'md5prefix8', 'md5short',
                           'name', 'ident', 'identprefix')
 
@@ -76,7 +76,7 @@ class SignaturePicklist:
                 # for now, override => md5short in column match_md5
                 coltype = 'md5prefix8'
                 column_name = 'match_md5'
-            elif coltype == 'manifest':
+            elif coltype == 'manifest' or coltype == 'search':
                 # for now, override => md5
                 coltype = 'md5'
                 column_name = 'md5'

--- a/src/sourmash/picklist.py
+++ b/src/sourmash/picklist.py
@@ -65,8 +65,6 @@ class SignaturePicklist:
         if coltype in self.meta_coltypes:
             if column_name:
                 raise ValueError(f"no column name allowed for coltype '{coltype}'")
-            if pickstyle != PickStyle.INCLUDE:
-                raise ValueError(f"picklist coltype '{coltype}' only supports picklist inclusion")
             if coltype == 'gather':
                 # for now, override => md5short in column md5
                 coltype = 'md5prefix8'
@@ -79,7 +77,7 @@ class SignaturePicklist:
                 # for now, override => md5
                 coltype = 'md5'
                 column_name = 'md5'
-            else:
+            else:               # should never be reached!
                 assert 0
 
         self.coltype = coltype

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -5220,6 +5220,46 @@ def test_gather_with_prefetch_picklist_3_gather(runtmp, linear_gather):
     assert "1.9 Mbp       13.1%  100.0%    NC_000853.1 " in out
 
 
+def test_gather_with_prefetch_picklist_3_gather_badcol(runtmp):
+    # test 'gather' using a picklist taken from 'sourmash gather' output,
+    # using ::gather.
+    # (this doesn't really do anything useful, but it's an ok test :)
+    gcf_sigs = glob.glob(utils.get_test_data('gather/GCF*.sig'))
+    metag_sig = utils.get_test_data('gather/combined.sig')
+    gather_csv = runtmp.output('gather-out.csv')
+
+    runtmp.sourmash('gather', metag_sig, *gcf_sigs,
+                    '-k', '21', '-o', gather_csv)
+
+    err = runtmp.last_result.err
+    print(err)
+
+    out = runtmp.last_result.out
+    print(out)
+
+    assert "found 11 matches total;" in out
+    assert "the recovered matches hit 99.9% of the query" in out
+
+    assert "4.9 Mbp       33.2%  100.0%    NC_003198.1 " in out
+    assert "1.9 Mbp       13.1%  100.0%    NC_000853.1 " in out
+
+    # now, do another gather with the results, but with a bad picklist
+    # parameter
+    with pytest.raises(ValueError):
+        runtmp.sourmash('gather', metag_sig, *gcf_sigs,
+                        '-k', '21', '--picklist',
+                        f'{gather_csv}:FOO:gather')
+
+    err = runtmp.last_result.err
+    print(err)
+
+    out = runtmp.last_result.out
+    print(out)
+
+    assert "ERROR: could not load picklist." in err
+    assert "no column name allowed for coltype 'gather'" in err
+
+
 def test_gather_with_prefetch_picklist_4_manifest(runtmp, linear_gather):
     # test 'gather' using a picklist taken from 'sourmash sig manifest'
     # output, using ::manifest.
@@ -5252,3 +5292,35 @@ def test_gather_with_prefetch_picklist_4_manifest(runtmp, linear_gather):
 
     # the query sig itself is in there, so :shrug: that matches at 100%
     assert "14.7 Mbp     100.0%  100.0%    -" in out
+
+
+def test_gather_with_prefetch_picklist_4_manifest_excl(runtmp, linear_gather):
+    # test 'gather' using a picklist taken from 'sourmash sig manifest'
+    # output, using ::manifest.
+    # (this doesn't really do anything useful, but it's an ok test :)
+    gather_dir = utils.get_test_data('gather/')
+    metag_sig = utils.get_test_data('gather/combined.sig')
+    manifest_csv = runtmp.output('manifest.csv')
+
+    runtmp.sourmash('sig', 'manifest', gather_dir, '-o', manifest_csv)
+
+    err = runtmp.last_result.err
+    print(err)
+
+    out = runtmp.last_result.out
+    print(out)
+
+    # now, do a gather on the manifest
+    runtmp.sourmash('gather', metag_sig, gather_dir, linear_gather,
+                    '-k', '21', '--picklist',
+                    f'{manifest_csv}::manifest:exclude')
+
+    err = runtmp.last_result.err
+    print(err)
+
+    out = runtmp.last_result.out
+    print(out)
+
+    # excluded everything, so nothing to match!
+    assert "found 0 matches total;" in out
+    assert "the recovered matches hit 0.0% of the query" in out

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -5142,7 +5142,7 @@ def test_gather_with_prefetch_picklist(runtmp, linear_gather):
     assert "1.9 Mbp       13.1%  100.0%    NC_000853.1 " in out
 
 
-def test_gather_with_prefetch_picklist_2(runtmp, linear_gather):
+def test_gather_with_prefetch_picklist_2_prefetch(runtmp, linear_gather):
     # test 'gather' using a picklist taken from 'sourmash prefetch' output
     # using ::prefetch
     gcf_sigs = glob.glob(utils.get_test_data('gather/GCF*.sig'))
@@ -5218,3 +5218,37 @@ def test_gather_with_prefetch_picklist_3_gather(runtmp, linear_gather):
 
     assert "4.9 Mbp       33.2%  100.0%    NC_003198.1 " in out
     assert "1.9 Mbp       13.1%  100.0%    NC_000853.1 " in out
+
+
+def test_gather_with_prefetch_picklist_4_manifest(runtmp, linear_gather):
+    # test 'gather' using a picklist taken from 'sourmash sig manifest'
+    # output, using ::manifest.
+    # (this doesn't really do anything useful, but it's an ok test :)
+    gather_dir = utils.get_test_data('gather/')
+    metag_sig = utils.get_test_data('gather/combined.sig')
+    manifest_csv = runtmp.output('manifest.csv')
+
+    runtmp.sourmash('sig', 'manifest', gather_dir, '-o', manifest_csv)
+
+    err = runtmp.last_result.err
+    print(err)
+
+    out = runtmp.last_result.out
+    print(out)
+
+    # now, do a gather on the manifest
+    runtmp.sourmash('gather', metag_sig, gather_dir, linear_gather,
+                    '-k', '21', '--picklist',
+                    f'{manifest_csv}::manifest')
+
+    err = runtmp.last_result.err
+    print(err)
+
+    out = runtmp.last_result.out
+    print(out)
+
+    assert "found 1 matches total;" in out
+    assert "the recovered matches hit 100.0% of the query" in out
+
+    # the query sig itself is in there, so :shrug: that matches at 100%
+    assert "14.7 Mbp     100.0%  100.0%    -" in out

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -5140,3 +5140,81 @@ def test_gather_with_prefetch_picklist(runtmp, linear_gather):
 
     assert "4.9 Mbp       33.2%  100.0%    NC_003198.1 " in out
     assert "1.9 Mbp       13.1%  100.0%    NC_000853.1 " in out
+
+
+def test_gather_with_prefetch_picklist_2(runtmp, linear_gather):
+    # test 'gather' using a picklist taken from 'sourmash prefetch' output
+    # using ::prefetch
+    gcf_sigs = glob.glob(utils.get_test_data('gather/GCF*.sig'))
+    metag_sig = utils.get_test_data('gather/combined.sig')
+    prefetch_csv = runtmp.output('prefetch-out.csv')
+
+    runtmp.sourmash('prefetch', metag_sig, *gcf_sigs,
+                    '-k', '21', '-o', prefetch_csv)
+
+    err = runtmp.last_result.err
+    print(err)
+
+    out = runtmp.last_result.out
+    print(out)
+
+    assert "total of 12 matching signatures." in err
+    assert "of 1466 distinct query hashes, 1466 were found in matches above threshold." in err
+
+    # now, do a gather with the results
+    runtmp.sourmash('gather', metag_sig, *gcf_sigs, linear_gather,
+                    '-k', '21', '--picklist',
+                    f'{prefetch_csv}::prefetch')
+
+    err = runtmp.last_result.err
+    print(err)
+
+    out = runtmp.last_result.out
+    print(out)
+
+    assert "found 11 matches total;" in out
+    assert "the recovered matches hit 99.9% of the query" in out
+
+    assert "4.9 Mbp       33.2%  100.0%    NC_003198.1 " in out
+    assert "1.9 Mbp       13.1%  100.0%    NC_000853.1 " in out
+
+
+def test_gather_with_prefetch_picklist_3_gather(runtmp, linear_gather):
+    # test 'gather' using a picklist taken from 'sourmash gather' output,
+    # using ::gather.
+    # (this doesn't really do anything useful, but it's an ok test :)
+    gcf_sigs = glob.glob(utils.get_test_data('gather/GCF*.sig'))
+    metag_sig = utils.get_test_data('gather/combined.sig')
+    gather_csv = runtmp.output('gather-out.csv')
+
+    runtmp.sourmash('gather', metag_sig, *gcf_sigs,
+                    '-k', '21', '-o', gather_csv)
+
+    err = runtmp.last_result.err
+    print(err)
+
+    out = runtmp.last_result.out
+    print(out)
+
+    assert "found 11 matches total;" in out
+    assert "the recovered matches hit 99.9% of the query" in out
+
+    assert "4.9 Mbp       33.2%  100.0%    NC_003198.1 " in out
+    assert "1.9 Mbp       13.1%  100.0%    NC_000853.1 " in out
+
+    # now, do another gather with the results
+    runtmp.sourmash('gather', metag_sig, *gcf_sigs, linear_gather,
+                    '-k', '21', '--picklist',
+                    f'{gather_csv}::gather')
+
+    err = runtmp.last_result.err
+    print(err)
+
+    out = runtmp.last_result.out
+    print(out)
+
+    assert "found 11 matches total;" in out
+    assert "the recovered matches hit 99.9% of the query" in out
+
+    assert "4.9 Mbp       33.2%  100.0%    NC_003198.1 " in out
+    assert "1.9 Mbp       13.1%  100.0%    NC_000853.1 " in out

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -5324,3 +5324,40 @@ def test_gather_with_prefetch_picklist_4_manifest_excl(runtmp, linear_gather):
     # excluded everything, so nothing to match!
     assert "found 0 matches total;" in out
     assert "the recovered matches hit 0.0% of the query" in out
+
+
+def test_gather_with_prefetch_picklist_5_search(runtmp):
+    # test 'gather' using a picklist taken from 'sourmash prefetch' output
+    # using ::prefetch
+    gcf_sigs = glob.glob(utils.get_test_data('gather/GCF*.sig'))
+    metag_sig = utils.get_test_data('gather/combined.sig')
+    search_csv = runtmp.output('search-out.csv')
+
+    runtmp.sourmash('search', '--containment', metag_sig, *gcf_sigs,
+                    '-k', '21', '-o', search_csv)
+
+    err = runtmp.last_result.err
+    print(err)
+
+    out = runtmp.last_result.out
+    print(out)
+
+    assert "12 matches; showing first 3:" in out
+    assert " 33.2%       NC_003198.1 Salmonella enterica subsp." in out
+
+    # now, do a gather with the results
+    runtmp.sourmash('gather', metag_sig, *gcf_sigs,
+                    '-k', '21', '--picklist',
+                    f'{search_csv}::search')
+
+    err = runtmp.last_result.err
+    print(err)
+
+    out = runtmp.last_result.out
+    print(out)
+
+    assert "found 11 matches total;" in out
+    assert "the recovered matches hit 99.9% of the query" in out
+
+    assert "4.9 Mbp       33.2%  100.0%    NC_003198.1 " in out
+    assert "1.9 Mbp       13.1%  100.0%    NC_000853.1 " in out


### PR DESCRIPTION
This PR adds three new picklist types - `gather`, `prefetch`, and `manifest`. These picklist types load the CSV output of `sourmash gather`, `sourmash prefetch`, and `sourmash sig manifest` (or, generically, any manifest...) for use as a picklist.

To use them, omit the column name and just use the 'special' column type:
```
sourmash gather <query> <db> --picklist xyz.csv::prefetch
```

The goal is to support a range of use cases, e.g.
```
sourmash prefetch <query> <db> -o xyz.csv
sourmash gather <query> <db> --picklist xyz.csv::prefetch
```

- [x] needs tests...
- [x] should we add `search` coltype too?
- [ ] enable explicit composite coltypes, e.g. (md5, ident) to deal with duplicate md5?