### PR TITLE
[MRG] implement a lazy/on-demand `Index` loading class

### DIFF
--- a/src/sourmash/index.py
+++ b/src/sourmash/index.py
@@ -1066,20 +1066,18 @@ class LazyLoadedIndex(Index):
         return bool(self.manifest)
 
     @classmethod
-    def load(cls, location, *, create_manifest=False):
-        "Load manifest from given location, and then unload."
+    def load(cls, location):
+        """Load index from given location, but retain only the manifest.
+
+        Fail if no manifest.
+        """
         idx = sourmash.load_file_as_index(location)
         manifest = idx.manifest
 
-        # do we need to create the manifest?
-        if manifest is None:
-            if create_manifest:
-                iter = idx._signatures_with_internal()
-                manifest = CollectionManifest.create_manifest(idx,
-                                                       include_signature=False)
-            else:
-                raise ValueError(f"no manifest on index at {location}")
+        if not idx.manifest:
+            raise ValueError(f"no manifest on index at {location}")
 
+        del idx
         # NOTE: index is not retained outside this scope, just location.
 
         return cls(location, manifest)

--- a/src/sourmash/index.py
+++ b/src/sourmash/index.py
@@ -28,6 +28,8 @@ ZipFileLinearIndex - simple on-disk storage of signatures.
 class MultiIndex - in-memory storage and selection of signatures from multiple
 index objects, using manifests.
 
+LazyLoadedIndex - selection on manifests with loading of index on demand.
+
 CounterGather - an ancillary class returned by the 'counter_gather()' method.
 """
 
@@ -987,3 +989,112 @@ class MultiIndex(Index):
         "Run 'select' on the manifest."
         new_manifest = self.manifest.select_to_manifest(**kwargs)
         return MultiIndex(new_manifest, parent=self.parent)
+
+
+class LazyLoadedIndex(Index):
+    """Given an index location and a manifest, do select only on the manifest
+    until signatures are actually requested, and only then load the index.
+
+    This class is useful when you have an index object that consume
+    memory when it is loaded (e.g. JSON signature files, or LCA
+    databases) and you want to avoid keeping them in memory.  The
+    downside of using this class is that it will load the signatures
+    from disk every time they are needed (e.g. 'find(...)', 'signatures()').
+
+    Can be used with LazyMultiIndex to support many such indices at once.
+
+    Wrapper class; signatures dynamically loaded from disk; uses manifests.
+    """
+    def __init__(self, filename, manifest):
+        "Create an Index with given filename and manifest."
+        self.filename = filename
+        self.manifest = manifest
+
+    @property
+    def location(self):
+        "the 'location' attribute for this index will be the filename."
+        return self.filename
+
+    def signatures(self):
+        "yield all signatures from the manifest."
+        if not len(self):
+            # nothing in manifest? done!
+            return []
+
+        # ok - something in manifest, let's go get those signatures!
+        picklist = self.manifest.to_picklist()
+        idx = sourmash.load_file_as_index(self.location)
+
+        # convert remaining manifest into picklist
+        # CTB: one optimization down the road is, for storage-backed
+        # Index objects, to just reach in and get the signatures directly,
+        # without going through 'select'. Still, this is nice for abstraction
+        # because we don't need to care what the index is - it'll work on
+        # anything. It just might be a bit slower.
+        idx = idx.select(picklist=picklist)
+
+        # extract signatures.
+        for ss in idx.signatures():
+            yield ss
+
+    def find(self, *args, **kwargs):
+        """Run find after loading and selecting; this provides 'search',
+        "'gather', and 'prefetch' functionality, which are built on 'find'.
+        """
+        if not len(self):
+            # nothing in manifest? done!
+            return []
+
+        # ok - something in manifest, let's go get those signatures!
+        picklist = self.manifest.to_picklist()
+        idx = sourmash.load_file_as_index(self.location)
+
+        # convert remaining manifest into picklist
+        # CTB: one optimization down the road is, for storage-backed
+        # Index objects, to just reach in and get the signatures directly,
+        # without going through 'select'. Still, this is nice for abstraction
+        # because we don't need to care what the index is - it'll work on
+        # anything. It just might be a bit slower.
+        idx = idx.select(picklist=picklist)
+
+        for x in idx.find(*args, **kwargs):
+            yield x
+
+    def __len__(self):
+        "track index size based on the manifest."
+        return len(self.manifest)
+
+    def __bool__(self):
+        return bool(self.manifest)
+
+    @classmethod
+    def load(cls, location, *, create_manifest=False):
+        "Load manifest from given location, and then unload."
+        idx = sourmash.load_file_as_index(location)
+        manifest = idx.manifest
+
+        # do we need to create the manifest?
+        if manifest is None:
+            if create_manifest:
+                iter = idx._signatures_with_internal()
+                manifest = CollectionManifest.create_manifest(idx,
+                                                       include_signature=False)
+            else:
+                raise ValueError(f"no manifest on index at {location}")
+
+        # NOTE: index is not retained outside this scope, just location.
+
+        return cls(location, manifest)
+
+    def insert(self, *args):
+        raise NotImplementedError
+
+    def save(self, *args):
+        raise NotImplementedError
+
+    def select(self, **kwargs):
+        "Run 'select' on manifest, return new object with new manifest."
+        manifest = self.manifest
+        new_manifest = manifest.select_to_manifest(**kwargs)
+
+        return LazyLoadedIndex(self.filename, new_manifest)

--- a/src/sourmash/index.py
+++ b/src/sourmash/index.py
@@ -1001,8 +1001,6 @@ class LazyLoadedIndex(Index):
     downside of using this class is that it will load the signatures
     from disk every time they are needed (e.g. 'find(...)', 'signatures()').
 
-    Can be used with LazyMultiIndex to support many such indices at once.
-
     Wrapper class; signatures dynamically loaded from disk; uses manifests.
     """
     def __init__(self, filename, manifest):

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -2240,3 +2240,49 @@ def test_lazy_loaded_index_1(runtmp):
     shutil.copyfile(sigzip, test_zip)
     x = list(db.signatures())
     assert len(x) == 2
+
+
+def test_lazy_loaded_index_2_empty(runtmp):
+    # some basic tests for LazyLoadedIndex that is empty
+    sigzip = utils.get_test_data('prot/protein.zip')
+
+    # load something:
+    test_zip = runtmp.output('test.zip')
+    shutil.copyfile(sigzip, test_zip)
+    db = index.LazyLoadedIndex.load(test_zip)
+    assert len(db) == 2
+    assert db.location == test_zip
+    assert bool(db)
+
+    # select to empty:
+    db = db.select(ksize=50)
+
+    assert len(db) == 0
+    assert not bool(db)
+
+    x = list(db.signatures())
+    assert len(x) == 0
+
+
+def test_lazy_loaded_index_3_find(runtmp):
+    # test 'find'
+    query_file = utils.get_test_data('prot/protein/GCA_001593925.1_ASM159392v1_protein.faa.gz.sig')
+    sigzip = utils.get_test_data('prot/protein.zip')
+
+    # load something:
+    test_zip = runtmp.output('test.zip')
+    shutil.copyfile(sigzip, test_zip)
+    db = index.LazyLoadedIndex.load(test_zip)
+
+    # can we find matches? should find two.
+    query = sourmash.load_one_signature(query_file)
+    assert query.minhash.ksize == 19
+    x = db.search(query, threshold=0.0)
+    x = list(x)
+    assert len(x) == 2
+
+    # no matches!
+    db = db.select(ksize=20)
+    x = db.search(query, threshold=0.0)
+    x = list(x)
+    assert len(x) == 0

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -2214,11 +2214,6 @@ def test_lazy_loaded_index_1(runtmp):
     # no manifest on LCA database
     assert "no manifest on index at" in str(exc)
 
-    with pytest.raises(NotImplementedError) as exc:
-        db = index.LazyLoadedIndex.load(lcafile, create_manifest=True)
-    # can't create a manifest, either, at the moment, b/c no
-    # _signatures_with_internal
-
     # load something, check that it's only accessed upon .signatures(...)
     test_zip = runtmp.output('test.zip')
     shutil.copyfile(sigzip, test_zip)
@@ -2286,12 +2281,3 @@ def test_lazy_loaded_index_3_find(runtmp):
     x = db.search(query, threshold=0.0)
     x = list(x)
     assert len(x) == 0
-
-
-def test_lazy_loaded_index_4_create_manifest(runtmp):
-    # test load from a directory w/no manifest
-    lcafile = utils.get_test_data('prot/protein.lca.json.gz')
-
-    # load, and try to create manifest; should fail :)
-    with pytest.raises(NotImplementedError):
-        db = index.LazyLoadedIndex.load(lcafile, create_manifest=True)

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -2286,3 +2286,14 @@ def test_lazy_loaded_index_3_find(runtmp):
     x = db.search(query, threshold=0.0)
     x = list(x)
     assert len(x) == 0
+
+
+def test_lazy_loaded_index_4_create_manifest(runtmp):
+    # test load from a directory w/no manifest
+    dirname = utils.get_test_data('prot/protein/')
+
+    # load:
+    db = index.LazyLoadedIndex.load(dirname)
+
+    assert len(db) == 2
+    assert db.location == dirname

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -2290,10 +2290,8 @@ def test_lazy_loaded_index_3_find(runtmp):
 
 def test_lazy_loaded_index_4_create_manifest(runtmp):
     # test load from a directory w/no manifest
-    dirname = utils.get_test_data('prot/protein/')
+    lcafile = utils.get_test_data('prot/protein.lca.json.gz')
 
-    # load:
-    db = index.LazyLoadedIndex.load(dirname)
-
-    assert len(db) == 2
-    assert db.location == dirname
+    # load, and try to create manifest; should fail :)
+    with pytest.raises(NotImplementedError):
+        db = index.LazyLoadedIndex.load(lcafile, create_manifest=True)


### PR DESCRIPTION
This PR implements `indexLazyLoadedIndex(...)` which takes the location of an index + and a manifest, and only opens the index when signatures are needed. In particular, `select` calls are performed on the manifest, and then on index load the manifest is used as a picklist to select out the signatures to be loaded. 

In brief, this supports low memory tracking of a large index without needing to keep the Index object itself in memory.

(Code originally developed over in https://github.com/sourmash-bio/sourmash/pull/1619)

- [x] add tests for find, bool, and empty manifest