### PR TITLE
[MRG] add tests for containment threshold arg

### DIFF
--- a/src/sourmash/cli/utils.py
+++ b/src/sourmash/cli/utils.py
@@ -1,5 +1,6 @@
 from glob import glob
 import os
+import argparse
 
 
 def add_moltype_args(parser):
@@ -58,9 +59,9 @@ def range_limited_float_type(arg):
     try:
         f = float(arg)
     except ValueError:
-        raise argparse.ArgumentTypeError("Must be a floating point number")
+        raise argparse.ArgumentTypeError("\n\tERROR: Must be a floating point number.")
     if f < min_val or f > max_val:
-        raise argparse.ArgumentTypeError(f"Argument must be >{str(min_val)} and <{str(max_val)}")
+        raise argparse.ArgumentTypeError(f"\n\tERROR: Argument must be >{str(min_val)} and <{str(max_val)}.")
     return f
 
 

--- a/tests/test_tax.py
+++ b/tests/test_tax.py
@@ -1222,6 +1222,48 @@ def test_genome_empty_gather_results_with_csv_force(runtmp):
     assert "test1,match,species,0.058,d__Bacteria;p__Proteobacteria;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Escherichia;s__Escherichia coli" in c.last_result.out
 
 
+def test_genome_containment_threshold_bounds(runtmp):
+    c = runtmp
+    g_csv = utils.get_test_data('tax/test1.gather.csv')
+    tax = utils.get_test_data('tax/test.taxonomy.csv')
+    below_threshold = "-1"
+
+    with pytest.raises(ValueError) as exc:
+        c.run_sourmash('tax', 'genome', '-g', tax, '--taxonomy-csv', tax,
+                       '--containment-threshold', below_threshold)
+
+    print(c.last_result.status)
+    print(c.last_result.out)
+    print(c.last_result.err)
+    assert "ERROR: Argument must be >0 and <1" in str(exc.value)
+
+    above_threshold = "1.1"
+    with pytest.raises(ValueError) as exc:
+        c.run_sourmash('tax', 'genome', '-g', tax, '--taxonomy-csv', tax,
+                       '--containment-threshold', above_threshold)
+
+    print(c.last_result.status)
+    print(c.last_result.out)
+    print(c.last_result.err)
+    assert "ERROR: Argument must be >0 and <1" in str(exc.value)
+
+
+def test_genome_containment_threshold_type(runtmp):
+    c = runtmp
+    g_csv = utils.get_test_data('tax/test1.gather.csv')
+    tax = utils.get_test_data('tax/test.taxonomy.csv')
+    not_a_float = "str"
+
+    with pytest.raises(ValueError) as exc:
+        c.run_sourmash('tax', 'genome', '-g', tax, '--taxonomy-csv', tax,
+                       '--containment-threshold', not_a_float)
+
+    print(c.last_result.status)
+    print(c.last_result.out)
+    print(c.last_result.err)
+    assert "ERROR: Must be a floating point number" in str(exc.value)
+
+
 def test_annotate_0(runtmp):
     # test annotate
     c = runtmp


### PR DESCRIPTION
Add tests for`tax genome` `--containment-threshold` arg, which I missed in the main tax PR!

this PR:
- import argparse in `cli/utils.py`
- test threshold param type, as well as upper /lower bounds