### PR TITLE
[MRG] fix scaled=1 gather bug

### DIFF
--- a/src/sourmash/search.py
+++ b/src/sourmash/search.py
@@ -312,7 +312,7 @@ class GatherDatabases:
         self.orig_query_mh = orig_query_mh
         self.orig_query_abunds = orig_query_abunds
 
-        self.cmp_scaled = 1
+        self.cmp_scaled = 0     # initialize with something very low!
         self._update_scaled(cmp_scaled)
 
     def _update_scaled(self, scaled):

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -5361,3 +5361,22 @@ def test_gather_with_prefetch_picklist_5_search(runtmp):
 
     assert "4.9 Mbp       33.2%  100.0%    NC_003198.1 " in out
     assert "1.9 Mbp       13.1%  100.0%    NC_000853.1 " in out
+
+
+def test_gather_scaled_1(runtmp, linear_gather, prefetch_gather):
+    # test gather on a sig indexed with scaled=1
+    inp = utils.get_test_data('short.fa')
+    outp = runtmp.output('out.sig')
+
+    # prepare a signature with a scaled of 1
+    runtmp.sourmash('sketch', 'dna', '-p', 'scaled=1,k=31', inp, '-o', outp)
+
+    # run with a low threshold
+    runtmp.sourmash('gather', outp, outp, '--threshold-bp', '0')
+
+    print(runtmp.last_result.out)
+    print('---')
+    print(runtmp.last_result.err)
+
+    assert "1.0 kbp      100.0%  100.0%" in runtmp.last_result.out
+    assert "found 1 matches total;" in runtmp.last_result.out


### PR DESCRIPTION
Creates a test for & and fixes a bug noted in https://github.com/sourmash-bio/sourmash/issues/1421#issuecomment-879682078 - the default "unset" value used in the https://github.com/sourmash-bio/sourmash/pull/1613 code was set to a valid scaled value, and we never tested it! Oops!
