### PR TITLE
[MRG] refactor and simplify `sourmash sig` subcommand signature loading

### DIFF
--- a/src/sourmash/cli/categorize.py
+++ b/src/sourmash/cli/categorize.py
@@ -1,7 +1,5 @@
 "'sourmash categorize' - query an SBT for bes match, with many signatures."
 
-import argparse
-
 from sourmash.cli.utils import add_ksize_arg, add_moltype_args
 
 

--- a/src/sourmash/cli/compute.py
+++ b/src/sourmash/cli/compute.py
@@ -29,8 +29,6 @@ Please see -h for all of the options as well as more detailed help.
 ---
 """
 
-from argparse import FileType
-
 from sourmash.minhash import get_minhash_default_seed
 from sourmash.cli.utils import add_construct_moltype_args
 

--- a/src/sourmash/cli/import_csv.py
+++ b/src/sourmash/cli/import_csv.py
@@ -1,6 +1,5 @@
 """'sourmash import_csv' description goes here"""
 
-import sys
 from sourmash.logging import notify
 
 

--- a/src/sourmash/cli/sig/cat.py
+++ b/src/sourmash/cli/sig/cat.py
@@ -2,6 +2,7 @@
 
 import sourmash
 from sourmash.logging import notify, print_results, error
+from sourmash.cli.utils import add_moltype_args, add_ksize_arg
 
 
 def subparser(subparsers):
@@ -27,6 +28,8 @@ def subparser(subparsers):
         '-f', '--force', action='store_true',
         help='try to load all files as signatures'
     )
+    add_ksize_arg(subparser, 31)
+    add_moltype_args(subparser)
 
 
 def main(args):

--- a/src/sourmash/cli/sig/cat.py
+++ b/src/sourmash/cli/sig/cat.py
@@ -1,7 +1,5 @@
 """concatenate signature files"""
 
-import sourmash
-from sourmash.logging import notify, print_results, error
 from sourmash.cli.utils import (add_moltype_args, add_ksize_arg,
                                 add_picklist_args)
 

--- a/src/sourmash/cli/sig/cat.py
+++ b/src/sourmash/cli/sig/cat.py
@@ -2,7 +2,8 @@
 
 import sourmash
 from sourmash.logging import notify, print_results, error
-from sourmash.cli.utils import add_moltype_args, add_ksize_arg
+from sourmash.cli.utils import (add_moltype_args, add_ksize_arg,
+                                add_picklist_args)
 
 
 def subparser(subparsers):
@@ -30,6 +31,7 @@ def subparser(subparsers):
     )
     add_ksize_arg(subparser, 31)
     add_moltype_args(subparser)
+    add_picklist_args(subparser)
 
 
 def main(args):

--- a/src/sourmash/cli/sig/describe.py
+++ b/src/sourmash/cli/sig/describe.py
@@ -1,7 +1,5 @@
 """show details of signature"""
 
-import sourmash
-from sourmash.logging import notify, print_results, error
 from sourmash.cli.utils import (add_moltype_args, add_ksize_arg,
                                 add_picklist_args)
 

--- a/src/sourmash/cli/sig/describe.py
+++ b/src/sourmash/cli/sig/describe.py
@@ -2,6 +2,7 @@
 
 import sourmash
 from sourmash.logging import notify, print_results, error
+from sourmash.cli.utils import add_moltype_args, add_ksize_arg
 
 
 def subparser(subparsers):
@@ -15,6 +16,16 @@ def subparser(subparsers):
         '--csv', metavar='FILE',
         help='output information to a CSV file'
     )
+    subparser.add_argument(
+        '-f', '--force', action='store_true',
+        help='try to load all files as signatures'
+    )
+    subparser.add_argument(
+        '--from-file',
+        help='a text file containing a list of files to load signatures from'
+    )
+    add_ksize_arg(subparser, 31)
+    add_moltype_args(subparser)
 
 
 def main(args):

--- a/src/sourmash/cli/sig/describe.py
+++ b/src/sourmash/cli/sig/describe.py
@@ -7,7 +7,7 @@ from sourmash.cli.utils import add_moltype_args, add_ksize_arg
 
 def subparser(subparsers):
     subparser = subparsers.add_parser('describe')
-    subparser.add_argument('signatures', nargs='+')
+    subparser.add_argument('signatures', nargs='*')
     subparser.add_argument(
         '-q', '--quiet', action='store_true',
         help='suppress non-error output'

--- a/src/sourmash/cli/sig/describe.py
+++ b/src/sourmash/cli/sig/describe.py
@@ -2,7 +2,8 @@
 
 import sourmash
 from sourmash.logging import notify, print_results, error
-from sourmash.cli.utils import add_moltype_args, add_ksize_arg
+from sourmash.cli.utils import (add_moltype_args, add_ksize_arg,
+                                add_picklist_args)
 
 
 def subparser(subparsers):
@@ -26,6 +27,7 @@ def subparser(subparsers):
     )
     add_ksize_arg(subparser, 31)
     add_moltype_args(subparser)
+    add_picklist_args(subparser)
 
 
 def main(args):

--- a/src/sourmash/cli/sig/downsample.py
+++ b/src/sourmash/cli/sig/downsample.py
@@ -2,7 +2,8 @@
 
 import sys
 
-from sourmash.cli.utils import add_moltype_args, add_ksize_arg
+from sourmash.cli.utils import (add_moltype_args, add_ksize_arg,
+                                add_picklist_args)
 
 
 def subparser(subparsers):
@@ -35,6 +36,7 @@ def subparser(subparsers):
     )
     add_ksize_arg(subparser, 31)
     add_moltype_args(subparser)
+    add_picklist_args(subparser)
 
 
 def main(args):

--- a/src/sourmash/cli/sig/downsample.py
+++ b/src/sourmash/cli/sig/downsample.py
@@ -7,7 +7,7 @@ from sourmash.cli.utils import add_moltype_args, add_ksize_arg
 
 def subparser(subparsers):
     subparser = subparsers.add_parser('downsample')
-    subparser.add_argument('signatures', nargs="+")
+    subparser.add_argument('signatures', nargs="*")
     subparser.add_argument(
         '--scaled', type=int, default=0,
         help='scaled value to downsample to'

--- a/src/sourmash/cli/sig/downsample.py
+++ b/src/sourmash/cli/sig/downsample.py
@@ -13,6 +13,10 @@ def subparser(subparsers):
         help='scaled value to downsample to'
     )
     subparser.add_argument(
+        '--from-file',
+        help='a text file containing a list of files to load signatures from'
+    )
+    subparser.add_argument(
         '--num', metavar='N', type=int, default=0,
         help='num value to downsample to'
     )
@@ -24,6 +28,10 @@ def subparser(subparsers):
         '-o', '--output', metavar='FILE',
         help='output signature to this file (default stdout)',
         default='-',
+    )
+    subparser.add_argument(
+        '-f', '--force', action='store_true',
+        help='try to load all files as signatures'
     )
     add_ksize_arg(subparser, 31)
     add_moltype_args(subparser)

--- a/src/sourmash/cli/sig/downsample.py
+++ b/src/sourmash/cli/sig/downsample.py
@@ -1,7 +1,5 @@
 """downsample one or more signatures"""
 
-import sys
-
 from sourmash.cli.utils import (add_moltype_args, add_ksize_arg,
                                 add_picklist_args)
 

--- a/src/sourmash/cli/sig/export.py
+++ b/src/sourmash/cli/sig/export.py
@@ -1,7 +1,5 @@
 """export a signature, e.g. to mash"""
 
-import sys
-
 from sourmash.cli.utils import add_ksize_arg, add_moltype_args
 
 

--- a/src/sourmash/cli/sig/extract.py
+++ b/src/sourmash/cli/sig/extract.py
@@ -8,7 +8,7 @@ from sourmash.cli.utils import (add_moltype_args, add_ksize_arg,
 
 def subparser(subparsers):
     subparser = subparsers.add_parser('extract')
-    subparser.add_argument('signatures', nargs='+')
+    subparser.add_argument('signatures', nargs='*')
     subparser.add_argument(
         '-q', '--quiet', action='store_true',
         help='suppress non-error output'
@@ -25,6 +25,14 @@ def subparser(subparsers):
     subparser.add_argument(
         '--name', default=None,
         help='select signatures whose name contains this substring'
+    )
+    subparser.add_argument(
+        '-f', '--force', action='store_true',
+        help='try to load all files as signatures'
+    )
+    subparser.add_argument(
+        '--from-file',
+        help='a text file containing a list of files to load signatures from'
     )
     add_ksize_arg(subparser, 31)
     add_moltype_args(subparser)

--- a/src/sourmash/cli/sig/extract.py
+++ b/src/sourmash/cli/sig/extract.py
@@ -1,7 +1,5 @@
 """extract one or more signatures"""
 
-import sys
-
 from sourmash.cli.utils import (add_moltype_args, add_ksize_arg,
                                 add_picklist_args)
 

--- a/src/sourmash/cli/sig/filter.py
+++ b/src/sourmash/cli/sig/filter.py
@@ -1,7 +1,5 @@
 """filter k-mers on abundance"""
 
-import sys
-
 from sourmash.cli.utils import add_moltype_args, add_ksize_arg
 
 

--- a/src/sourmash/cli/sig/flatten.py
+++ b/src/sourmash/cli/sig/flatten.py
@@ -2,7 +2,8 @@
 
 import sys
 
-from sourmash.cli.utils import add_moltype_args, add_ksize_arg
+from sourmash.cli.utils import (add_moltype_args, add_ksize_arg,
+                                add_picklist_args)
 
 
 def subparser(subparsers):
@@ -35,6 +36,7 @@ def subparser(subparsers):
     )
     add_ksize_arg(subparser, 31)
     add_moltype_args(subparser)
+    add_picklist_args(subparser)
 
 
 def main(args):

--- a/src/sourmash/cli/sig/flatten.py
+++ b/src/sourmash/cli/sig/flatten.py
@@ -1,7 +1,5 @@
 """remove abundances"""
 
-import sys
-
 from sourmash.cli.utils import (add_moltype_args, add_ksize_arg,
                                 add_picklist_args)
 

--- a/src/sourmash/cli/sig/flatten.py
+++ b/src/sourmash/cli/sig/flatten.py
@@ -7,7 +7,7 @@ from sourmash.cli.utils import add_moltype_args, add_ksize_arg
 
 def subparser(subparsers):
     subparser = subparsers.add_parser('flatten')
-    subparser.add_argument('signatures', nargs='+')
+    subparser.add_argument('signatures', nargs='*')
     subparser.add_argument(
         '-q', '--quiet', action='store_true',
         help='suppress non-error output'
@@ -24,6 +24,14 @@ def subparser(subparsers):
     subparser.add_argument(
         '--name', default=None,
         help='select signatures whose name contains this substring'
+    )
+    subparser.add_argument(
+        '-f', '--force', action='store_true',
+        help='try to load all files as signatures'
+    )
+    subparser.add_argument(
+        '--from-file',
+        help='a text file containing a list of files to load signatures from'
     )
     add_ksize_arg(subparser, 31)
     add_moltype_args(subparser)

--- a/src/sourmash/cli/sig/ingest.py
+++ b/src/sourmash/cli/sig/ingest.py
@@ -1,7 +1,5 @@
 """ingest/import a mash or other signature"""
 
-import sys
-
 
 def subparser(subparsers):
     # Dirty hack to simultaneously support new and previous interface

--- a/src/sourmash/cli/sig/intersect.py
+++ b/src/sourmash/cli/sig/intersect.py
@@ -7,7 +7,7 @@ from sourmash.cli.utils import add_moltype_args, add_ksize_arg
 
 def subparser(subparsers):
     subparser = subparsers.add_parser('intersect')
-    subparser.add_argument('signatures', nargs='+')
+    subparser.add_argument('signatures', nargs='*')
     subparser.add_argument(
         '-q', '--quiet', action='store_true',
         help='suppress non-error output'
@@ -19,6 +19,14 @@ def subparser(subparsers):
     subparser.add_argument(
         '-A', '--abundances-from', metavar='FILE',
         help='intersect with & take abundances from this signature'
+    )
+    subparser.add_argument(
+        '-f', '--force', action='store_true',
+        help='try to load all files as signatures'
+    )
+    subparser.add_argument(
+        '--from-file',
+        help='a text file containing a list of files to load signatures from'
     )
     add_ksize_arg(subparser, 31)
     add_moltype_args(subparser)

--- a/src/sourmash/cli/sig/intersect.py
+++ b/src/sourmash/cli/sig/intersect.py
@@ -2,7 +2,8 @@
 
 import sys
 
-from sourmash.cli.utils import add_moltype_args, add_ksize_arg
+from sourmash.cli.utils import (add_moltype_args, add_ksize_arg,
+                                add_picklist_args)
 
 
 def subparser(subparsers):
@@ -30,6 +31,7 @@ def subparser(subparsers):
     )
     add_ksize_arg(subparser, 31)
     add_moltype_args(subparser)
+    add_picklist_args(subparser)
 
 
 def main(args):

--- a/src/sourmash/cli/sig/intersect.py
+++ b/src/sourmash/cli/sig/intersect.py
@@ -1,7 +1,5 @@
 """intersect one or more signatures"""
 
-import sys
-
 from sourmash.cli.utils import (add_moltype_args, add_ksize_arg,
                                 add_picklist_args)
 

--- a/src/sourmash/cli/sig/manifest.py
+++ b/src/sourmash/cli/sig/manifest.py
@@ -1,8 +1,5 @@
 """create a manifest for a collection of signatures"""
 
-import sourmash
-from sourmash.logging import notify, print_results, error
-
 
 def subparser(subparsers):
     subparser = subparsers.add_parser('manifest')

--- a/src/sourmash/cli/sig/merge.py
+++ b/src/sourmash/cli/sig/merge.py
@@ -2,7 +2,8 @@
 
 import sys
 
-from sourmash.cli.utils import add_moltype_args, add_ksize_arg
+from sourmash.cli.utils import (add_moltype_args, add_ksize_arg,
+                                add_picklist_args)
 
 
 def subparser(subparsers):
@@ -34,6 +35,7 @@ def subparser(subparsers):
     )
     add_ksize_arg(subparser, 31)
     add_moltype_args(subparser)
+    add_picklist_args(subparser)
 
 
 def main(args):

--- a/src/sourmash/cli/sig/merge.py
+++ b/src/sourmash/cli/sig/merge.py
@@ -1,7 +1,5 @@
 """merge one or more signatures"""
 
-import sys
-
 from sourmash.cli.utils import (add_moltype_args, add_ksize_arg,
                                 add_picklist_args)
 

--- a/src/sourmash/cli/sig/merge.py
+++ b/src/sourmash/cli/sig/merge.py
@@ -6,7 +6,7 @@ from sourmash.cli.utils import (add_moltype_args, add_ksize_arg,
 
 def subparser(subparsers):
     subparser = subparsers.add_parser('merge')
-    subparser.add_argument('signatures', nargs='+')
+    subparser.add_argument('signatures', nargs='*')
     subparser.add_argument(
         '-q', '--quiet', action='store_true',
         help='suppress non-error output'

--- a/src/sourmash/cli/sig/merge.py
+++ b/src/sourmash/cli/sig/merge.py
@@ -24,6 +24,14 @@ def subparser(subparsers):
         '--name',
         help='rename merged signature'
     )
+    subparser.add_argument(
+        '-f', '--force', action='store_true',
+        help='try to load all files as signatures'
+    )
+    subparser.add_argument(
+        '--from-file',
+        help='a text file containing a list of files to load signatures from'
+    )
     add_ksize_arg(subparser, 31)
     add_moltype_args(subparser)
 

--- a/src/sourmash/cli/sig/rename.py
+++ b/src/sourmash/cli/sig/rename.py
@@ -1,6 +1,7 @@
 """rename signature"""
 
-from sourmash.cli.utils import add_ksize_arg, add_moltype_args
+from sourmash.cli.utils import (add_moltype_args, add_ksize_arg,
+                                add_picklist_args)
 
 
 def subparser(subparsers):
@@ -30,6 +31,7 @@ def subparser(subparsers):
     )
     add_ksize_arg(subparser, 31)
     add_moltype_args(subparser)
+    add_picklist_args(subparser)
 
 
 def main(args):

--- a/src/sourmash/cli/sig/rename.py
+++ b/src/sourmash/cli/sig/rename.py
@@ -5,7 +5,7 @@ from sourmash.cli.utils import add_ksize_arg, add_moltype_args
 
 def subparser(subparsers):
     subparser = subparsers.add_parser('rename')
-    subparser.add_argument('sigfiles', nargs='+')
+    subparser.add_argument('signatures', nargs='*')
     subparser.add_argument('name')
     subparser.add_argument(
         '-q', '--quiet', action='store_true',
@@ -19,6 +19,14 @@ def subparser(subparsers):
         '-o', '--output', metavar='FILE', 
         help='output renamed signature to this file (default stdout)',
         default='-'
+    )
+    subparser.add_argument(
+        '-f', '--force', action='store_true',
+        help='try to load all files as signatures'
+    )
+    subparser.add_argument(
+        '--from-file',
+        help='a text file containing a list of files to load signatures from'
     )
     add_ksize_arg(subparser, 31)
     add_moltype_args(subparser)

--- a/src/sourmash/cli/sig/split.py
+++ b/src/sourmash/cli/sig/split.py
@@ -6,7 +6,7 @@ from sourmash.cli.utils import add_moltype_args, add_ksize_arg
 
 def subparser(subparsers):
     subparser = subparsers.add_parser('split')
-    subparser.add_argument('signatures', nargs='+')
+    subparser.add_argument('signatures', nargs='*')
     subparser.add_argument(
         '-q', '--quiet', action='store_true',
         help='suppress non-error output'

--- a/src/sourmash/cli/sig/split.py
+++ b/src/sourmash/cli/sig/split.py
@@ -1,6 +1,7 @@
 """concatenate signature files"""
 
 import sourmash
+from sourmash.cli.utils import add_moltype_args, add_ksize_arg
 
 
 def subparser(subparsers):
@@ -13,6 +14,16 @@ def subparser(subparsers):
     subparser.add_argument(
         '--outdir', help='output signatures to this directory'
     )
+    subparser.add_argument(
+        '-f', '--force', action='store_true',
+        help='try to load all files as signatures'
+    )
+    subparser.add_argument(
+        '--from-file',
+        help='a text file containing a list of files to load signatures from'
+    )
+    add_ksize_arg(subparser, 31)
+    add_moltype_args(subparser)
 
 
 def main(args):

--- a/src/sourmash/cli/sig/split.py
+++ b/src/sourmash/cli/sig/split.py
@@ -1,7 +1,8 @@
 """concatenate signature files"""
 
 import sourmash
-from sourmash.cli.utils import add_moltype_args, add_ksize_arg
+from sourmash.cli.utils import (add_moltype_args, add_ksize_arg,
+                                add_picklist_args)
 
 
 def subparser(subparsers):
@@ -24,6 +25,7 @@ def subparser(subparsers):
     )
     add_ksize_arg(subparser, 31)
     add_moltype_args(subparser)
+    add_picklist_args(subparser)
 
 
 def main(args):

--- a/src/sourmash/cli/sig/split.py
+++ b/src/sourmash/cli/sig/split.py
@@ -1,6 +1,5 @@
 """concatenate signature files"""
 
-import sourmash
 from sourmash.cli.utils import (add_moltype_args, add_ksize_arg,
                                 add_picklist_args)
 

--- a/src/sourmash/cli/sig/subtract.py
+++ b/src/sourmash/cli/sig/subtract.py
@@ -1,7 +1,5 @@
 """subtract one or more signatures"""
 
-import sys
-
 from sourmash.cli.utils import (add_moltype_args, add_ksize_arg,
                                 add_picklist_args)
 

--- a/src/sourmash/cli/sig/subtract.py
+++ b/src/sourmash/cli/sig/subtract.py
@@ -2,7 +2,8 @@
 
 import sys
 
-from sourmash.cli.utils import add_moltype_args, add_ksize_arg
+from sourmash.cli.utils import (add_moltype_args, add_ksize_arg,
+                                add_picklist_args)
 
 
 def subparser(subparsers):
@@ -23,6 +24,7 @@ def subparser(subparsers):
     )
     add_ksize_arg(subparser, 31)
     add_moltype_args(subparser)
+    add_picklist_args(subparser)
 
 
 def main(args):

--- a/src/sourmash/cli/sig/subtract.py
+++ b/src/sourmash/cli/sig/subtract.py
@@ -1,7 +1,6 @@
 """subtract one or more signatures"""
 
-from sourmash.cli.utils import (add_moltype_args, add_ksize_arg,
-                                add_picklist_args)
+from sourmash.cli.utils import (add_moltype_args, add_ksize_arg)
 
 
 def subparser(subparsers):
@@ -22,7 +21,6 @@ def subparser(subparsers):
     )
     add_ksize_arg(subparser, 31)
     add_moltype_args(subparser)
-    add_picklist_args(subparser)
 
 
 def main(args):

--- a/src/sourmash/sig/__main__.py
+++ b/src/sourmash/sig/__main__.py
@@ -470,7 +470,6 @@ def intersect(args):
                                                 force=args.force)
 
     for sigobj, sigloc in loader:
-
         if first_sig is None:
             first_sig = sigobj
             mins = set(sigobj.minhash.hashes)

--- a/src/sourmash/sig/__main__.py
+++ b/src/sourmash/sig/__main__.py
@@ -68,6 +68,7 @@ def cat(args):
     """
     set_quiet(args.quiet)
     moltype = sourmash_args.calculate_moltype(args)
+    picklist = sourmash_args.load_picklist(args)
 
     encountered_md5sums = defaultdict(int)   # used by --unique
 
@@ -86,6 +87,7 @@ def cat(args):
     loader = sourmash_args.load_many_signatures(args.signatures,
                                                 ksize=args.ksize,
                                                 moltype=moltype,
+                                                picklist=picklist,
                                                 progress=progress,
                                                 yield_all_files=args.force,
                                                 force=args.force)
@@ -98,6 +100,8 @@ def cat(args):
         save_sigs.add(ss)
 
     notify('loaded {} signatures total.', len(save_sigs))
+    if picklist:
+        sourmash_args.report_picklist(args, picklist)
 
     save_sigs.close()
 
@@ -116,6 +120,7 @@ def split(args):
     """
     set_quiet(args.quiet)
     moltype = sourmash_args.calculate_moltype(args)
+    picklist = sourmash_args.load_picklist(args)
 
     output_names = set()
     output_scaled_template = '{md5sum}.k={ksize}.scaled={scaled}.{moltype}.dup={dup}.{basename}.sig'
@@ -136,6 +141,7 @@ def split(args):
     loader = sourmash_args.load_many_signatures(args.signatures,
                                                 ksize=args.ksize,
                                                 moltype=moltype,
+                                                picklist=picklist,
                                                 progress=progress,
                                                 yield_all_files=args.force,
                                                 force=args.force)
@@ -184,6 +190,8 @@ def split(args):
             notify('writing sig to {}', output_name)
 
     notify(f'loaded and split {len(progress)} signatures total.')
+    if picklist:
+        sourmash_args.report_picklist(args, picklist)
 
 
 def describe(args):
@@ -192,6 +200,7 @@ def describe(args):
     """
     set_quiet(args.quiet)
     moltype = sourmash_args.calculate_moltype(args)
+    picklist = sourmash_args.load_picklist(args)
 
     # write CSV?
     w = None
@@ -217,6 +226,7 @@ def describe(args):
     loader = sourmash_args.load_many_signatures(args.signatures,
                                                 ksize=args.ksize,
                                                 moltype=moltype,
+                                                picklist=picklist,
                                                 progress=progress,
                                                 yield_all_files=args.force,
                                                 force=args.force)
@@ -256,6 +266,9 @@ signature license: {license}
 
     if csv_fp:
         csv_fp.close()
+
+    if picklist:
+        sourmash_args.report_picklist(args, picklist)
 
 
 def manifest(args):
@@ -384,6 +397,7 @@ def merge(args):
     """
     set_quiet(args.quiet)
     moltype = sourmash_args.calculate_moltype(args)
+    picklist = sourmash_args.load_picklist(args)
 
     first_sig = None
     mh = None
@@ -400,6 +414,7 @@ def merge(args):
     loader = sourmash_args.load_many_signatures(args.signatures,
                                                 ksize=args.ksize,
                                                 moltype=moltype,
+                                                picklist=picklist,
                                                 progress=progress,
                                                 yield_all_files=args.force,
                                                 force=args.force)
@@ -438,6 +453,9 @@ def merge(args):
 
     notify(f'loaded and merged {len(progress)} signatures')
 
+    if picklist:
+        sourmash_args.report_picklist(args, picklist)
+
 
 def intersect(args):
     """
@@ -447,6 +465,7 @@ def intersect(args):
     """
     set_quiet(args.quiet)
     moltype = sourmash_args.calculate_moltype(args)
+    picklist = sourmash_args.load_picklist(args)
 
     first_sig = None
     mins = None
@@ -462,6 +481,7 @@ def intersect(args):
     loader = sourmash_args.load_many_signatures(args.signatures,
                                                 ksize=args.ksize,
                                                 moltype=moltype,
+                                                picklist=picklist,
                                                 progress=progress,
                                                 yield_all_files=args.force,
                                                 force=args.force)
@@ -512,6 +532,8 @@ def intersect(args):
         sourmash.save_signatures([intersect_sigobj], fp=fp)
 
     notify(f'loaded and intersected {len(progress)} signatures')
+    if picklist:
+        sourmash_args.report_picklist(args, picklist)
 
 
 def subtract(args):
@@ -520,6 +542,7 @@ def subtract(args):
     """
     set_quiet(args.quiet)
     moltype = sourmash_args.calculate_moltype(args)
+    picklist = sourmash_args.load_picklist(args)
 
     from_sigfile = args.signature_from
     from_sigobj = sourmash.load_one_signature(from_sigfile, ksize=args.ksize, select_moltype=moltype)
@@ -556,7 +579,6 @@ def subtract(args):
         error("no signatures to subtract!?")
         sys.exit(-1)
 
-
     subtract_mh = from_sigobj.minhash.copy_and_clear()
     subtract_mh.add_many(subtract_mins)
 
@@ -566,6 +588,8 @@ def subtract(args):
         sourmash.save_signatures([subtract_sigobj], fp=fp)
 
     notify(f'loaded and subtracted {len(progress)} signatures')
+    if picklist:
+        sourmash_args.report_picklist(args, picklist)
 
 
 def rename(args):
@@ -574,6 +598,7 @@ def rename(args):
     """
     set_quiet(args.quiet, args.quiet)
     moltype = sourmash_args.calculate_moltype(args)
+    picklist = sourmash_args.load_picklist(args)
 
     save_sigs = sourmash_args.SaveSignaturesToLocation(args.output)
     save_sigs.open()
@@ -589,6 +614,7 @@ def rename(args):
     loader = sourmash_args.load_many_signatures(args.signatures,
                                                 ksize=args.ksize,
                                                 moltype=moltype,
+                                                picklist=picklist,
                                                 progress=progress,
                                                 yield_all_files=args.force,
                                                 force=args.force)
@@ -600,6 +626,8 @@ def rename(args):
     save_sigs.close()
 
     notify(f"set name to '{args.name}' on {len(save_sigs)} signatures")
+    if picklist:
+        sourmash_args.report_picklist(args, picklist)
 
 
 def extract(args):
@@ -722,6 +750,7 @@ def flatten(args):
     """
     set_quiet(args.quiet)
     moltype = sourmash_args.calculate_moltype(args)
+    picklist = sourmash_args.load_picklist(args)
 
     save_sigs = sourmash_args.SaveSignaturesToLocation(args.output)
     save_sigs.open()
@@ -737,6 +766,7 @@ def flatten(args):
     loader = sourmash_args.load_many_signatures(args.signatures,
                                                 ksize=args.ksize,
                                                 moltype=moltype,
+                                                picklist=picklist,
                                                 progress=progress,
                                                 yield_all_files=args.force,
                                                 force=args.force)
@@ -758,6 +788,8 @@ def flatten(args):
     notify(f"loaded {len(progress)} total that matched ksize & molecule type")
     notify("extracted {} signatures from {} file(s)", len(save_sigs),
            len(args.signatures))
+    if picklist:
+        sourmash_args.report_picklist(args, picklist)
 
 
 def downsample(args):
@@ -766,6 +798,7 @@ def downsample(args):
     """
     set_quiet(args.quiet)
     moltype = sourmash_args.calculate_moltype(args)
+    picklist = sourmash_args.load_picklist(args)
 
     if not args.num and not args.scaled:
         error('ERROR: must specify either --num or --scaled value')
@@ -790,6 +823,7 @@ def downsample(args):
     loader = sourmash_args.load_many_signatures(args.signatures,
                                                 ksize=args.ksize,
                                                 moltype=moltype,
+                                                picklist=picklist,
                                                 progress=progress,
                                                 yield_all_files=args.force,
                                                 force=args.force)
@@ -832,6 +866,8 @@ def downsample(args):
 
     notify(f"loaded {len(progress)} signatures")
     notify(f"output {len(save_sigs)} downsampled signatures", len(save_sigs))
+    if picklist:
+        sourmash_args.report_picklist(args, picklist)
 
 
 def sig_import(args):

--- a/src/sourmash/sig/__main__.py
+++ b/src/sourmash/sig/__main__.py
@@ -424,11 +424,11 @@ def merge(args):
                 sigobj_mh.track_abundance = False
 
             mh.merge(sigobj_mh)
-        except:
-            assert 0
+        except (TypeError, ValueError) as exc:
             error("ERROR when merging signature '{}' ({}) from file {}",
                   sigobj, sigobj.md5sum()[:8], sigloc)
-            raise
+            error(str(exc))
+            sys.exit(-1)
 
     if not len(progress):
         error("no signatures to merge!?")

--- a/src/sourmash/sig/__main__.py
+++ b/src/sourmash/sig/__main__.py
@@ -47,6 +47,13 @@ def _check_abundance_compatibility(sig1, sig2):
         raise ValueError("incompatible signatures: track_abundance is {} in first sig, {} in second".format(sig1.minhash.track_abundance, sig2.minhash.track_abundance))
 
 
+def _extend_signatures_with_from_file(args):
+    # extend input signatures with --from-file
+    if args.from_file:
+        more_files = sourmash_args.load_pathlist_from_file(args.from_file)
+        args.signatures = list(args.signatures)
+        args.signatures.extend(more_files)
+
 def _set_num_scaled(mh, num, scaled):
     "set num and scaled values on a MinHash object"
     mh_params = list(mh.__getstate__())
@@ -76,11 +83,7 @@ def cat(args):
     save_sigs = sourmash_args.SaveSignaturesToLocation(args.output)
     save_sigs.open()
 
-    # extend input signatures with --from-file
-    if args.from_file:
-        more_files = sourmash_args.load_pathlist_from_file(args.from_file)
-        args.signatures = list(args.signatures)
-        args.signatures.extend(more_files)
+    _extend_signatures_with_from_file(args)
 
     # start loading!
     progress = sourmash_args.SignatureLoadingProgress()
@@ -121,6 +124,7 @@ def split(args):
     set_quiet(args.quiet)
     moltype = sourmash_args.calculate_moltype(args)
     picklist = sourmash_args.load_picklist(args)
+    _extend_signatures_with_from_file(args)
 
     output_names = set()
     output_scaled_template = '{md5sum}.k={ksize}.scaled={scaled}.{moltype}.dup={dup}.{basename}.sig'
@@ -130,12 +134,6 @@ def split(args):
         if not os.path.exists(args.outdir):
             notify('Creating --outdir {}', args.outdir)
             os.mkdir(args.outdir)
-
-    # extend input signatures with --from-file
-    if args.from_file:
-        more_files = sourmash_args.load_pathlist_from_file(args.from_file)
-        args.signatures = list(args.signatures)
-        args.signatures.extend(more_files)
 
     progress = sourmash_args.SignatureLoadingProgress()
     loader = sourmash_args.load_many_signatures(args.signatures,
@@ -201,6 +199,7 @@ def describe(args):
     set_quiet(args.quiet)
     moltype = sourmash_args.calculate_moltype(args)
     picklist = sourmash_args.load_picklist(args)
+    _extend_signatures_with_from_file(args)
 
     # write CSV?
     w = None
@@ -214,12 +213,6 @@ def describe(args):
                             'name', 'filename', 'license'],
                            extrasaction='ignore')
         w.writeheader()
-
-    # extend input signatures with --from-file
-    if args.from_file:
-        more_files = sourmash_args.load_pathlist_from_file(args.from_file)
-        args.signatures = list(args.signatures)
-        args.signatures.extend(more_files)
 
     # start loading!
     progress = sourmash_args.SignatureLoadingProgress()
@@ -398,16 +391,10 @@ def merge(args):
     set_quiet(args.quiet)
     moltype = sourmash_args.calculate_moltype(args)
     picklist = sourmash_args.load_picklist(args)
+    _extend_signatures_with_from_file(args)
 
     first_sig = None
     mh = None
-    total_loaded = 0
-
-    # extend input signatures with --from-file
-    if args.from_file:
-        more_files = sourmash_args.load_pathlist_from_file(args.from_file)
-        args.signatures = list(args.signatures)
-        args.signatures.extend(more_files)
 
     # start loading!
     progress = sourmash_args.SignatureLoadingProgress()
@@ -438,8 +425,9 @@ def merge(args):
 
             mh.merge(sigobj_mh)
         except:
+            assert 0
             error("ERROR when merging signature '{}' ({}) from file {}",
-                  sigobj, sigobj.md5sum()[:8], sigfile)
+                  sigobj, sigobj.md5sum()[:8], sigloc)
             raise
 
     if not len(progress):
@@ -466,15 +454,10 @@ def intersect(args):
     set_quiet(args.quiet)
     moltype = sourmash_args.calculate_moltype(args)
     picklist = sourmash_args.load_picklist(args)
+    _extend_signatures_with_from_file(args)
 
     first_sig = None
     mins = None
-
-    # extend input signatures with --from-file
-    if args.from_file:
-        more_files = sourmash_args.load_pathlist_from_file(args.from_file)
-        args.signatures = list(args.signatures)
-        args.signatures.extend(more_files)
 
     # start loading!
     progress = sourmash_args.SignatureLoadingProgress()
@@ -599,15 +582,11 @@ def rename(args):
     set_quiet(args.quiet, args.quiet)
     moltype = sourmash_args.calculate_moltype(args)
     picklist = sourmash_args.load_picklist(args)
+    _extend_signatures_with_from_file(args)
+
 
     save_sigs = sourmash_args.SaveSignaturesToLocation(args.output)
     save_sigs.open()
-
-    # extend input signatures with --from-file
-    if args.from_file:
-        more_files = sourmash_args.load_pathlist_from_file(args.from_file)
-        args.signatures = list(args.signatures)
-        args.signatures.extend(more_files)
 
     # start loading!
     progress = sourmash_args.SignatureLoadingProgress()
@@ -637,6 +616,7 @@ def extract(args):
     set_quiet(args.quiet)
     moltype = sourmash_args.calculate_moltype(args)
     picklist = sourmash_args.load_picklist(args)
+    _extend_signatures_with_from_file(args)
 
     # further filtering on md5 or name?
     if args.md5 is not None or args.name is not None:
@@ -656,12 +636,6 @@ def extract(args):
     # ok! filtering defined, let's go forward
     save_sigs = sourmash_args.SaveSignaturesToLocation(args.output)
     save_sigs.open()
-
-    # extend input signatures with --from-file
-    if args.from_file:
-        more_files = sourmash_args.load_pathlist_from_file(args.from_file)
-        args.signatures = list(args.signatures)
-        args.signatures.extend(more_files)
 
     # start loading!
     progress = sourmash_args.SignatureLoadingProgress()
@@ -751,15 +725,10 @@ def flatten(args):
     set_quiet(args.quiet)
     moltype = sourmash_args.calculate_moltype(args)
     picklist = sourmash_args.load_picklist(args)
+    _extend_signatures_with_from_file(args)
 
     save_sigs = sourmash_args.SaveSignaturesToLocation(args.output)
     save_sigs.open()
-
-    # extend input signatures with --from-file
-    if args.from_file:
-        more_files = sourmash_args.load_pathlist_from_file(args.from_file)
-        args.signatures = list(args.signatures)
-        args.signatures.extend(more_files)
 
     # start loading!
     progress = sourmash_args.SignatureLoadingProgress()
@@ -799,6 +768,7 @@ def downsample(args):
     set_quiet(args.quiet)
     moltype = sourmash_args.calculate_moltype(args)
     picklist = sourmash_args.load_picklist(args)
+    _extend_signatures_with_from_file(args)
 
     if not args.num and not args.scaled:
         error('ERROR: must specify either --num or --scaled value')
@@ -811,12 +781,6 @@ def downsample(args):
     # open output for saving sigs
     save_sigs = sourmash_args.SaveSignaturesToLocation(args.output)
     save_sigs.open()
-
-    # extend input signatures with --from-file
-    if args.from_file:
-        more_files = sourmash_args.load_pathlist_from_file(args.from_file)
-        args.signatures = list(args.signatures)
-        args.signatures.extend(more_files)
 
     # start loading!
     progress = sourmash_args.SignatureLoadingProgress()

--- a/src/sourmash/sig/__main__.py
+++ b/src/sourmash/sig/__main__.py
@@ -83,12 +83,12 @@ def cat(args):
 
     # start loading!
     progress = sourmash_args.SignatureLoadingProgress()
-    loader = sourmash_args.LoadManySignatures(args.signatures,
-                                              ksize=args.ksize,
-                                              moltype=moltype,
-                                              progress=progress,
-                                              yield_all_files=args.force,
-                                              force=args.force)
+    loader = sourmash_args.load_many_signatures(args.signatures,
+                                                ksize=args.ksize,
+                                                moltype=moltype,
+                                                progress=progress,
+                                                yield_all_files=args.force,
+                                                force=args.force)
     for ss, sigloc in loader:
         md5 = ss.md5sum()
         encountered_md5sums[md5] += 1
@@ -133,12 +133,12 @@ def split(args):
         args.signatures.extend(more_files)
 
     progress = sourmash_args.SignatureLoadingProgress()
-    loader = sourmash_args.LoadManySignatures(args.signatures,
-                                              ksize=args.ksize,
-                                              moltype=moltype,
-                                              progress=progress,
-                                              yield_all_files=args.force,
-                                              force=args.force)
+    loader = sourmash_args.load_many_signatures(args.signatures,
+                                                ksize=args.ksize,
+                                                moltype=moltype,
+                                                progress=progress,
+                                                yield_all_files=args.force,
+                                                force=args.force)
 
     for sig, sigloc in loader:
         # save each file individually --
@@ -214,12 +214,12 @@ def describe(args):
 
     # start loading!
     progress = sourmash_args.SignatureLoadingProgress()
-    loader = sourmash_args.LoadManySignatures(args.signatures,
-                                              ksize=args.ksize,
-                                              moltype=moltype,
-                                              progress=progress,
-                                              yield_all_files=args.force,
-                                              force=args.force)
+    loader = sourmash_args.load_many_signatures(args.signatures,
+                                                ksize=args.ksize,
+                                                moltype=moltype,
+                                                progress=progress,
+                                                yield_all_files=args.force,
+                                                force=args.force)
 
     for sig, location in loader:
         # extract info, write as appropriate.
@@ -397,12 +397,12 @@ def merge(args):
 
     # start loading!
     progress = sourmash_args.SignatureLoadingProgress()
-    loader = sourmash_args.LoadManySignatures(args.signatures,
-                                              ksize=args.ksize,
-                                              moltype=moltype,
-                                              progress=progress,
-                                              yield_all_files=args.force,
-                                              force=args.force)
+    loader = sourmash_args.load_many_signatures(args.signatures,
+                                                ksize=args.ksize,
+                                                moltype=moltype,
+                                                progress=progress,
+                                                yield_all_files=args.force,
+                                                force=args.force)
 
     for sigobj, sigloc in loader:
         # first signature? initialize a bunch of stuff
@@ -459,12 +459,12 @@ def intersect(args):
 
     # start loading!
     progress = sourmash_args.SignatureLoadingProgress()
-    loader = sourmash_args.LoadManySignatures(args.signatures,
-                                              ksize=args.ksize,
-                                              moltype=moltype,
-                                              progress=progress,
-                                              yield_all_files=args.force,
-                                              force=args.force)
+    loader = sourmash_args.load_many_signatures(args.signatures,
+                                                ksize=args.ksize,
+                                                moltype=moltype,
+                                                progress=progress,
+                                                yield_all_files=args.force,
+                                                force=args.force)
 
     for sigobj, sigloc in loader:
 
@@ -586,12 +586,12 @@ def rename(args):
 
     # start loading!
     progress = sourmash_args.SignatureLoadingProgress()
-    loader = sourmash_args.LoadManySignatures(args.signatures,
-                                              ksize=args.ksize,
-                                              moltype=moltype,
-                                              progress=progress,
-                                              yield_all_files=args.force,
-                                              force=args.force)
+    loader = sourmash_args.load_many_signatures(args.signatures,
+                                                ksize=args.ksize,
+                                                moltype=moltype,
+                                                progress=progress,
+                                                yield_all_files=args.force,
+                                                force=args.force)
 
     for sigobj, sigloc in loader:
         sigobj._name = args.name
@@ -637,13 +637,13 @@ def extract(args):
 
     # start loading!
     progress = sourmash_args.SignatureLoadingProgress()
-    loader = sourmash_args.LoadManySignatures(args.signatures,
-                                              ksize=args.ksize,
-                                              moltype=moltype,
-                                              picklist=picklist,
-                                              progress=progress,
-                                              yield_all_files=args.force,
-                                              force=args.force)
+    loader = sourmash_args.load_many_signatures(args.signatures,
+                                                ksize=args.ksize,
+                                                moltype=moltype,
+                                                picklist=picklist,
+                                                progress=progress,
+                                                yield_all_files=args.force,
+                                                force=args.force)
     for ss, sigloc in loader:
         if filter_fn(ss):
             save_sigs.add(ss)
@@ -734,12 +734,12 @@ def flatten(args):
 
     # start loading!
     progress = sourmash_args.SignatureLoadingProgress()
-    loader = sourmash_args.LoadManySignatures(args.signatures,
-                                              ksize=args.ksize,
-                                              moltype=moltype,
-                                              progress=progress,
-                                              yield_all_files=args.force,
-                                              force=args.force)
+    loader = sourmash_args.load_many_signatures(args.signatures,
+                                                ksize=args.ksize,
+                                                moltype=moltype,
+                                                progress=progress,
+                                                yield_all_files=args.force,
+                                                force=args.force)
     for ss, sigloc in loader:
         # select!
         if args.md5 is not None:
@@ -787,12 +787,12 @@ def downsample(args):
 
     # start loading!
     progress = sourmash_args.SignatureLoadingProgress()
-    loader = sourmash_args.LoadManySignatures(args.signatures,
-                                              ksize=args.ksize,
-                                              moltype=moltype,
-                                              progress=progress,
-                                              yield_all_files=args.force,
-                                              force=args.force)
+    loader = sourmash_args.load_many_signatures(args.signatures,
+                                                ksize=args.ksize,
+                                                moltype=moltype,
+                                                progress=progress,
+                                                yield_all_files=args.force,
+                                                force=args.force)
     for ss, sigloc in loader:
         mh = ss.minhash
 

--- a/src/sourmash/sig/__main__.py
+++ b/src/sourmash/sig/__main__.py
@@ -818,7 +818,8 @@ def downsample(args):
 
     save_sigs.close()
 
-    notify(f"loaded and downsampled {len(progress)} signatures")
+    notify(f"loaded {len(progress)} signatures")
+    notify(f"output {len(save_sigs)} downsampled signatures", len(save_sigs))
 
 
 def sig_import(args):

--- a/src/sourmash/sig/__main__.py
+++ b/src/sourmash/sig/__main__.py
@@ -13,7 +13,7 @@ from sourmash.sourmash_args import FileOutput
 from sourmash.logging import set_quiet, error, notify, print_results, debug
 from sourmash import sourmash_args
 from sourmash.minhash import _get_max_hash_for_scaled
-from sourmash.picklist import SignaturePicklist
+
 
 usage='''
 sourmash signature <command> [<args>] - manipulate/work with signature files.

--- a/src/sourmash/sig/__main__.py
+++ b/src/sourmash/sig/__main__.py
@@ -524,7 +524,6 @@ def subtract(args):
     """
     set_quiet(args.quiet)
     moltype = sourmash_args.calculate_moltype(args)
-    picklist = sourmash_args.load_picklist(args)
 
     from_sigfile = args.signature_from
     from_sigobj = sourmash.load_one_signature(from_sigfile, ksize=args.ksize, select_moltype=moltype)
@@ -570,8 +569,6 @@ def subtract(args):
         sourmash.save_signatures([subtract_sigobj], fp=fp)
 
     notify(f'loaded and subtracted {len(progress)} signatures')
-    if picklist:
-        sourmash_args.report_picklist(args, picklist)
 
 
 def rename(args):

--- a/src/sourmash/sourmash_args.py
+++ b/src/sourmash/sourmash_args.py
@@ -620,7 +620,8 @@ class LoadManySignatures:
                     notify(str(exc))
                     continue
                 else:
-                    raise
+                    notify(str(exc))
+                    sys.exit(-1)
             except KeyboardInterrupt:
                 notify("Received CTRL-C - exiting.")
                 sys.exit(-1)

--- a/src/sourmash/sourmash_args.py
+++ b/src/sourmash/sourmash_args.py
@@ -613,11 +613,12 @@ def load_many_signatures(locations, progress, *, yield_all_files=False,
             notify(f"loaded {n} isgnatures from '{loc}'", end='\r')
         except ValueError as exc:
             # trap expected errors, and either power through or display + exit.
-            if self.force:
-                notify(str(exc))
+            if force:
+                notify("ERROR: {}", str(exc))
+                notify("(continuing)")
                 continue
             else:
-                notify(str(exc))
+                notify("ERROR: {}". str(exc))
                 sys.exit(-1)
         except KeyboardInterrupt:
             notify("Received CTRL-C - exiting.")

--- a/src/sourmash/sourmash_args.py
+++ b/src/sourmash/sourmash_args.py
@@ -585,49 +585,47 @@ class SignatureLoadingProgress(object):
                           end='\r')
 
 
-class LoadManySignatures:
-    def __init__(self, locations, progress, *,
-                 yield_all_files=False, ksize=None, moltype=None,
-                 picklist=None, force=False):
-        self.locations = locations
-        self.progress = progress
+def load_many_signatures(locations, progress, *, yield_all_files=False,
+                         ksize=None, moltype=None, picklist=None, force=False):
+    """
+    Load many signatures from multiple files, with progress indicators.
 
-        self.yield_all_files = yield_all_files
-        self.ksize = ksize
-        self.moltype = moltype
-        self.picklist = picklist
-        self.force = force
+    Takes ksize, moltype, and picklist selectors.
 
-    def __iter__(self):
-        progress = self.progress
-        for loc in self.locations:
-            try:
-                idx = load_file_as_index(loc,
-                                         yield_all_files=self.yield_all_files)
-                idx = idx.select(ksize=self.ksize,
-                                 moltype=self.moltype,
-                                 picklist=self.picklist)
+    If 'yield_all_files=True' then tries to load all files in specified
+    directories.
 
-                loader = idx.signatures_with_location()
+    If 'force=True' then continues past survivable errors.
 
-                n = 0
-                for sig, sigloc in progress.start_file(loc, loader):
-                    yield sig, sigloc
-                    n += 1
-                notify(f"loaded {n} isgnatures from '{loc}'", end='\r')
-            except ValueError as exc:
-                if self.force:
-                    notify(str(exc))
-                    continue
-                else:
-                    notify(str(exc))
-                    sys.exit(-1)
-            except KeyboardInterrupt:
-                notify("Received CTRL-C - exiting.")
+    Yields (sig, location) tuples.
+    """
+    for loc in locations:
+        try:
+            idx = load_file_as_index(loc, yield_all_files=yield_all_files)
+            idx = idx.select(ksize=ksize, moltype=moltype, picklist=picklist)
+
+            loader = idx.signatures_with_location()
+
+            n = 0
+            for sig, sigloc in progress.start_file(loc, loader):
+                yield sig, sigloc
+                n += 1
+            notify(f"loaded {n} isgnatures from '{loc}'", end='\r')
+        except ValueError as exc:
+            # trap expected errors, and either power through or display + exit.
+            if self.force:
+                notify(str(exc))
+                continue
+            else:
+                notify(str(exc))
                 sys.exit(-1)
+        except KeyboardInterrupt:
+            notify("Received CTRL-C - exiting.")
+            sys.exit(-1)
 
-        n_files = len(self.locations)
-        notify(f"loaded {len(progress)} signatures total, from {n_files} files")
+    n_files = len(locations)
+    notify(f"loaded {len(progress)} signatures total, from {n_files} files")
+
 
 #
 # enum and classes for saving signatures progressively

--- a/tests/test_cmd_signature.py
+++ b/tests/test_cmd_signature.py
@@ -2080,7 +2080,48 @@ def test_sig_flatten_1(c):
 
 
 @utils.in_tempdir
-def test_sig_flatten_2_ksize(c):
+def test_sig_flatten_1_select_name(c):
+    # extract matches to several names from among several signatures & flatten
+    sig47abund = utils.get_test_data('track_abund/47.fa.sig')
+    sig2 = utils.get_test_data('2.fa.sig')
+    sig47 = utils.get_test_data('47.fa.sig')
+    c.run_sourmash('sig', 'flatten', sig2, sig47abund, '--name', 'Shewanella')
+
+    # stdout should be new signature
+    out = c.last_result.out
+
+    siglist = load_signatures(out)
+    siglist = list(siglist)
+
+    assert len(siglist) == 1
+
+    test_flattened = sourmash.load_one_signature(sig47)
+    assert test_flattened.minhash == siglist[0].minhash
+
+
+def test_sig_flatten_1_select_md5(runtmp):
+    c = runtmp
+
+    # extract matches to several names from among several signatures & flatten
+    sig47abund = utils.get_test_data('track_abund/47.fa.sig')
+    sig2 = utils.get_test_data('2.fa.sig')
+    sig47 = utils.get_test_data('47.fa.sig')
+    c.run_sourmash('sig', 'flatten', sig2, sig47abund, '--md5', '09a08691c')
+
+    # stdout should be new signature
+    out = c.last_result.out
+
+    siglist = load_signatures(out)
+    siglist = list(siglist)
+
+    assert len(siglist) == 1
+
+    test_flattened = sourmash.load_one_signature(sig47)
+    assert test_flattened.minhash == siglist[0].minhash
+
+
+def test_sig_flatten_2_ksize(runtmp):
+    c = runtmp
     # flatten only one signature selected using ksize
     psw_mag = utils.get_test_data('lca/TARA_PSW_MAG_00136.sig')
     c.run_sourmash('sig', 'flatten', psw_mag, '-k', '31')

--- a/tests/test_cmd_signature.py
+++ b/tests/test_cmd_signature.py
@@ -649,6 +649,15 @@ def test_sig_rename_3_file_dne(c):
     assert "Error while reading signatures from 'no-such-sig'" in c.last_result.err
 
 
+@utils.in_tempdir
+def test_sig_rename_3_file_dne_force(c):
+    # rename on a file that does not exist should fail!
+    c.run_sourmash('sig', 'rename', 'no-such-sig', 'fiz bar', '-f')
+    print(c.last_result.err)
+
+    assert "Error while reading signatures from 'no-such-sig'" in c.last_result.err
+
+
 @utils.in_thisdir
 def test_sig_cat_1(c):
     # cat 47 to 47...

--- a/tests/test_cmd_signature.py
+++ b/tests/test_cmd_signature.py
@@ -2642,7 +2642,7 @@ signature license: CC0
     for line in out.splitlines():
         cleaned_line = line.strip().replace(
             testdata_dirname, '').replace(location, '')
-        assert cleaned_line in expected_output
+        assert cleaned_line in expected_output, cleaned_line
 
 
 @utils.in_tempdir

--- a/tests/test_cmd_signature.py
+++ b/tests/test_cmd_signature.py
@@ -2259,6 +2259,16 @@ def test_sig_downsample_2_num_to_scaled_fail(c):
 
 
 @utils.in_tempdir
+def test_sig_downsample_2_num_and_scaled_both_fail(c):
+    # cannot specify both --num and --scaled
+    sigs11 = utils.get_test_data('genome-s11.fa.gz.sig')
+
+    with pytest.raises(ValueError):
+        c.run_sourmash('sig', 'downsample', '--scaled', '100', '--num', '50',
+                       '-k', '21', '--dna', sigs11)
+
+
+@utils.in_tempdir
 def test_sig_downsample_2_num_empty(c):
     # downsample a num signature
     sigs11 = utils.get_test_data('genome-s11.fa.gz.sig')

--- a/tests/test_cmd_signature.py
+++ b/tests/test_cmd_signature.py
@@ -976,6 +976,44 @@ def test_sig_cat_5_from_file(c):
     assert repr(siglist) == """[SourmashSignature('', 0107d767), SourmashSignature('NC_009665.1 Shewanella baltica OS185, complete genome', 09a08691), SourmashSignature('NC_009665.1 Shewanella baltica OS185, complete genome', 09a08691), SourmashSignature('', 4e94e602), SourmashSignature('', 60f7e23c), SourmashSignature('', 6d6e87e1), SourmashSignature('', b59473c9), SourmashSignature('', f0c834bc), SourmashSignature('', f71e7817)]"""
 
 
+def test_sig_cat_5_from_file_picklist(runtmp):
+    c = runtmp
+
+    # cat using a file list as input
+    sig47 = utils.get_test_data('47.fa.sig')
+    sbt = utils.get_test_data('v6.sbt.zip')
+
+    filelist = c.output("filelist")
+    with open(filelist, 'w') as f:
+        f.write("\n".join((sig47, sbt)))
+
+    picklist = _write_file(runtmp, 'pl.csv', ['md5short', '09a08691'])
+
+    c.run_sourmash('sig', 'cat', '--from-file', filelist,
+                   '--picklist', f'{picklist}:md5short:md5short',
+                   '-o', 'out.sig')
+
+    # stdout should be same signatures
+    out = c.output('out.sig')
+
+    siglist = list(load_signatures(out))
+    print(len(siglist))
+    # print("siglist: ",siglist)
+    # print("\n")
+
+    # verify the number of signatures matches what we expect to see based
+    # on the input files
+    all_sigs = []
+    all_sigs += list(load_signatures(sig47, ksize=31))
+
+    assert len(all_sigs) == len(siglist)
+
+    # sort the signatures by something deterministic and unique
+    siglist.sort(key = lambda x: x.md5sum())
+
+    assert repr(siglist) == """[SourmashSignature('NC_009665.1 Shewanella baltica OS185, complete genome', 09a08691)]"""
+
+
 def test_sig_split_1(runtmp):
     c = runtmp
     # split 47 into 1 sig :)

--- a/tests/test_cmd_signature.py
+++ b/tests/test_cmd_signature.py
@@ -139,8 +139,10 @@ def test_sig_merge_1_ksize_moltype_fail(c):
     sig63 = utils.get_test_data('63.fa.sig')
     sig2and63 = utils.get_test_data('2+63.fa.sig')
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as exc:
         c.run_sourmash('sig', 'merge', sig2, sig63)
+
+    assert "ERROR when merging signature" in str(exc.value)
 
 
 @utils.in_tempdir

--- a/tests/test_cmd_signature.py
+++ b/tests/test_cmd_signature.py
@@ -16,6 +16,13 @@ from sourmash.manifest import CollectionManifest
 ## command line tests
 
 
+def _write_file(runtmp, basename, lines):
+    loc = runtmp.output(basename)
+    with open(loc, 'wt') as fp:
+        fp.write("\n".join(lines))
+    return loc
+
+
 def test_run_sourmash_signature_cmd():
     status, out, err = utils.runscript('sourmash', ['signature'], fail_ok=True)
     assert not 'sourmash: error: argument cmd: invalid choice:' in err
@@ -30,13 +37,42 @@ def test_run_sourmash_sig_cmd():
     assert status != 0                    # no args provided, ok ;)
 
 
-@utils.in_tempdir
-def test_sig_merge_1_use_full_signature_in_cmd(c):
+def test_sig_merge_1_use_full_signature_in_cmd(runtmp):
+    c = runtmp
+
     # merge of 47 & 63 should be union of mins
     sig47 = utils.get_test_data('47.fa.sig')
     sig63 = utils.get_test_data('63.fa.sig')
     sig47and63 = utils.get_test_data('47+63.fa.sig')
     c.run_sourmash('signature', 'merge', sig47, sig63)
+
+    # stdout should be new signature
+    out = c.last_result.out
+
+    test_merge_sig = sourmash.load_one_signature(sig47and63)
+    actual_merge_sig = sourmash.load_one_signature(out)
+
+    print(test_merge_sig.minhash)
+    print(actual_merge_sig.minhash)
+    print(out)
+
+    assert actual_merge_sig.minhash == test_merge_sig.minhash
+
+
+def test_sig_merge_1_fromfile_picklist(runtmp):
+    c = runtmp
+
+    # merge of 47 & 63 should be union of mins
+    sig47 = utils.get_test_data('47.fa.sig')
+    sig63 = utils.get_test_data('63.fa.sig')
+    sig47and63 = utils.get_test_data('47+63.fa.sig')
+
+    from_file = _write_file(runtmp, 'list.txt', [sig47, sig63])
+    picklist = _write_file(runtmp, 'pl.csv',
+                           ['md5short', '09a08691', '38729c63'])
+
+    c.run_sourmash('signature', 'merge', '--from-file', from_file,
+                   '--picklist', f'{picklist}:md5short:md5short')
 
     # stdout should be new signature
     out = c.last_result.out
@@ -322,13 +358,42 @@ def test_sig_merge_flatten_2(c):
     assert actual_merge_sig.minhash == test_merge_sig.minhash
 
 
-@utils.in_tempdir
-def test_sig_intersect_1(c):
+def test_sig_intersect_1(runtmp):
+    c = runtmp
+
     # intersect of 47 and 63 should be intersection of mins
     sig47 = utils.get_test_data('47.fa.sig')
     sig63 = utils.get_test_data('63.fa.sig')
     sig47and63 = utils.get_test_data('47+63-intersect.fa.sig')
     c.run_sourmash('sig', 'intersect', sig47, sig63)
+
+    # stdout should be new signature
+    out = c.last_result.out
+
+    test_intersect_sig = sourmash.load_one_signature(sig47and63)
+    actual_intersect_sig = sourmash.load_one_signature(out)
+
+    print(test_intersect_sig.minhash)
+    print(actual_intersect_sig.minhash)
+    print(out)
+
+    assert actual_intersect_sig.minhash == test_intersect_sig.minhash
+
+
+def test_sig_intersect_1_fromfile_picklist(runtmp):
+    c = runtmp
+
+    # intersect of 47 and 63 should be intersection of mins
+    sig47 = utils.get_test_data('47.fa.sig')
+    sig63 = utils.get_test_data('63.fa.sig')
+    sig47and63 = utils.get_test_data('47+63-intersect.fa.sig')
+
+    from_file = _write_file(runtmp, 'list.txt', [sig47, sig63])
+    picklist = _write_file(runtmp, 'pl.csv',
+                           ['md5short', '09a08691', '38729c63'])
+
+    c.run_sourmash('signature', 'intersect', '--from-file', from_file,
+                   '--picklist', f'{picklist}:md5short:md5short')
 
     # stdout should be new signature
     out = c.last_result.out
@@ -571,11 +636,38 @@ def test_sig_subtract_4_ksize_succeed(c):
     assert 'loaded and subtracted 1 signatures' in c.last_result.err
 
 
-@utils.in_tempdir
-def test_sig_rename_1(c):
+def test_sig_rename_1(runtmp):
+    c = runtmp
+
     # set new name for 47
     sig47 = utils.get_test_data('47.fa.sig')
     c.run_sourmash('sig', 'rename', sig47, 'fiz bar')
+
+    # stdout should be new signature
+    out = c.last_result.out
+
+    test_rename_sig = sourmash.load_one_signature(sig47)
+    actual_rename_sig = sourmash.load_one_signature(out)
+
+    print(test_rename_sig.minhash)
+    print(actual_rename_sig.minhash)
+
+    assert actual_rename_sig.minhash == test_rename_sig.minhash
+    assert test_rename_sig.name != actual_rename_sig.name
+    assert actual_rename_sig.name == 'fiz bar'
+
+
+def test_sig_rename_1_fromfile_picklist(runtmp):
+    c = runtmp
+
+    # set new name for 47
+    sig47 = utils.get_test_data('47.fa.sig')
+
+    from_file = _write_file(runtmp, 'list.txt', [sig47])
+    picklist = _write_file(runtmp, 'pl.csv', ['md5short', '09a08691'])
+
+    c.run_sourmash('sig', 'rename', '--from-file', from_file, 'fiz bar',
+                   '--picklist', f'{picklist}:md5short:md5short')
 
     # stdout should be new signature
     out = c.last_result.out
@@ -884,11 +976,32 @@ def test_sig_cat_5_from_file(c):
     assert repr(siglist) == """[SourmashSignature('', 0107d767), SourmashSignature('NC_009665.1 Shewanella baltica OS185, complete genome', 09a08691), SourmashSignature('NC_009665.1 Shewanella baltica OS185, complete genome', 09a08691), SourmashSignature('', 4e94e602), SourmashSignature('', 60f7e23c), SourmashSignature('', 6d6e87e1), SourmashSignature('', b59473c9), SourmashSignature('', f0c834bc), SourmashSignature('', f71e7817)]"""
 
 
-@utils.in_tempdir
-def test_sig_split_1(c):
+def test_sig_split_1(runtmp):
+    c = runtmp
     # split 47 into 1 sig :)
     sig47 = utils.get_test_data('47.fa.sig')
     c.run_sourmash('sig', 'split', sig47)
+
+    outname = '09a08691.k=31.scaled=1000.DNA.dup=0.47.fa.sig'
+
+    assert os.path.exists(c.output(outname))
+
+    test_split_sig = sourmash.load_one_signature(sig47)
+    actual_split_sig = sourmash.load_one_signature(c.output(outname))
+
+    assert actual_split_sig == test_split_sig
+
+
+def test_sig_split_1_fromfile_picklist(runtmp):
+    c = runtmp
+    # split 47 into 1 sig :)
+    sig47 = utils.get_test_data('47.fa.sig')
+
+    from_file = _write_file(runtmp, 'list.txt', [sig47])
+    picklist = _write_file(runtmp, 'pl.csv', ['md5short', '09a08691'])
+
+    c.run_sourmash('sig', 'split', '--from-file', from_file,
+                   '--picklist', f'{picklist}:md5short:md5short')
 
     outname = '09a08691.k=31.scaled=1000.DNA.dup=0.47.fa.sig'
 
@@ -1040,11 +1153,29 @@ def test_sig_split_6_numsigs(runtmp):
         assert os.path.exists(c.output(filename))
 
 
-@utils.in_tempdir
-def test_sig_extract_1(c):
+def test_sig_extract_1(runtmp):
+    c = runtmp
+
     # extract 47 from 47... :)
     sig47 = utils.get_test_data('47.fa.sig')
     c.run_sourmash('sig', 'extract', sig47)
+
+    # stdout should be new signature
+    out = c.last_result.out
+
+    test_extract_sig = sourmash.load_one_signature(sig47)
+    actual_extract_sig = sourmash.load_one_signature(out)
+
+    assert actual_extract_sig == test_extract_sig
+
+
+def test_sig_extract_1(runtmp):
+    c = runtmp
+
+    # extract 47 from 47... :)
+    sig47 = utils.get_test_data('47.fa.sig')
+    from_file = _write_file(runtmp, 'list.txt', [sig47])
+    c.run_sourmash('sig', 'extract', '--from-file', from_file)
 
     # stdout should be new signature
     out = c.last_result.out
@@ -2062,12 +2193,38 @@ def test_sig_extract_12_picklist_bad_colname_exclude(runtmp):
     assert "column 'BADCOLNAME' not in pickfile" in err
 
 
-@utils.in_tempdir
-def test_sig_flatten_1(c):
+def test_sig_flatten_1(runtmp):
+    c = runtmp
+
     # extract matches to several names from among several signatures & flatten
     sig47abund = utils.get_test_data('track_abund/47.fa.sig')
     sig47 = utils.get_test_data('47.fa.sig')
     c.run_sourmash('sig', 'flatten', sig47abund, '--name', 'Shewanella')
+
+    # stdout should be new signature
+    out = c.last_result.out
+
+    siglist = load_signatures(out)
+    siglist = list(siglist)
+
+    assert len(siglist) == 1
+
+    test_flattened = sourmash.load_one_signature(sig47)
+    assert test_flattened.minhash == siglist[0].minhash
+
+
+def test_sig_flatten_1(runtmp):
+    c = runtmp
+
+    # extract matches to several names from among several signatures & flatten
+    sig47abund = utils.get_test_data('track_abund/47.fa.sig')
+    sig47 = utils.get_test_data('47.fa.sig')
+
+    from_file = _write_file(runtmp, 'list.txt', [sig47abund])
+    picklist = _write_file(runtmp, 'pl.csv', ['md5short', '09a08691'])
+
+    c.run_sourmash('sig', 'flatten', '--from-file', from_file,
+                   '--picklist', f'{picklist}:md5short:md5short')
 
     # stdout should be new signature
     out = c.last_result.out
@@ -2279,11 +2436,38 @@ def test_sig_downsample_2_num_empty(c):
         c.run_sourmash('sig', 'downsample', '-k', '21', '--dna', sigs11)
 
 
-@utils.in_tempdir
-def test_sig_describe_1(c):
+def test_sig_describe_1(runtmp):
+    c = runtmp
+
     # get basic info on a signature
     sig47 = utils.get_test_data('47.fa.sig')
     c.run_sourmash('sig', 'describe', sig47)
+
+    out = c.last_result.out
+    print(c.last_result)
+
+    expected_output = """\
+signature: NC_009665.1 Shewanella baltica OS185, complete genome
+source file: 47.fa
+md5: 09a08691ce52952152f0e866a59f6261
+k=31 molecule=DNA num=0 scaled=1000 seed=42 track_abundance=0
+size: 5177
+signature license: CC0
+""".splitlines()
+    for line in expected_output:
+        assert line.strip() in out
+
+
+def test_sig_describe_1_fromfile_picklist(runtmp):
+    c = runtmp
+
+    # get basic info on a signature
+    sig47 = utils.get_test_data('47.fa.sig')
+    from_file = _write_file(runtmp, 'list.txt', [sig47])
+    picklist = _write_file(runtmp, 'pl.csv', ['md5short', '09a08691'])
+
+    c.run_sourmash('sig', 'describe',  '--from-file', from_file,
+                   '--picklist', f'{picklist}:md5short:md5short')
 
     out = c.last_result.out
     print(c.last_result)

--- a/tests/test_cmd_signature.py
+++ b/tests/test_cmd_signature.py
@@ -1020,6 +1020,24 @@ def test_sig_split_5_no_exist(c):
         c.run_sourmash('sig', 'split', 'foo')
 
 
+def test_sig_split_6_numsigs(runtmp):
+    c = runtmp
+
+    sigs11 = utils.get_test_data('genome-s11.fa.gz.sig')
+    c.run_sourmash('sig', 'split', sigs11)
+
+    print(c.last_result.out)
+    print(c.last_result.err)
+
+    outlist = ['1437d8ea.k=21.num=500.DNA.dup=0.genome-s11.fa.gz.sig',
+               '37aea787.k=7.num=500.protein.dup=0.genome-s11.fa.gz.sig',
+               '68c565be.k=30.num=500.DNA.dup=0.genome-s11.fa.gz.sig',
+               '73b6df1c.k=10.num=500.protein.dup=0.genome-s11.fa.gz.sig']
+
+    for filename in outlist:
+        assert os.path.exists(c.output(filename))
+
+
 @utils.in_tempdir
 def test_sig_extract_1(c):
     # extract 47 from 47... :)


### PR DESCRIPTION
Fixes #1631

* adds `--force` and `--from-file` to most of `sig` commands.
* adds `-k` and moltype arguments to most of the `sig` commands.
* supports more robust loading of signatures (and catching of errors); better UX, too.
* substantial code simplification and refactoring.

TODO:
- [x] test `split --from-file`
- [x] test `downsample --num` on scaled sig
- [x] test `describe --from-file`
- [x] test `merge --from-file`
- [x] test `intersect --from-file`
- [x] test `rename --from-file`
- [x] test `extract --from-file`
- [x] test `flatten --from-file`
- [x] test `downsample --num --scaled` both
- [x] revisit `LoadManySignatures` - should it be a generator fn only? should it be in `sig/__main__.py` only?
- [x] probably worth writing some tests for `LoadManySignatures` directly.
- [x] add picklists throughout?