### PR TITLE
[MRG] an example of using a custom exception for sourmash CLI test failures

### DIFF
--- a/tests/test_test_framework.py
+++ b/tests/test_test_framework.py
@@ -1,0 +1,12 @@
+import pytest
+import sourmash_tst_utils as utils
+
+
+def test_failed_sourmash_exception(runtmp):
+    # this is current behavior:
+    with pytest.raises(ValueError):
+        runtmp.sourmash('')
+
+    # ...this is desired behavior:
+    with pytest.raises(utils.SourmashCommandFailed):
+        runtmp.sourmash('')


### PR DESCRIPTION
This is an example of what I imagine a solution to https://github.com/sourmash-bio/sourmash/pull/1611 would look like, ref #1621.

cc @keyabarve you can merge this if you want something that should work once #1611 is fixed. You'll need to remove the ValueError check, which is current behavior, of course.

