### PR TITLE
[MRG] test and fix `sourmash_args.load_many_signatures(...)` and `lca_db.load_single_database`

### DIFF
--- a/src/sourmash/lca/lca_db.py
+++ b/src/sourmash/lca/lca_db.py
@@ -226,7 +226,7 @@ class LCA_Database(Index):
                 first_ch = fp.read(1)
             except ValueError:
                 first_ch = 'X'
-            if first_ch[0] != '{':
+            if not first_ch or first_ch[0] != '{':
                 raise ValueError(f"'{db_name}' is not an LCA database file.")
 
             fp.seek(0)

--- a/src/sourmash/sourmash_args.py
+++ b/src/sourmash/sourmash_args.py
@@ -601,16 +601,21 @@ def load_many_signatures(locations, progress, *, yield_all_files=False,
     """
     for loc in locations:
         try:
+            # open index,
             idx = load_file_as_index(loc, yield_all_files=yield_all_files)
+
+            # select on parameters as desired,
             idx = idx.select(ksize=ksize, moltype=moltype, picklist=picklist)
 
+            # start up iterator,
             loader = idx.signatures_with_location()
 
-            n = 0
+            # go!
+            n = 0               # count signatures loaded
             for sig, sigloc in progress.start_file(loc, loader):
                 yield sig, sigloc
                 n += 1
-            notify(f"loaded {n} isgnatures from '{loc}'", end='\r')
+            notify(f"loaded {n} signatures from '{loc}'", end='\r')
         except ValueError as exc:
             # trap expected errors, and either power through or display + exit.
             if force:
@@ -618,7 +623,7 @@ def load_many_signatures(locations, progress, *, yield_all_files=False,
                 notify("(continuing)")
                 continue
             else:
-                notify("ERROR: {}". str(exc))
+                notify("ERROR: {}", str(exc))
                 sys.exit(-1)
         except KeyboardInterrupt:
             notify("Received CTRL-C - exiting.")

--- a/tests/test_lca.py
+++ b/tests/test_lca.py
@@ -452,6 +452,19 @@ def test_load_single_db():
     assert scaled == 10000
 
 
+def test_load_single_db_empty(runtmp):
+    # test load_single_database on an empty file; should raise ValueError
+    empty = runtmp.output('empty.lca.json')
+
+    with open(empty, "wt") as fp:
+        pass
+
+    with pytest.raises(ValueError) as exc:
+        db, ksize, scaled = lca_utils.load_single_database(empty)
+
+    assert f"'{empty}' is not an LCA database file." in str(exc.value)
+
+
 def test_databases():
     filename1 = utils.get_test_data('lca/delmont-1.lca.json')
     filename2 = utils.get_test_data('lca/delmont-2.lca.json')

--- a/tests/test_sourmash_args.py
+++ b/tests/test_sourmash_args.py
@@ -211,3 +211,39 @@ def test_load_empty_zipfile(runtmp):
 
     sigiter = sourmash.load_file_as_signatures(outloc)
     assert list(sigiter) == []
+
+
+def test_load_many_sigs_empty_file(runtmp):
+    # make sure load_many_signatures behaves properly on empty file
+    outloc = runtmp.output("empty.sig")
+
+    progress = sourmash_args.SignatureLoadingProgress()
+
+    with contextlib.redirect_stderr(io.StringIO()) as errfp:
+        with pytest.raises(SystemExit) as exc:
+            for ss, sigloc in sourmash_args.load_many_signatures([outloc],
+                                                                 progress):
+                pass
+
+    err = errfp.getvalue()
+    print(err)
+    assert f"ERROR: Error while reading signatures from '{outloc}'." in err
+    assert "(continuing)" not in err
+
+
+def test_load_many_sigs_empty_file_force(runtmp):
+    # make sure load_many_signatures behaves properly on empty file w/force
+    outloc = runtmp.output("empty.sig")
+
+    progress = sourmash_args.SignatureLoadingProgress()
+
+    with contextlib.redirect_stderr(io.StringIO()) as errfp:
+        for ss, sigloc in sourmash_args.load_many_signatures([outloc],
+                                                             progress,
+                                                             force=True):
+            pass
+
+    err = errfp.getvalue()
+    print(err)
+    assert f"ERROR: Error while reading signatures from '{outloc}'." in err
+    assert "(continuing)" in err

--- a/tests/test_sourmash_args.py
+++ b/tests/test_sourmash_args.py
@@ -216,6 +216,8 @@ def test_load_empty_zipfile(runtmp):
 def test_load_many_sigs_empty_file(runtmp):
     # make sure load_many_signatures behaves properly on empty file
     outloc = runtmp.output("empty.sig")
+    with open(outloc, "wt") as fp:
+        pass
 
     progress = sourmash_args.SignatureLoadingProgress()
 
@@ -234,6 +236,8 @@ def test_load_many_sigs_empty_file(runtmp):
 def test_load_many_sigs_empty_file_force(runtmp):
     # make sure load_many_signatures behaves properly on empty file w/force
     outloc = runtmp.output("empty.sig")
+    with open(outloc, "wt") as fp:
+        pass
 
     progress = sourmash_args.SignatureLoadingProgress()
 


### PR DESCRIPTION
Back in https://github.com/sourmash-bio/sourmash/pull/1672, released in 4.2.1, we added `sourmash_args.load_many_signatures(...)`. However, I failed to properly test some of the error conditions.

Separately, a bug in `lca_db.load_single_database(...)` resulted in an `IndexError` being raised on an empty file (instead of a `ValueError`), which in turn resulted in a visible exception being presented to the user.

This PR fixes both issues and properly tests `load_many_signatures` error conditions directly.
