### PR TITLE
[MRG] Doing bounds checking on `--num` via command line

### DIFF
--- a/src/sourmash/cli/compute.py
+++ b/src/sourmash/cli/compute.py
@@ -30,7 +30,7 @@ Please see -h for all of the options as well as more detailed help.
 """
 
 from sourmash.minhash import get_minhash_default_seed
-from sourmash.cli.utils import add_construct_moltype_args
+from sourmash.cli.utils import add_construct_moltype_args, add_num_arg
 
 
 def ksize_parser(ksizes):
@@ -57,6 +57,7 @@ def subparser(subparsers):
         '-n', '--num-hashes', type=int, default=500,
         help='number of hashes to use in each sketch; default=%(default)i'
     )
+    # add_num_arg(subparser, 0)
     sketch_args.add_argument(
         '--track-abundance', action='store_true',
         help='track k-mer abundances in the generated signature'

--- a/src/sourmash/cli/compute.py
+++ b/src/sourmash/cli/compute.py
@@ -57,7 +57,6 @@ def subparser(subparsers):
         '-n', '--num-hashes', type=int, default=500,
         help='number of hashes to use in each sketch; default=%(default)i'
     )
-    # add_num_arg(subparser, 0)
     sketch_args.add_argument(
         '--track-abundance', action='store_true',
         help='track k-mer abundances in the generated signature'
@@ -124,6 +123,7 @@ def subparser(subparsers):
     )
     subparser._positionals.title = 'Required arguments'
     subparser._optionals.title = 'Miscellaneous options'
+    # add_num_arg(sketch_args, 0)
 
 
 def main(args):

--- a/src/sourmash/cli/compute.py
+++ b/src/sourmash/cli/compute.py
@@ -123,7 +123,7 @@ def subparser(subparsers):
     )
     subparser._positionals.title = 'Required arguments'
     subparser._optionals.title = 'Miscellaneous options'
-    add_num_arg(sketch_args, 0)
+    add_num_arg(sketch_args, 500)
 
 
 def main(args):

--- a/src/sourmash/cli/compute.py
+++ b/src/sourmash/cli/compute.py
@@ -53,10 +53,6 @@ def subparser(subparsers):
         type=ksize_parser,
         help='comma-separated list of k-mer sizes; default=%(default)s'
     )
-    # sketch_args.add_argument(
-    #     '-n', '--num-hashes', type=int, default=500,
-    #     help='number of hashes to use in each sketch; default=%(default)i'
-    # )
     sketch_args.add_argument(
         '--track-abundance', action='store_true',
         help='track k-mer abundances in the generated signature'

--- a/src/sourmash/cli/compute.py
+++ b/src/sourmash/cli/compute.py
@@ -53,10 +53,10 @@ def subparser(subparsers):
         type=ksize_parser,
         help='comma-separated list of k-mer sizes; default=%(default)s'
     )
-    sketch_args.add_argument(
-        '-n', '--num-hashes', type=int, default=500,
-        help='number of hashes to use in each sketch; default=%(default)i'
-    )
+    # sketch_args.add_argument(
+    #     '-n', '--num-hashes', type=int, default=500,
+    #     help='number of hashes to use in each sketch; default=%(default)i'
+    # )
     sketch_args.add_argument(
         '--track-abundance', action='store_true',
         help='track k-mer abundances in the generated signature'
@@ -123,7 +123,7 @@ def subparser(subparsers):
     )
     subparser._positionals.title = 'Required arguments'
     subparser._optionals.title = 'Miscellaneous options'
-    # add_num_arg(sketch_args, 0)
+    add_num_arg(sketch_args, 0)
 
 
 def main(args):

--- a/src/sourmash/cli/sig/downsample.py
+++ b/src/sourmash/cli/sig/downsample.py
@@ -15,10 +15,6 @@ def subparser(subparsers):
         '--from-file',
         help='a text file containing a list of files to load signatures from'
     )
-    # subparser.add_argument(
-    #     '--num', metavar='N', type=int, default=0,
-    #     help='num value to downsample to'
-    # )
     subparser.add_argument(
         '-q', '--quiet', action='store_true',
         help='suppress non-error output'

--- a/src/sourmash/cli/sig/downsample.py
+++ b/src/sourmash/cli/sig/downsample.py
@@ -15,6 +15,7 @@ def subparser(subparsers):
         '--from-file',
         help='a text file containing a list of files to load signatures from'
     )
+    # use as reference
     subparser.add_argument(
         '--num', metavar='N', type=int, default=0,
         help='num value to downsample to'

--- a/src/sourmash/cli/sig/downsample.py
+++ b/src/sourmash/cli/sig/downsample.py
@@ -15,10 +15,10 @@ def subparser(subparsers):
         '--from-file',
         help='a text file containing a list of files to load signatures from'
     )
-    subparser.add_argument(
-        '--num', metavar='N', type=int, default=0,
-        help='num value to downsample to'
-    )
+    # subparser.add_argument(
+    #     '--num', metavar='N', type=int, default=0,
+    #     help='num value to downsample to'
+    # )
     subparser.add_argument(
         '-q', '--quiet', action='store_true',
         help='suppress non-error output'
@@ -35,7 +35,7 @@ def subparser(subparsers):
     add_ksize_arg(subparser, 31)
     add_moltype_args(subparser)
     add_picklist_args(subparser)
-    # add_num_arg(subparser, 0)
+    add_num_arg(subparser, 0)
 
 
 def main(args):

--- a/src/sourmash/cli/sig/downsample.py
+++ b/src/sourmash/cli/sig/downsample.py
@@ -1,6 +1,6 @@
 """downsample one or more signatures"""
 
-from sourmash.cli.utils import (add_moltype_args, add_ksize_arg, add_num_arg,
+from sourmash.cli.utils import (add_moltype_args, add_ksize_arg,
                                 add_picklist_args, add_num_arg)
 
 

--- a/src/sourmash/cli/sig/downsample.py
+++ b/src/sourmash/cli/sig/downsample.py
@@ -1,7 +1,7 @@
 """downsample one or more signatures"""
 
-from sourmash.cli.utils import (add_moltype_args, add_ksize_arg,
-                                add_picklist_args)
+from sourmash.cli.utils import (add_moltype_args, add_ksize_arg, add_num_arg,
+                                add_picklist_args, add_num_arg)
 
 
 def subparser(subparsers):
@@ -15,7 +15,6 @@ def subparser(subparsers):
         '--from-file',
         help='a text file containing a list of files to load signatures from'
     )
-    # use as reference
     subparser.add_argument(
         '--num', metavar='N', type=int, default=0,
         help='num value to downsample to'
@@ -36,6 +35,7 @@ def subparser(subparsers):
     add_ksize_arg(subparser, 31)
     add_moltype_args(subparser)
     add_picklist_args(subparser)
+    # add_num_arg(subparser, 0)
 
 
 def main(args):

--- a/src/sourmash/cli/utils.py
+++ b/src/sourmash/cli/utils.py
@@ -140,3 +140,7 @@ def add_num_arg(parser, default=None):
         '--num', metavar='N', type=check_num_bounds,
         help='num value should be between 50 and 50000'
     )
+    parser.add_argument(
+        '--num-hashes', metavar='N', type=check_num_bounds,
+        help='number of hashes to use in each sketch (default: %(default)i)'
+    )

--- a/src/sourmash/cli/utils.py
+++ b/src/sourmash/cli/utils.py
@@ -137,10 +137,6 @@ def check_num_bounds(arg):
 
 def add_num_arg(parser, default=0):
     parser.add_argument(
-        '-n', '--num-hashes', '--num', metavar='INT', type=check_num_bounds, default=0,
+        '-n', '--num-hashes', '--num', metavar='N', type=check_num_bounds, default=default,
         help='num value should be between 50 and 50000'
     )
-    # parser.add_argument(
-    #     '-n', '--num-hashes', metavar='INT', type=check_num_bounds, default=500,
-    #     help='number of hashes to use in each sketch (default: %(default)i)'
-    # )

--- a/src/sourmash/cli/utils.py
+++ b/src/sourmash/cli/utils.py
@@ -135,12 +135,12 @@ def check_num_bounds(arg):
     return f
 
 
-def add_num_arg(parser, default=500):
+def add_num_arg(parser, default=0):
     parser.add_argument(
-        '--num', metavar='INT', type=check_num_bounds, default=0,
+        '-n', '--num-hashes', '--num', metavar='INT', type=check_num_bounds, default=0,
         help='num value should be between 50 and 50000'
     )
-    parser.add_argument(
-        '-n', '--num-hashes', metavar='INT', type=check_num_bounds, default=500,
-        help='number of hashes to use in each sketch (default: %(default)i)'
-    )
+    # parser.add_argument(
+    #     '-n', '--num-hashes', metavar='INT', type=check_num_bounds, default=500,
+    #     help='number of hashes to use in each sketch (default: %(default)i)'
+    # )

--- a/src/sourmash/cli/utils.py
+++ b/src/sourmash/cli/utils.py
@@ -127,11 +127,11 @@ def check_num_bounds(arg):
     f = int(arg)
 
     if f < actual_min_val:
-        raise argparse.ArgumentTypeError(f"ERROR: --num value must be positive")
+        raise argparse.ArgumentTypeError(f"ERROR: --num-hashes value must be positive")
     if f < min_val:
-        notify('WARNING: --num value should be >= 50. Continuing anyway.')
+        notify('WARNING: --num-hashes value should be >= 50. Continuing anyway.')
     if f > max_val:
-        notify('WARNING: --num value should be <= 50000. Continuing anyway.')
+        notify('WARNING: --num-hashes value should be <= 50000. Continuing anyway.')
     return f
 
 

--- a/src/sourmash/cli/utils.py
+++ b/src/sourmash/cli/utils.py
@@ -124,7 +124,7 @@ def check_num_bounds(arg):
     min_val = 50
     max_val = 50000
 
-    f = float(arg)
+    f = int(arg)
 
     if f < actual_min_val:
         raise argparse.ArgumentTypeError(f"ERROR: --num value must be positive")

--- a/src/sourmash/cli/utils.py
+++ b/src/sourmash/cli/utils.py
@@ -117,3 +117,26 @@ def add_scaled_arg(parser, default=None):
         '--scaled', metavar='FLOAT', type=check_scaled_bounds,
         help='scaled value should be between 100 and 1e6'
     )
+
+
+def check_num_bounds(arg):
+    actual_min_val = 0
+    min_val = 50
+    max_val = 50000
+
+    f = float(arg)
+
+    if f < actual_min_val:
+        raise argparse.ArgumentTypeError(f"ERROR: --num value must be positive")
+    if f < min_val:
+        notify('WARNING: --num value should be >= 50. Continuing anyway.')
+    if f > max_val:
+        notify('WARNING: --num value should be <= 50000. Continuing anyway.')
+    return f
+
+
+def add_num_arg(parser, default=None):
+    parser.add_argument(
+        '--num', metavar='N', type=check_num_bounds,
+        help='num value should be between 50 and 50000'
+    )

--- a/src/sourmash/cli/utils.py
+++ b/src/sourmash/cli/utils.py
@@ -135,12 +135,12 @@ def check_num_bounds(arg):
     return f
 
 
-def add_num_arg(parser, default=None):
+def add_num_arg(parser, default=500):
     parser.add_argument(
-        '--num', metavar='N', type=check_num_bounds,
+        '--num', metavar='INT', type=check_num_bounds, default=0,
         help='num value should be between 50 and 50000'
     )
     parser.add_argument(
-        '--num-hashes', metavar='N', type=check_num_bounds,
+        '-n', '--num-hashes', metavar='INT', type=check_num_bounds, default=500,
         help='number of hashes to use in each sketch (default: %(default)i)'
     )

--- a/src/sourmash/cli/watch.py
+++ b/src/sourmash/cli/watch.py
@@ -24,7 +24,6 @@ def subparser(subparsers):
         help='Consume protein sequences - no translation needed'
     )
     add_moltype_args(subparser)
-    # add_num_arg(subparser, 0)
     subparser.add_argument(
         '-n', '--num-hashes', type=int, default=500,
         help='number of hashes to use in each sketch (default: %(default)i)'
@@ -34,7 +33,7 @@ def subparser(subparsers):
         help='name to use for generated signature'
     )
     add_ksize_arg(subparser, 31)
-
+    # add_num_arg(subparser, 0)
 
 def main(args):
     import sourmash

--- a/src/sourmash/cli/watch.py
+++ b/src/sourmash/cli/watch.py
@@ -1,6 +1,6 @@
 """classify a stream of sequences"""
 
-from sourmash.cli.utils import add_ksize_arg, add_moltype_args
+from sourmash.cli.utils import add_ksize_arg, add_moltype_args, add_num_arg
 
 
 def subparser(subparsers):
@@ -24,6 +24,7 @@ def subparser(subparsers):
         help='Consume protein sequences - no translation needed'
     )
     add_moltype_args(subparser)
+    # add_num_arg(subparser, 0)
     subparser.add_argument(
         '-n', '--num-hashes', type=int, default=500,
         help='number of hashes to use in each sketch (default: %(default)i)'

--- a/src/sourmash/cli/watch.py
+++ b/src/sourmash/cli/watch.py
@@ -33,7 +33,7 @@ def subparser(subparsers):
         help='name to use for generated signature'
     )
     add_ksize_arg(subparser, 31)
-    add_num_arg(subparser, 0)
+    add_num_arg(subparser, 500)
 
 def main(args):
     import sourmash

--- a/src/sourmash/cli/watch.py
+++ b/src/sourmash/cli/watch.py
@@ -24,16 +24,16 @@ def subparser(subparsers):
         help='Consume protein sequences - no translation needed'
     )
     add_moltype_args(subparser)
-    subparser.add_argument(
-        '-n', '--num-hashes', type=int, default=500,
-        help='number of hashes to use in each sketch (default: %(default)i)'
-    )
+    # subparser.add_argument(
+    #     '-n', '--num-hashes', type=int, default=500,
+    #     help='number of hashes to use in each sketch (default: %(default)i)'
+    # )
     subparser.add_argument(
         '--name', type=str, default='stdin',
         help='name to use for generated signature'
     )
     add_ksize_arg(subparser, 31)
-    # add_num_arg(subparser, 0)
+    add_num_arg(subparser, 0)
 
 def main(args):
     import sourmash

--- a/src/sourmash/cli/watch.py
+++ b/src/sourmash/cli/watch.py
@@ -24,10 +24,6 @@ def subparser(subparsers):
         help='Consume protein sequences - no translation needed'
     )
     add_moltype_args(subparser)
-    # subparser.add_argument(
-    #     '-n', '--num-hashes', type=int, default=500,
-    #     help='number of hashes to use in each sketch (default: %(default)i)'
-    # )
     subparser.add_argument(
         '--name', type=str, default='stdin',
         help='name to use for generated signature'

--- a/src/sourmash/sig/__main__.py
+++ b/src/sourmash/sig/__main__.py
@@ -766,11 +766,11 @@ def downsample(args):
     picklist = sourmash_args.load_picklist(args)
     _extend_signatures_with_from_file(args)
 
-    if not args.num and not args.scaled:
+    if not args.num_hashes and not args.scaled:
         error('ERROR: must specify either --num or --scaled value')
         sys.exit(-1)
 
-    if args.num and args.scaled:
+    if args.num_hashes and args.scaled:
         error('ERROR: cannot specify both --num and --scaled')
         sys.exit(-1)
 
@@ -804,18 +804,18 @@ def downsample(args):
 
                 mh_new = mh.copy()
                 _set_num_scaled(mh_new, 0, args.scaled)
-        elif args.num:
+        elif args.num_hashes:
             # downsample num to num? straightforward.
             if mh.num:
-                mh_new = mh.downsample(num=args.num)
+                mh_new = mh.downsample(num=args.num_hashes)
             # try to turn a scaled into a num - trickier.
             else:
                 # first check: can we?
-                if len(mh) < args.num:
+                if len(mh) < args.num_hashes:
                     raise ValueError(f"this scaled MinHash has only {len(mh)} hashes")
 
                 mh_new = mh.copy()
-                _set_num_scaled(mh_new, args.num, 0)
+                _set_num_scaled(mh_new, args.num_hashes, 0)
 
         ss.minhash = mh_new
 

--- a/tests/test_cmd_signature.py
+++ b/tests/test_cmd_signature.py
@@ -2392,7 +2392,7 @@ def test_sig_downsample_check_num_bounds_negative(runtmp):
     with pytest.raises(ValueError):
         c.run_sourmash('sig', 'downsample', '--num', '-5', sig47)
 
-    assert "ERROR: --num value must be positive" in c.last_result.err
+    assert "ERROR: --num-hashes value must be positive" in c.last_result.err
 
 
 def test_sig_downsample_check_num_bounds_less_than_minimum(runtmp):
@@ -2401,7 +2401,7 @@ def test_sig_downsample_check_num_bounds_less_than_minimum(runtmp):
 
     c.run_sourmash('sig', 'downsample', '--num', '25', sig47)
 
-    assert "WARNING: --num value should be >= 50. Continuing anyway." in c.last_result.err
+    assert "WARNING: --num-hashes value should be >= 50. Continuing anyway." in c.last_result.err
 
 
 def test_sig_downsample_check_num_bounds_more_than_maximum(runtmp):
@@ -2411,7 +2411,7 @@ def test_sig_downsample_check_num_bounds_more_than_maximum(runtmp):
     with pytest.raises(ValueError):
         c.run_sourmash('sig', 'downsample', '--num', '100000', sig47)
 
-    assert "WARNING: --num value should be <= 50000. Continuing anyway." in c.last_result.err
+    assert "WARNING: --num-hashes value should be <= 50000. Continuing anyway." in c.last_result.err
 
 
 @utils.in_tempdir

--- a/tests/test_cmd_signature.py
+++ b/tests/test_cmd_signature.py
@@ -2385,6 +2385,35 @@ def test_sig_downsample_1_scaled_to_num(c):
     assert actual_mins == test_mins
 
 
+def test_sig_downsample_check_num_bounds_negative(runtmp):
+    c=runtmp
+    sig47 = utils.get_test_data('47.fa.sig')
+
+    with pytest.raises(ValueError):
+        c.run_sourmash('sig', 'downsample', '--num', '-5', sig47)
+
+    assert "ERROR: --num value must be positive" in c.last_result.err
+
+
+def test_sig_downsample_check_num_bounds_less_than_minimum(runtmp):
+    c=runtmp
+    sig47 = utils.get_test_data('47.fa.sig')
+
+    c.run_sourmash('sig', 'downsample', '--num', '25', sig47)
+
+    assert "WARNING: --num value should be >= 50. Continuing anyway." in c.last_result.err
+
+
+def test_sig_downsample_check_num_bounds_more_than_maximum(runtmp):
+    c=runtmp
+    sig47 = utils.get_test_data('47.fa.sig')
+
+    with pytest.raises(ValueError):
+        c.run_sourmash('sig', 'downsample', '--num', '100000', sig47)
+
+    assert "WARNING: --num value should be <= 50000. Continuing anyway." in c.last_result.err
+
+
 @utils.in_tempdir
 def test_sig_downsample_1_scaled_to_num_fail(c):
     # downsample a scaled signature

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -4897,6 +4897,23 @@ def test_sbt_categorize_multiple_ksizes_moltypes():
                                            in_directory=location)
 
 
+# @utils.in_tempdir
+# def test_watch_check_num_bounds_negative(c):
+#     testdata0 = utils.get_test_data('genome-s10.fa.gz')
+#     testdata1 = utils.get_test_data('genome-s10.fa.gz.sig')
+#     shutil.copyfile(testdata1, c.output('1.sig'))
+
+#     c.run_sourmash('index', '--dna', '-k', '21', 'zzz', '1.sig')
+
+#     with pytest.raises(ValueError) as exc:
+#         c.run_sourmash('watch', '--ksize', '21', '-n', '-5', '--dna', 'zzz', testdata0)
+
+#     # print(c.last_result.out)
+#     # print(c.last_result.err)
+#     # assert 'FOUND: genome-s10, at 1.000' in c.last_result.out
+#     assert "ERROR: --scaled value must be positive" in str(exc.value)
+
+
 @utils.in_tempdir
 def test_watch(c):
     testdata0 = utils.get_test_data('genome-s10.fa.gz')

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -4848,7 +4848,7 @@ def test_watch_check_num_bounds_negative(runtmp):
     with pytest.raises(ValueError) as exc:
         c.run_sourmash('watch', '--ksize', '21', '-n', '-5', '--dna', 'zzz', testdata0)
 
-    assert "ERROR: --num value must be positive" in c.last_result.err
+    assert "ERROR: --num-hashes value must be positive" in c.last_result.err
 
 
 def test_watch_check_num_bounds_less_than_minimum(runtmp):
@@ -4861,7 +4861,7 @@ def test_watch_check_num_bounds_less_than_minimum(runtmp):
 
     c.run_sourmash('watch', '--ksize', '21', '-n', '25', '--dna', 'zzz', testdata0)
 
-    assert "WARNING: --num value should be >= 50. Continuing anyway." in c.last_result.err
+    assert "WARNING: --num-hashes value should be >= 50. Continuing anyway." in c.last_result.err
 
 
 def test_watch_check_num_bounds_more_than_maximum(runtmp):
@@ -4874,7 +4874,7 @@ def test_watch_check_num_bounds_more_than_maximum(runtmp):
 
     c.run_sourmash('watch', '--ksize', '21', '-n', '100000', '--dna', 'zzz', testdata0)
 
-    assert "WARNING: --num value should be <= 50000. Continuing anyway." in c.last_result.err
+    assert "WARNING: --num-hashes value should be <= 50000. Continuing anyway." in c.last_result.err
 
 
 @utils.in_tempdir

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -4836,21 +4836,44 @@ def test_sbt_categorize_multiple_ksizes_moltypes():
                                            in_directory=location)
 
 
-# @utils.in_tempdir
-# def test_watch_check_num_bounds_negative(c):
-#     testdata0 = utils.get_test_data('genome-s10.fa.gz')
-#     testdata1 = utils.get_test_data('genome-s10.fa.gz.sig')
-#     shutil.copyfile(testdata1, c.output('1.sig'))
+def test_watch_check_num_bounds_negative(runtmp):
+    c=runtmp
+    testdata0 = utils.get_test_data('genome-s10.fa.gz')
+    testdata1 = utils.get_test_data('genome-s10.fa.gz.sig')
+    shutil.copyfile(testdata1, c.output('1.sig'))
 
-#     c.run_sourmash('index', '--dna', '-k', '21', 'zzz', '1.sig')
+    c.run_sourmash('index', '--dna', '-k', '21', 'zzz', '1.sig')
 
-#     with pytest.raises(ValueError) as exc:
-#         c.run_sourmash('watch', '--ksize', '21', '-n', '-5', '--dna', 'zzz', testdata0)
+    with pytest.raises(ValueError) as exc:
+        c.run_sourmash('watch', '--ksize', '21', '-n', '-5', '--dna', 'zzz', testdata0)
 
-#     # print(c.last_result.out)
-#     # print(c.last_result.err)
-#     # assert 'FOUND: genome-s10, at 1.000' in c.last_result.out
-#     assert "ERROR: --scaled value must be positive" in str(exc.value)
+    assert "ERROR: --num value must be positive" in c.last_result.err
+
+
+def test_watch_check_num_bounds_less_than_minimum(runtmp):
+    c=runtmp
+    testdata0 = utils.get_test_data('genome-s10.fa.gz')
+    testdata1 = utils.get_test_data('genome-s10.fa.gz.sig')
+    shutil.copyfile(testdata1, c.output('1.sig'))
+
+    c.run_sourmash('index', '--dna', '-k', '21', 'zzz', '1.sig')
+
+    c.run_sourmash('watch', '--ksize', '21', '-n', '25', '--dna', 'zzz', testdata0)
+
+    assert "WARNING: --num value should be >= 50. Continuing anyway." in c.last_result.err
+
+
+def test_watch_check_num_bounds_more_than_maximum(runtmp):
+    c=runtmp
+    testdata0 = utils.get_test_data('genome-s10.fa.gz')
+    testdata1 = utils.get_test_data('genome-s10.fa.gz.sig')
+    shutil.copyfile(testdata1, c.output('1.sig'))
+
+    c.run_sourmash('index', '--dna', '-k', '21', 'zzz', '1.sig')
+
+    c.run_sourmash('watch', '--ksize', '21', '-n', '100000', '--dna', 'zzz', testdata0)
+
+    assert "WARNING: --num value should be <= 50000. Continuing anyway." in c.last_result.err
 
 
 @utils.in_tempdir

--- a/tests/test_sourmash_compute.py
+++ b/tests/test_sourmash_compute.py
@@ -38,6 +38,43 @@ def test_do_sourmash_compute():
         assert str(sig).endswith('short.fa')
 
 
+def test_do_sourmash_compute_check_num_bounds_negative(runtmp):
+    c=runtmp
+    testdata1 = utils.get_test_data('short.fa')
+    testdata2 = utils.get_test_data('short2.fa')
+    testdata3 = utils.get_test_data('short3.fa')
+    sigfile = c.output('short.fa.sig')
+
+    with pytest.raises(ValueError):
+        c.run_sourmash('compute', '-k', '31', '--num-hashes', '-5', '-o', sigfile, '--merge', '"name"', testdata1, testdata2, testdata3)
+    
+    assert "ERROR: --num-hashes value must be positive" in c.last_result.err
+
+
+def test_do_sourmash_compute_check_num_bounds_less_than_minimum(runtmp):
+    c=runtmp
+    testdata1 = utils.get_test_data('short.fa')
+    testdata2 = utils.get_test_data('short2.fa')
+    testdata3 = utils.get_test_data('short3.fa')
+    sigfile = c.output('short.fa.sig')
+
+    c.run_sourmash('compute', '-k', '31', '--num-hashes', '25', '-o', sigfile, '--merge', '"name"', testdata1, testdata2, testdata3)
+    
+    assert "WARNING: --num-hashes value should be >= 50. Continuing anyway." in c.last_result.err
+
+
+def test_do_sourmash_compute_check_num_bounds_more_than_maximum(runtmp):
+    c=runtmp
+    testdata1 = utils.get_test_data('short.fa')
+    testdata2 = utils.get_test_data('short2.fa')
+    testdata3 = utils.get_test_data('short3.fa')
+    sigfile = c.output('short.fa.sig')
+
+    c.run_sourmash('compute', '-k', '31', '--num-hashes', '100000', '-o', sigfile, '--merge', '"name"', testdata1, testdata2, testdata3)
+    
+    assert "WARNING: --num-hashes value should be <= 50000. Continuing anyway." in c.last_result.err
+
+
 @utils.in_tempdir
 def test_do_sourmash_compute_outdir(c):
     testdata1 = utils.get_test_data('short.fa')


### PR DESCRIPTION
Fixes #1243

Done:
- Add checks for the values of num. num values should always be > 0. if they are unreasonable, say > 50,000 or < 50, we should emit a warning.
- Tests for `watch` command written in tests/test_sourmash.py`.
- Tests for `compute` command written in `tests/test_sourmash_compute.py`.
- Tests for `downsample` command written in `tests/test_cmd_signature.py`.

NOTE:
- `sourmash compute` has been changed to `sourmash sketch` in almost all of the places in `tests/test_sourmash.py` (check #1419).
- The tests for each command have been written in the same file as other tests for that particular command.