### PR TITLE
[MRG] add option: bad_kmers_as_zeroes

### DIFF
--- a/include/sourmash.h
+++ b/include/sourmash.h
@@ -239,6 +239,7 @@ const uint64_t *kmerminhash_seq_to_hashes(SourmashKmerMinHash *ptr,
                                           const char *sequence,
                                           uintptr_t insize,
                                           bool force,
+                                          bool bad_kmers_as_zeroes,
                                           bool is_protein,
                                           uintptr_t *size);
 

--- a/src/sourmash/minhash.py
+++ b/src/sourmash/minhash.py
@@ -334,9 +334,14 @@ class MinHash(RustObject):
         """
         import screed
 
+        bad_kmers_as_zeroes = False
+        if force:
+            bad_kmers_as_zeroes = True
+
         sequence = sequence.upper()
         hashvals = self.seq_to_hashes(sequence,
-                                      force=force, is_protein=is_protein)
+                                      force=force, is_protein=is_protein,
+                                      bad_kmers_as_zeroes=bad_kmers_as_zeroes)
 
         ksize = self.ksize
         translate = False

--- a/src/sourmash/minhash.py
+++ b/src/sourmash/minhash.py
@@ -309,7 +309,7 @@ class MinHash(RustObject):
 
         if is_protein and self.moltype not in ("protein", "dayhoff", "hp"):
             raise ValueError("cannot add protein sequence to DNA MinHash")
-        
+
         if bad_kmers_as_zeroes and not force:
             raise ValueError("cannot represent invalid kmers as 0 while force is not set to True")
 

--- a/tests/test_minhash.py
+++ b/tests/test_minhash.py
@@ -2247,8 +2247,6 @@ def test_dna_kmers_3_bad_dna():
 
 
 def test_dna_kmers_4_bad_dna():
-    # @CTB: THIS DOESN'T CURRENTLY WORK :(
-    return
     # test kmers_and_hashes for bad dna -> dna, using force
     mh = MinHash(0, ksize=31, scaled=1) # DNA
     seq = "NTGCGAGTGTTGAAGTTCGGCGGTACATCAGTGGCAAATGCAGAACGTTTTCTGCGTGTTGCCGATATTCTGGAAAGCAATGCCAGGCAGGGGCAGGTGGCCACCGTCCTCTCTGCCCCCGCCAAAATCACCAACCACCTGGTGGCGATGATTGAAAAAACCATTAGCGGCCAGGATGCTTTACCCAATATCAGCGATGCCGAACGTATTTTTGCCGAACTTTTGACGGGACTCGCCGCCGCCCAGCCGGGGTTCCCGCTGGCGCAATTGAAAACTTTCGTCGATCAGGAATTTGCCCAAATAAAACATGTCCTGCATGGCATTAGTTTGTTGGGGCAGTGCCCGGATAGCATCAACGCTGCGCTGATTTGCCGTGGCGAGAAAATGTCGATCGCCATTATGGCCGGCGTATTAGAAGCGCGCGGTCACAACGTTACTGTTATCGATCCGGTCGAAAAACTGCTGGCAGTGGGGCATTACCTCGAATCTACCGTCGATATTGCTGAGTCCACCCGCCGTATTGCGGCAAGCCGCATTCCGGCTGATCACATGGTGCTGAT"
@@ -2257,11 +2255,18 @@ def test_dna_kmers_4_bad_dna():
     for kmer, hashval in mh.kmers_and_hashes(seq, force=True):
         # add to minhash obj
         single_mh = mh.copy_and_clear()
-        single_mh.add_sequence(kmer)
-        assert len(single_mh) == 1
+
+        bad_kmer = False
+        try:
+            single_mh.add_sequence(kmer)
+            assert len(single_mh) == 1
+        except ValueError:
+            # bad k-mer :)
+            bad_kmer = True
 
         # confirm it all matches
-        assert hashval == list(single_mh.hashes)[0]
+        if not bad_kmer:
+            assert hashval == list(single_mh.hashes)[0]
 
 
 def test_protein_kmers():

--- a/tests/test_minhash.py
+++ b/tests/test_minhash.py
@@ -232,6 +232,21 @@ def test_seq_to_hashes_translated(track_abundance):
 
     assert set(golden_hashes) == set(new_hashes)
 
+def test_seq_to_hashes_bad_kmers_as_zeroes_1():
+    mh = sourmash.minhash.MinHash(n=0, ksize=21, scaled=1)
+    seq = "ATGAGAGACGATAGACAGATGACN"
+    
+    # New seq to hashes without adding to the sketch
+    hashes = mh.seq_to_hashes(seq, force=True, bad_kmers_as_zeroes=True)
+
+    assert len(hashes) == len(seq) - 21 + 1
+
+def test_seq_to_hashes_bad_kmers_as_zeroes_2():
+    mh = sourmash.minhash.MinHash(n=0, ksize=21, scaled=1)
+    seq = "ATGAGAGACGATAGACAGATGACN"
+    
+    with pytest.raises(ValueError):
+        hashes = mh.seq_to_hashes(seq, bad_kmers_as_zeroes=True)
 
 
 def test_bytes_protein_dayhoff(track_abundance, dayhoff):


### PR DESCRIPTION
A PR into #1695 

This PR adds a flag to represent the invalid kmers as zeroes in `mh.seq_to_hashes` that was introduced in #1653
 
```python
from sourmash import MinHash

mh = MinHash(n = 0, ksize=21, scaled =1, seed = 42)

seq = "ACGTACGTACGTATATATGCTANCGTA"

hashes = mh.seq_to_hashes(seq, force = True)
hashes_with_zeros = mh.seq_to_hashes(seq, force = True, bad_kmers_as_zeroes = True)

print(f"hashes: {hashes}")
print(f"hashes_with_zeros: {hashes_with_zeros}")
```

**Output:**
```
hashes: [4809413341467539085, 7406346453746946037]
hashes_with_zeros: [4809413341467539085, 7406346453746946037, 0, 0, 0, 0, 0]
```
