### PR TITLE
[MRG] Adding bounds checking for `--scaled` and `--num` in `sourmash sketch`

### DIFF
--- a/src/sourmash/cli/utils.py
+++ b/src/sourmash/cli/utils.py
@@ -140,5 +140,3 @@ def add_num_arg(parser, default=0):
         '-n', '--num-hashes', '--num', metavar='N', type=check_num_bounds, default=default,
         help='num value should be between 50 and 50000'
     )
-
-# working on this for sketch

--- a/src/sourmash/cli/utils.py
+++ b/src/sourmash/cli/utils.py
@@ -2,8 +2,7 @@ from glob import glob
 import os
 import argparse
 from sourmash.logging import notify
-from sourmash.sourmash_args import check_scaled_bounds
-from sourmash.sourmash_args import check_num_bounds
+from sourmash.sourmash_args import check_scaled_bounds, check_num_bounds
 
 
 def add_moltype_args(parser):

--- a/src/sourmash/cli/utils.py
+++ b/src/sourmash/cli/utils.py
@@ -140,3 +140,5 @@ def add_num_arg(parser, default=0):
         '-n', '--num-hashes', '--num', metavar='N', type=check_num_bounds, default=default,
         help='num value should be between 50 and 50000'
     )
+
+# working on this for sketch

--- a/src/sourmash/cli/utils.py
+++ b/src/sourmash/cli/utils.py
@@ -97,43 +97,11 @@ def command_list(dirpath):
     return sorted(basenames)
 
 
-# def check_scaled_bounds(arg):
-#     actual_min_val = 0
-#     min_val = 100
-#     max_val = 1e6
-
-#     f = float(arg)
-
-#     if f < actual_min_val:
-#         raise argparse.ArgumentTypeError(f"ERROR: --scaled value must be positive")
-#     if f < min_val:
-#         notify('WARNING: --scaled value should be >= 100. Continuing anyway.')
-#     if f > max_val:
-#         notify('WARNING: --scaled value should be <= 1e6. Continuing anyway.')
-#     return f
-
-
 def add_scaled_arg(parser, default=None):
     parser.add_argument(
         '--scaled', metavar='FLOAT', type=check_scaled_bounds,
         help='scaled value should be between 100 and 1e6'
     )
-
-
-# def check_num_bounds(arg):
-#     actual_min_val = 0
-#     min_val = 50
-#     max_val = 50000
-
-#     f = int(arg)
-
-#     if f < actual_min_val:
-#         raise argparse.ArgumentTypeError(f"ERROR: --num-hashes value must be positive")
-#     if f < min_val:
-#         notify('WARNING: --num-hashes value should be >= 50. Continuing anyway.')
-#     if f > max_val:
-#         notify('WARNING: --num-hashes value should be <= 50000. Continuing anyway.')
-#     return f
 
 
 def add_num_arg(parser, default=0):

--- a/src/sourmash/cli/utils.py
+++ b/src/sourmash/cli/utils.py
@@ -2,6 +2,8 @@ from glob import glob
 import os
 import argparse
 from sourmash.logging import notify
+from sourmash.sourmash_args import check_scaled_bounds
+from sourmash.sourmash_args import check_num_bounds
 
 
 def add_moltype_args(parser):
@@ -96,20 +98,20 @@ def command_list(dirpath):
     return sorted(basenames)
 
 
-def check_scaled_bounds(arg):
-    actual_min_val = 0
-    min_val = 100
-    max_val = 1e6
+# def check_scaled_bounds(arg):
+#     actual_min_val = 0
+#     min_val = 100
+#     max_val = 1e6
 
-    f = float(arg)
+#     f = float(arg)
 
-    if f < actual_min_val:
-        raise argparse.ArgumentTypeError(f"ERROR: --scaled value must be positive")
-    if f < min_val:
-        notify('WARNING: --scaled value should be >= 100. Continuing anyway.')
-    if f > max_val:
-        notify('WARNING: --scaled value should be <= 1e6. Continuing anyway.')
-    return f
+#     if f < actual_min_val:
+#         raise argparse.ArgumentTypeError(f"ERROR: --scaled value must be positive")
+#     if f < min_val:
+#         notify('WARNING: --scaled value should be >= 100. Continuing anyway.')
+#     if f > max_val:
+#         notify('WARNING: --scaled value should be <= 1e6. Continuing anyway.')
+#     return f
 
 
 def add_scaled_arg(parser, default=None):
@@ -119,20 +121,20 @@ def add_scaled_arg(parser, default=None):
     )
 
 
-def check_num_bounds(arg):
-    actual_min_val = 0
-    min_val = 50
-    max_val = 50000
+# def check_num_bounds(arg):
+#     actual_min_val = 0
+#     min_val = 50
+#     max_val = 50000
 
-    f = int(arg)
+#     f = int(arg)
 
-    if f < actual_min_val:
-        raise argparse.ArgumentTypeError(f"ERROR: --num-hashes value must be positive")
-    if f < min_val:
-        notify('WARNING: --num-hashes value should be >= 50. Continuing anyway.')
-    if f > max_val:
-        notify('WARNING: --num-hashes value should be <= 50000. Continuing anyway.')
-    return f
+#     if f < actual_min_val:
+#         raise argparse.ArgumentTypeError(f"ERROR: --num-hashes value must be positive")
+#     if f < min_val:
+#         notify('WARNING: --num-hashes value should be >= 50. Continuing anyway.')
+#     if f > max_val:
+#         notify('WARNING: --num-hashes value should be <= 50000. Continuing anyway.')
+#     return f
 
 
 def add_num_arg(parser, default=0):

--- a/src/sourmash/command_sketch.py
+++ b/src/sourmash/command_sketch.py
@@ -7,7 +7,8 @@ from .signature import SourmashSignature
 from .logging import notify, error, set_quiet
 from .command_compute import (_compute_individual, _compute_merged,
                               ComputeParameters)
-
+from sourmash.sourmash_args import check_scaled_bounds
+from sourmash.sourmash_args import check_num_bounds
 
 DEFAULTS = dict(
     dna='k=31,scaled=1000,noabund',
@@ -40,12 +41,16 @@ def _parse_params_str(params_str):
                 raise ValueError(f"cannot parse num='{num}' as a number")
             # if num < 0:
             #     raise ValueError(f"num is {num}, must be >= 0")
-            if num < 0:
-                raise ValueError(f"ERROR: num value must be positive")
-            if num < 50:
-                notify('WARNING: num value should be >= 50. Continuing anyway.')
-            if num > 50000:
-                notify('WARNING: num value should be <= 50000. Continuing anyway.')
+
+            # if num < 0:
+            #     raise ValueError(f"ERROR: num value must be positive")
+            # if num < 50:
+            #     notify('WARNING: num value should be >= 50. Continuing anyway.')
+            # if num > 50000:
+            #     notify('WARNING: num value should be <= 50000. Continuing anyway.')
+
+            num = check_num_bounds(num)
+
             params['num'] = int(item[4:])
             params['scaled'] = 0
         elif item.startswith('scaled='):
@@ -60,12 +65,16 @@ def _parse_params_str(params_str):
             #     raise ValueError(f"scaled is {scaled}, must be >= 1")
             # if scaled > 1e8:
             #     notify(f"WARNING: scaled value of {scaled} is nonsensical!?")
-            if scaled < 0:
-                raise ValueError(f"ERROR: scaled value must be positive")
-            if scaled < 100:
-                notify('WARNING: scaled value should be >= 100. Continuing anyway.')
-            if scaled > 1e6:
-                notify('WARNING: scaled value should be <= 1e6. Continuing anyway.')
+
+            # if scaled < 0:
+            #     raise ValueError(f"ERROR: scaled value must be positive")
+            # if scaled < 100:
+            #     notify('WARNING: scaled value should be >= 100. Continuing anyway.')
+            # if scaled > 1e6:
+            #     notify('WARNING: scaled value should be <= 1e6. Continuing anyway.')
+
+            scaled = check_scaled_bounds(scaled)
+
             params['scaled'] = scaled
             params['num'] = 0
         elif item.startswith('seed='):

--- a/src/sourmash/command_sketch.py
+++ b/src/sourmash/command_sketch.py
@@ -41,11 +41,11 @@ def _parse_params_str(params_str):
             # if num < 0:
             #     raise ValueError(f"num is {num}, must be >= 0")
             if num < 0:
-                raise ValueError(f"ERROR: --num-hashes value must be positive")
+                raise ValueError(f"ERROR: num value must be positive")
             if num < 50:
-                notify('WARNING: --num-hashes value should be >= 50. Continuing anyway.')
+                notify('WARNING: num value should be >= 50. Continuing anyway.')
             if num > 50000:
-                notify('WARNING: --num-hashes value should be <= 50000. Continuing anyway.')
+                notify('WARNING: num value should be <= 50000. Continuing anyway.')
             params['num'] = int(item[4:])
             params['scaled'] = 0
         elif item.startswith('scaled='):
@@ -61,11 +61,11 @@ def _parse_params_str(params_str):
             # if scaled > 1e8:
             #     notify(f"WARNING: scaled value of {scaled} is nonsensical!?")
             if scaled < 0:
-                raise ValueError(f"ERROR: --scaled value must be positive")
+                raise ValueError(f"ERROR: scaled value must be positive")
             if scaled < 100:
-                notify('WARNING: --scaled value should be >= 100. Continuing anyway.')
+                notify('WARNING: scaled value should be >= 100. Continuing anyway.')
             if scaled > 1e6:
-                notify('WARNING: --scaled value should be <= 1e6. Continuing anyway.')
+                notify('WARNING: scaled value should be <= 1e6. Continuing anyway.')
             params['scaled'] = scaled
             params['num'] = 0
         elif item.startswith('seed='):

--- a/src/sourmash/command_sketch.py
+++ b/src/sourmash/command_sketch.py
@@ -7,8 +7,7 @@ from .signature import SourmashSignature
 from .logging import notify, error, set_quiet
 from .command_compute import (_compute_individual, _compute_merged,
                               ComputeParameters)
-from sourmash.sourmash_args import check_scaled_bounds
-from sourmash.sourmash_args import check_num_bounds
+from sourmash.sourmash_args import check_scaled_bounds, check_num_bounds
 
 DEFAULTS = dict(
     dna='k=31,scaled=1000,noabund',

--- a/src/sourmash/command_sketch.py
+++ b/src/sourmash/command_sketch.py
@@ -38,8 +38,14 @@ def _parse_params_str(params_str):
                 num = int(num)
             except ValueError:
                 raise ValueError(f"cannot parse num='{num}' as a number")
+            # if num < 0:
+            #     raise ValueError(f"num is {num}, must be >= 0")
             if num < 0:
-                raise ValueError(f"num is {num}, must be >= 0")
+                raise ValueError(f"ERROR: --num-hashes value must be positive")
+            if num < 50:
+                notify('WARNING: --num-hashes value should be >= 50. Continuing anyway.')
+            if num > 50000:
+                notify('WARNING: --num-hashes value should be <= 50000. Continuing anyway.')
             params['num'] = int(item[4:])
             params['scaled'] = 0
         elif item.startswith('scaled='):
@@ -50,10 +56,16 @@ def _parse_params_str(params_str):
                 scaled = int(scaled)
             except ValueError:
                 raise ValueError(f"cannot parse scaled='{scaled}' as an integer")
+            # if scaled < 0:
+            #     raise ValueError(f"scaled is {scaled}, must be >= 1")
+            # if scaled > 1e8:
+            #     notify(f"WARNING: scaled value of {scaled} is nonsensical!?")
             if scaled < 0:
-                raise ValueError(f"scaled is {scaled}, must be >= 1")
-            if scaled > 1e8:
-                notify(f"WARNING: scaled value of {scaled} is nonsensical!?")
+                raise ValueError(f"ERROR: --scaled value must be positive")
+            if scaled < 100:
+                notify('WARNING: --scaled value should be >= 100. Continuing anyway.')
+            if scaled > 1e6:
+                notify('WARNING: --scaled value should be <= 1e6. Continuing anyway.')
             params['scaled'] = scaled
             params['num'] = 0
         elif item.startswith('seed='):

--- a/src/sourmash/command_sketch.py
+++ b/src/sourmash/command_sketch.py
@@ -38,15 +38,6 @@ def _parse_params_str(params_str):
                 num = int(num)
             except ValueError:
                 raise ValueError(f"cannot parse num='{num}' as a number")
-            # if num < 0:
-            #     raise ValueError(f"num is {num}, must be >= 0")
-
-            # if num < 0:
-            #     raise ValueError(f"ERROR: num value must be positive")
-            # if num < 50:
-            #     notify('WARNING: num value should be >= 50. Continuing anyway.')
-            # if num > 50000:
-            #     notify('WARNING: num value should be <= 50000. Continuing anyway.')
 
             num = check_num_bounds(num)
 
@@ -60,17 +51,6 @@ def _parse_params_str(params_str):
                 scaled = int(scaled)
             except ValueError:
                 raise ValueError(f"cannot parse scaled='{scaled}' as an integer")
-            # if scaled < 0:
-            #     raise ValueError(f"scaled is {scaled}, must be >= 1")
-            # if scaled > 1e8:
-            #     notify(f"WARNING: scaled value of {scaled} is nonsensical!?")
-
-            # if scaled < 0:
-            #     raise ValueError(f"ERROR: scaled value must be positive")
-            # if scaled < 100:
-            #     notify('WARNING: scaled value should be >= 100. Continuing anyway.')
-            # if scaled > 1e6:
-            #     notify('WARNING: scaled value should be <= 1e6. Continuing anyway.')
 
             scaled = check_scaled_bounds(scaled)
 

--- a/src/sourmash/sourmash_args.py
+++ b/src/sourmash/sourmash_args.py
@@ -29,33 +29,25 @@ DEFAULT_LOAD_K = 31
 
 
 def check_scaled_bounds(arg):
-    actual_min_val = 0
-    min_val = 100
-    max_val = 1e6
-
     f = float(arg)
 
-    if f < actual_min_val:
+    if f < 0:
         raise argparse.ArgumentTypeError(f"ERROR: scaled value must be positive")
-    if f < min_val:
+    if f < 100:
         notify('WARNING: scaled value should be >= 100. Continuing anyway.')
-    if f > max_val:
+    if f > 1e6:
         notify('WARNING: scaled value should be <= 1e6. Continuing anyway.')
     return f
 
 
 def check_num_bounds(arg):
-    actual_min_val = 0
-    min_val = 50
-    max_val = 50000
-
     f = int(arg)
 
-    if f < actual_min_val:
+    if f < 0:
         raise argparse.ArgumentTypeError(f"ERROR: num value must be positive")
-    if f < min_val:
+    if f < 50:
         notify('WARNING: num value should be >= 50. Continuing anyway.')
-    if f > max_val:
+    if f > 50000:
         notify('WARNING: num value should be <= 50000. Continuing anyway.')
     return f
 

--- a/src/sourmash/sourmash_args.py
+++ b/src/sourmash/sourmash_args.py
@@ -22,9 +22,42 @@ from .index import (LinearIndex, ZipFileLinearIndex, MultiIndex)
 from . import signature as sigmod
 from .picklist import SignaturePicklist, PickStyle
 from .manifest import CollectionManifest
+import argparse
 
 
 DEFAULT_LOAD_K = 31
+
+
+def check_scaled_bounds(arg):
+    actual_min_val = 0
+    min_val = 100
+    max_val = 1e6
+
+    f = float(arg)
+
+    if f < actual_min_val:
+        raise argparse.ArgumentTypeError(f"ERROR: scaled value must be positive")
+    if f < min_val:
+        notify('WARNING: scaled value should be >= 100. Continuing anyway.')
+    if f > max_val:
+        notify('WARNING: scaled value should be <= 1e6. Continuing anyway.')
+    return f
+
+
+def check_num_bounds(arg):
+    actual_min_val = 0
+    min_val = 50
+    max_val = 50000
+
+    f = int(arg)
+
+    if f < actual_min_val:
+        raise argparse.ArgumentTypeError(f"ERROR: num value must be positive")
+    if f < min_val:
+        notify('WARNING: num value should be >= 50. Continuing anyway.')
+    if f > max_val:
+        notify('WARNING: num value should be <= 50000. Continuing anyway.')
+    return f
 
 
 def get_moltype(sig, require=False):

--- a/tests/test_cmd_signature.py
+++ b/tests/test_cmd_signature.py
@@ -2394,7 +2394,7 @@ def test_sig_downsample_check_num_bounds_negative(runtmp):
     with pytest.raises(SourmashCommandFailed):
         c.run_sourmash('sig', 'downsample', '--num', '-5', sig47)
 
-    assert "ERROR: --num-hashes value must be positive" in c.last_result.err
+    assert "ERROR: num value must be positive" in c.last_result.err
 
 
 def test_sig_downsample_check_num_bounds_less_than_minimum(runtmp):
@@ -2403,7 +2403,7 @@ def test_sig_downsample_check_num_bounds_less_than_minimum(runtmp):
 
     c.run_sourmash('sig', 'downsample', '--num', '25', sig47)
 
-    assert "WARNING: --num-hashes value should be >= 50. Continuing anyway." in c.last_result.err
+    assert "WARNING: num value should be >= 50. Continuing anyway." in c.last_result.err
 
 
 def test_sig_downsample_check_num_bounds_more_than_maximum(runtmp):
@@ -2413,7 +2413,7 @@ def test_sig_downsample_check_num_bounds_more_than_maximum(runtmp):
     with pytest.raises(SourmashCommandFailed):
         c.run_sourmash('sig', 'downsample', '--num', '100000', sig47)
 
-    assert "WARNING: --num-hashes value should be <= 50000. Continuing anyway." in c.last_result.err
+    assert "WARNING: num value should be <= 50000. Continuing anyway." in c.last_result.err
 
 
 @utils.in_tempdir

--- a/tests/test_prefetch.py
+++ b/tests/test_prefetch.py
@@ -402,7 +402,7 @@ def test_prefetch_check_scaled_bounds_negative(runtmp, linear_gather):
         c.run_sourmash('prefetch', '-k', '31', sig47, sig63, sig2, sig47,
                     '--scaled', '-5', linear_gather)
 
-    assert "ERROR: --scaled value must be positive" in str(exc.value)
+    assert "ERROR: scaled value must be positive" in str(exc.value)
 
 
 def test_prefetch_check_scaled_bounds_less_than_minimum(runtmp, linear_gather):
@@ -416,7 +416,7 @@ def test_prefetch_check_scaled_bounds_less_than_minimum(runtmp, linear_gather):
         c.run_sourmash('prefetch', '-k', '31', sig47, sig63, sig2, sig47,
                     '--scaled', '50', linear_gather)
 
-    assert "WARNING: --scaled value should be >= 100. Continuing anyway." in str(exc.value)
+    assert "WARNING: scaled value should be >= 100. Continuing anyway." in str(exc.value)
 
 
 def test_prefetch_check_scaled_bounds_more_than_maximum(runtmp, linear_gather):
@@ -430,7 +430,7 @@ def test_prefetch_check_scaled_bounds_more_than_maximum(runtmp, linear_gather):
         c.run_sourmash('prefetch', '-k', '31', sig47, sig63, sig2, sig47,
                     '--scaled', '1e9', linear_gather)
 
-    assert "WARNING: --scaled value should be <= 1e6. Continuing anyway." in str(exc.value)
+    assert "WARNING: scaled value should be <= 1e6. Continuing anyway." in str(exc.value)
 
 
 def test_prefetch_downsample_scaled(runtmp, linear_gather):

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -4661,34 +4661,6 @@ def test_gather_output_unassigned_with_abundance(runtmp, prefetch_gather, linear
             assert nomatch_mh.hashes[hashval] == abund
 
 
-def test_multigather_output_unassigned_with_abundance(runtmp, prefetch_gather, linear_gather):
-    c = runtmp
-    query = utils.get_test_data('gather-abund/reads-s10x10-s11.sig')
-    against = utils.get_test_data('gather-abund/genome-s10.fa.gz.sig')
-
-    with pytest.raises(SourmashCommandFailed):
-        c.run_sourmash('multigather', query, against, '--output-unassigned',
-                   c.output('unassigned.sig'), linear_gather, prefetch_gather)
-
-    assert os.path.exists(c.output('unassigned.sig'))
-
-    nomatch = sourmash.load_one_signature(c.output('unassigned.sig'))
-    assert nomatch.minhash.track_abundance
-
-    query_ss = sourmash.load_one_signature(query)
-    against_ss = sourmash.load_one_signature(against)
-
-    # unassigned should have nothing that is in the database
-    nomatch_mh = nomatch.minhash
-    for hashval in against_ss.minhash.hashes:
-        assert hashval not in nomatch_mh.hashes
-
-    # unassigned should have abundances from original query, if not in database
-    for hashval, abund in query_ss.minhash.hashes.items():
-        if hashval not in against_ss.minhash.hashes:
-            assert nomatch_mh.hashes[hashval] == abund
-
-
 def test_sbt_categorize():
     with utils.TempDirectory() as location:
         testdata1 = utils.get_test_data('genome-s10.fa.gz.sig')

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -4661,6 +4661,34 @@ def test_gather_output_unassigned_with_abundance(runtmp, prefetch_gather, linear
             assert nomatch_mh.hashes[hashval] == abund
 
 
+def test_multigather_output_unassigned_with_abundance(runtmp, prefetch_gather, linear_gather):
+    c = runtmp
+    query = utils.get_test_data('gather-abund/reads-s10x10-s11.sig')
+    against = utils.get_test_data('gather-abund/genome-s10.fa.gz.sig')
+
+    with pytest.raises(SourmashCommandFailed):
+        c.run_sourmash('multigather', query, against, '--output-unassigned',
+                   c.output('unassigned.sig'), linear_gather, prefetch_gather)
+
+    assert os.path.exists(c.output('unassigned.sig'))
+
+    nomatch = sourmash.load_one_signature(c.output('unassigned.sig'))
+    assert nomatch.minhash.track_abundance
+
+    query_ss = sourmash.load_one_signature(query)
+    against_ss = sourmash.load_one_signature(against)
+
+    # unassigned should have nothing that is in the database
+    nomatch_mh = nomatch.minhash
+    for hashval in against_ss.minhash.hashes:
+        assert hashval not in nomatch_mh.hashes
+
+    # unassigned should have abundances from original query, if not in database
+    for hashval, abund in query_ss.minhash.hashes.items():
+        if hashval not in against_ss.minhash.hashes:
+            assert nomatch_mh.hashes[hashval] == abund
+
+
 def test_sbt_categorize():
     with utils.TempDirectory() as location:
         testdata1 = utils.get_test_data('genome-s10.fa.gz.sig')

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -1791,7 +1791,7 @@ def test_index_check_scaled_bounds_negative(c):
                                             '--dna'],
                                            in_directory=location, fail_ok=True)
 
-        assert "ERROR: --scaled value must be positive" in err
+        assert "ERROR: scaled value must be positive" in err
 
 
 @utils.in_tempdir
@@ -1805,7 +1805,7 @@ def test_index_check_scaled_bounds_less_than_minimum(c):
                                             '--dna'],
                                            in_directory=location, fail_ok=True)
 
-        assert "WARNING: --scaled value should be >= 100. Continuing anyway." in err
+        assert "WARNING: scaled value should be >= 100. Continuing anyway." in err
 
 
 @utils.in_tempdir
@@ -1819,7 +1819,7 @@ def test_index_check_scaled_bounds_more_than_maximum(c):
                                             '--dna'],
                                            in_directory=location, fail_ok=True)
 
-        assert "WARNING: --scaled value should be <= 1e6. Continuing anyway." in err
+        assert "WARNING: scaled value should be <= 1e6. Continuing anyway." in err
 
 
 @utils.in_tempdir
@@ -1998,7 +1998,7 @@ def test_search_check_scaled_bounds_negative():
         status, out, err = utils.runscript('sourmash', cmd.split(' '),
                                             in_directory=location, fail_ok=True)
 
-        assert "ERROR: --scaled value must be positive" in err
+        assert "ERROR: scaled value must be positive" in err
 
 
 def test_search_check_scaled_bounds_less_than_minimum():
@@ -2013,7 +2013,7 @@ def test_search_check_scaled_bounds_less_than_minimum():
         status, out, err = utils.runscript('sourmash', cmd.split(' '),
                                             in_directory=location, fail_ok=True)
 
-        assert "WARNING: --scaled value should be >= 100. Continuing anyway." in err
+        assert "WARNING: scaled value should be >= 100. Continuing anyway." in err
 
 
 def test_search_check_scaled_bounds_more_than_maximum():
@@ -2028,7 +2028,7 @@ def test_search_check_scaled_bounds_more_than_maximum():
         status, out, err = utils.runscript('sourmash', cmd.split(' '),
                                             in_directory=location, fail_ok=True)
 
-        assert "WARNING: --scaled value should be <= 1e6. Continuing anyway." in err
+        assert "WARNING: scaled value should be <= 1e6. Continuing anyway." in err
 
 
 # explanation: you cannot downsample a scaled SBT to match a scaled
@@ -3535,7 +3535,7 @@ def test_multigather_check_scaled_bounds_negative(c):
     with pytest.raises(SourmashCommandFailed) as exc:
         c.run_sourmash(*cmd)
 
-    assert "ERROR: --scaled value must be positive" in str(exc.value)
+    assert "ERROR: scaled value must be positive" in str(exc.value)
 
 
 @utils.in_tempdir
@@ -3556,7 +3556,7 @@ def test_multigather_check_scaled_bounds_less_than_minimum(c):
     with pytest.raises(SourmashCommandFailed) as exc:
         c.run_sourmash(*cmd)
 
-    assert "WARNING: --scaled value should be >= 100. Continuing anyway." in str(exc.value)
+    assert "WARNING: scaled value should be >= 100. Continuing anyway." in str(exc.value)
 
 
 @utils.in_tempdir
@@ -3576,7 +3576,7 @@ def test_multigather_check_scaled_bounds_more_than_maximum(c):
     
     c.run_sourmash(*cmd)
 
-    assert "WARNING: --scaled value should be <= 1e6. Continuing anyway." in c.last_result.err
+    assert "WARNING: scaled value should be <= 1e6. Continuing anyway." in c.last_result.err
 
 
 @utils.in_tempdir
@@ -4113,7 +4113,7 @@ def test_gather_check_scaled_bounds_negative(prefetch_gather, linear_gather):
                                         cmd.split(' '),
                                         in_directory=location, fail_ok=True)
 
-        assert "ERROR: --scaled value must be positive" in err
+        assert "ERROR: scaled value must be positive" in err
 
 
 def test_gather_check_scaled_bounds_less_than_minimum(prefetch_gather, linear_gather):
@@ -4129,7 +4129,7 @@ def test_gather_check_scaled_bounds_less_than_minimum(prefetch_gather, linear_ga
                                            cmd.split(' '),
                                            in_directory=location, fail_ok=True)
 
-        assert "WARNING: --scaled value should be >= 100. Continuing anyway." in err
+        assert "WARNING: scaled value should be >= 100. Continuing anyway." in err
 
 
 def test_gather_check_scaled_bounds_more_than_maximum(prefetch_gather, linear_gather):
@@ -4145,7 +4145,7 @@ def test_gather_check_scaled_bounds_more_than_maximum(prefetch_gather, linear_ga
                                            cmd.split(' '),
                                            in_directory=location, fail_ok=True)
     
-        assert "WARNING: --scaled value should be <= 1e6. Continuing anyway." in err
+        assert "WARNING: scaled value should be <= 1e6. Continuing anyway." in err
 
 
 def test_gather_metagenome_downsample(prefetch_gather, linear_gather):
@@ -4849,7 +4849,7 @@ def test_watch_check_num_bounds_negative(runtmp):
     with pytest.raises(SourmashCommandFailed) as exc:
         c.run_sourmash('watch', '--ksize', '21', '-n', '-5', '--dna', 'zzz', testdata0)
 
-    assert "ERROR: --num-hashes value must be positive" in c.last_result.err
+    assert "ERROR: num value must be positive" in c.last_result.err
 
 
 def test_watch_check_num_bounds_less_than_minimum(runtmp):
@@ -4862,7 +4862,7 @@ def test_watch_check_num_bounds_less_than_minimum(runtmp):
 
     c.run_sourmash('watch', '--ksize', '21', '-n', '25', '--dna', 'zzz', testdata0)
 
-    assert "WARNING: --num-hashes value should be >= 50. Continuing anyway." in c.last_result.err
+    assert "WARNING: num value should be >= 50. Continuing anyway." in c.last_result.err
 
 
 def test_watch_check_num_bounds_more_than_maximum(runtmp):
@@ -4875,7 +4875,7 @@ def test_watch_check_num_bounds_more_than_maximum(runtmp):
 
     c.run_sourmash('watch', '--ksize', '21', '-n', '100000', '--dna', 'zzz', testdata0)
 
-    assert "WARNING: --num-hashes value should be <= 50000. Continuing anyway." in c.last_result.err
+    assert "WARNING: num value should be <= 50000. Continuing anyway." in c.last_result.err
 
 
 @utils.in_tempdir

--- a/tests/test_sourmash_compute.py
+++ b/tests/test_sourmash_compute.py
@@ -49,7 +49,7 @@ def test_do_sourmash_compute_check_num_bounds_negative(runtmp):
     with pytest.raises(SourmashCommandFailed):
         c.run_sourmash('compute', '-k', '31', '--num-hashes', '-5', '-o', sigfile, '--merge', '"name"', testdata1, testdata2, testdata3)
     
-    assert "ERROR: --num-hashes value must be positive" in c.last_result.err
+    assert "ERROR: num value must be positive" in c.last_result.err
 
 
 def test_do_sourmash_compute_check_num_bounds_less_than_minimum(runtmp):
@@ -61,7 +61,7 @@ def test_do_sourmash_compute_check_num_bounds_less_than_minimum(runtmp):
 
     c.run_sourmash('compute', '-k', '31', '--num-hashes', '25', '-o', sigfile, '--merge', '"name"', testdata1, testdata2, testdata3)
     
-    assert "WARNING: --num-hashes value should be >= 50. Continuing anyway." in c.last_result.err
+    assert "WARNING: num value should be >= 50. Continuing anyway." in c.last_result.err
 
 
 def test_do_sourmash_compute_check_num_bounds_more_than_maximum(runtmp):
@@ -73,7 +73,7 @@ def test_do_sourmash_compute_check_num_bounds_more_than_maximum(runtmp):
 
     c.run_sourmash('compute', '-k', '31', '--num-hashes', '100000', '-o', sigfile, '--merge', '"name"', testdata1, testdata2, testdata3)
     
-    assert "WARNING: --num-hashes value should be <= 50000. Continuing anyway." in c.last_result.err
+    assert "WARNING: num value should be <= 50000. Continuing anyway." in c.last_result.err
 
 
 @utils.in_tempdir

--- a/tests/test_sourmash_sketch.py
+++ b/tests/test_sourmash_sketch.py
@@ -39,7 +39,6 @@ def test_do_sourmash_sketch_check_scaled_bounds_negative():
                                            in_directory=location,
                                            fail_ok=True)
 
-        assert status != 0
         assert "ERROR: --scaled value must be positive" in err
 
 
@@ -67,6 +66,45 @@ def test_do_sourmash_sketch_check_scaled_bounds_more_than_maximum():
                                            fail_ok=True)
 
         assert "WARNING: --scaled value should be <= 1e6. Continuing anyway." in err
+
+
+def test_do_sourmash_sketch_check_num_bounds_negative():
+    with utils.TempDirectory() as location:
+        testdata1 = utils.get_test_data('short.fa')
+        status, out, err = utils.runscript('sourmash',
+                                           ['sketch', 'translate',
+                                            '-p', 'num=-5',
+                                            testdata1],
+                                           in_directory=location,
+                                           fail_ok=True)
+
+        assert "ERROR: --num-hashes value must be positive" in err
+
+
+def test_do_sourmash_sketch_check_num_bounds_less_than_minimum():
+    with utils.TempDirectory() as location:
+        testdata1 = utils.get_test_data('short.fa')
+        status, out, err = utils.runscript('sourmash',
+                                           ['sketch', 'translate',
+                                            '-p', 'num=25',
+                                            testdata1],
+                                           in_directory=location,
+                                           fail_ok=True)
+
+        assert "WARNING: --num-hashes value should be >= 50. Continuing anyway." in err
+
+
+def test_do_sourmash_sketch_check_num_bounds_more_than_maximum():
+    with utils.TempDirectory() as location:
+        testdata1 = utils.get_test_data('short.fa')
+        status, out, err = utils.runscript('sourmash',
+                                           ['sketch', 'translate',
+                                            '-p', 'num=100000',
+                                            testdata1],
+                                           in_directory=location,
+                                           fail_ok=True)
+
+        assert "WARNING: --num-hashes value should be <= 50000. Continuing anyway." in err
 
 
 def test_dna_defaults():

--- a/tests/test_sourmash_sketch.py
+++ b/tests/test_sourmash_sketch.py
@@ -39,7 +39,7 @@ def test_do_sourmash_sketch_check_scaled_bounds_negative():
                                            in_directory=location,
                                            fail_ok=True)
 
-        assert "ERROR: --scaled value must be positive" in err
+        assert "ERROR: scaled value must be positive" in err
 
 
 def test_do_sourmash_sketch_check_scaled_bounds_less_than_minimum():
@@ -52,7 +52,7 @@ def test_do_sourmash_sketch_check_scaled_bounds_less_than_minimum():
                                            in_directory=location,
                                            fail_ok=True)
 
-        assert "WARNING: --scaled value should be >= 100. Continuing anyway." in err
+        assert "WARNING: scaled value should be >= 100. Continuing anyway." in err
 
 
 def test_do_sourmash_sketch_check_scaled_bounds_more_than_maximum():
@@ -65,7 +65,7 @@ def test_do_sourmash_sketch_check_scaled_bounds_more_than_maximum():
                                            in_directory=location,
                                            fail_ok=True)
 
-        assert "WARNING: --scaled value should be <= 1e6. Continuing anyway." in err
+        assert "WARNING: scaled value should be <= 1e6. Continuing anyway." in err
 
 
 def test_do_sourmash_sketch_check_num_bounds_negative():
@@ -78,7 +78,7 @@ def test_do_sourmash_sketch_check_num_bounds_negative():
                                            in_directory=location,
                                            fail_ok=True)
 
-        assert "ERROR: --num-hashes value must be positive" in err
+        assert "ERROR: num value must be positive" in err
 
 
 def test_do_sourmash_sketch_check_num_bounds_less_than_minimum():
@@ -91,7 +91,7 @@ def test_do_sourmash_sketch_check_num_bounds_less_than_minimum():
                                            in_directory=location,
                                            fail_ok=True)
 
-        assert "WARNING: --num-hashes value should be >= 50. Continuing anyway." in err
+        assert "WARNING: num value should be >= 50. Continuing anyway." in err
 
 
 def test_do_sourmash_sketch_check_num_bounds_more_than_maximum():
@@ -104,7 +104,7 @@ def test_do_sourmash_sketch_check_num_bounds_more_than_maximum():
                                            in_directory=location,
                                            fail_ok=True)
 
-        assert "WARNING: --num-hashes value should be <= 50000. Continuing anyway." in err
+        assert "WARNING: num value should be <= 50000. Continuing anyway." in err
 
 
 def test_dna_defaults():
@@ -926,7 +926,7 @@ def test_do_sourmash_sketchdna_with_bad_scaled():
 
         assert status != 0
         # assert 'scaled is -1, must be >= 1' in err
-        assert 'ERROR: --scaled value must be positive' in err
+        assert 'ERROR: scaled value must be positive' in err
 
         status, out, err = utils.runscript('sourmash',
                                            ['sketch', 'dna',
@@ -946,7 +946,7 @@ def test_do_sourmash_sketchdna_with_bad_scaled():
 
         assert status == 0
         # assert 'WARNING: scaled value of 1000000000 is nonsensical!?' in err
-        assert 'WARNING: --scaled value should be <= 1e6. Continuing anyway.' in err
+        assert 'WARNING: scaled value should be <= 1e6. Continuing anyway.' in err
 
 
 def test_do_sketch_with_seed():

--- a/tests/test_sourmash_sketch.py
+++ b/tests/test_sourmash_sketch.py
@@ -29,82 +29,42 @@ from sourmash.command_sketch import _signatures_for_sketch_factory
 from sourmash_tst_utils import SourmashCommandFailed
 
 
-def test_do_sourmash_sketch_check_scaled_bounds_negative():
-    with utils.TempDirectory() as location:
-        testdata1 = utils.get_test_data('short.fa')
-        status, out, err = utils.runscript('sourmash',
-                                           ['sketch', 'translate',
-                                            '-p', 'scaled=-5',
-                                            testdata1],
-                                           in_directory=location,
-                                           fail_ok=True)
-
-        assert "ERROR: scaled value must be positive" in err
+def test_do_sourmash_sketch_check_scaled_bounds_negative(runtmp):
+    testdata1 = utils.get_test_data('short.fa')
+    with pytest.raises(SourmashCommandFailed):
+        runtmp.sourmash('sketch', 'translate', '-p', 'scaled=-5', testdata1)
+    assert "ERROR: scaled value must be positive" in runtmp.last_result.err
 
 
-def test_do_sourmash_sketch_check_scaled_bounds_less_than_minimum():
-    with utils.TempDirectory() as location:
-        testdata1 = utils.get_test_data('short.fa')
-        status, out, err = utils.runscript('sourmash',
-                                           ['sketch', 'translate',
-                                            '-p', 'scaled=50',
-                                            testdata1],
-                                           in_directory=location,
-                                           fail_ok=True)
-
-        assert "WARNING: scaled value should be >= 100. Continuing anyway." in err
+def test_do_sourmash_sketch_check_scaled_bounds_less_than_minimum(runtmp):
+    testdata1 = utils.get_test_data('short.fa')
+    runtmp.sourmash('sketch', 'translate', '-p', 'scaled=50', testdata1)
+    assert "WARNING: scaled value should be >= 100. Continuing anyway." in runtmp.last_result.err
 
 
-def test_do_sourmash_sketch_check_scaled_bounds_more_than_maximum():
-    with utils.TempDirectory() as location:
-        testdata1 = utils.get_test_data('short.fa')
-        status, out, err = utils.runscript('sourmash',
-                                           ['sketch', 'translate',
-                                            '-p', 'scaled=1000000000',
-                                            testdata1],
-                                           in_directory=location,
-                                           fail_ok=True)
-
-        assert "WARNING: scaled value should be <= 1e6. Continuing anyway." in err
+def test_do_sourmash_sketch_check_scaled_bounds_more_than_maximum(runtmp):
+    testdata1 = utils.get_test_data('short.fa')
+    runtmp.sourmash('sketch', 'translate', '-p', 'scaled=1000000000', testdata1)
+    assert "WARNING: scaled value should be <= 1e6. Continuing anyway." in runtmp.last_result.err
 
 
-def test_do_sourmash_sketch_check_num_bounds_negative():
-    with utils.TempDirectory() as location:
-        testdata1 = utils.get_test_data('short.fa')
-        status, out, err = utils.runscript('sourmash',
-                                           ['sketch', 'translate',
-                                            '-p', 'num=-5',
-                                            testdata1],
-                                           in_directory=location,
-                                           fail_ok=True)
-
-        assert "ERROR: num value must be positive" in err
+def test_do_sourmash_sketch_check_num_bounds_negative(runtmp):
+    testdata1 = utils.get_test_data('short.fa')
+    with pytest.raises(SourmashCommandFailed):
+        runtmp.sourmash('sketch', 'translate', '-p', 'num=-5', testdata1)
+    assert "ERROR: num value must be positive" in runtmp.last_result.err
 
 
-def test_do_sourmash_sketch_check_num_bounds_less_than_minimum():
-    with utils.TempDirectory() as location:
-        testdata1 = utils.get_test_data('short.fa')
-        status, out, err = utils.runscript('sourmash',
-                                           ['sketch', 'translate',
-                                            '-p', 'num=25',
-                                            testdata1],
-                                           in_directory=location,
-                                           fail_ok=True)
-
-        assert "WARNING: num value should be >= 50. Continuing anyway." in err
+def test_do_sourmash_sketch_check_num_bounds_less_than_minimum(runtmp):
+    testdata1 = utils.get_test_data('short.fa')
+    runtmp.sourmash('sketch', 'translate', '-p', 'num=25', testdata1)
+    assert "WARNING: num value should be >= 50. Continuing anyway." in runtmp.last_result.err
 
 
-def test_do_sourmash_sketch_check_num_bounds_more_than_maximum():
-    with utils.TempDirectory() as location:
-        testdata1 = utils.get_test_data('short.fa')
-        status, out, err = utils.runscript('sourmash',
-                                           ['sketch', 'translate',
-                                            '-p', 'num=100000',
-                                            testdata1],
-                                           in_directory=location,
-                                           fail_ok=True)
-
-        assert "WARNING: num value should be <= 50000. Continuing anyway." in err
+def test_do_sourmash_sketch_check_num_bounds_more_than_maximum(runtmp):
+    testdata1 = utils.get_test_data('short.fa')
+    runtmp.sourmash('sketch', 'translate', '-p', 'num=100000', testdata1)
+    assert "WARNING: num value should be <= 50000. Continuing anyway." in runtmp.last_result.err
 
 
 def test_dna_defaults():

--- a/tests/test_sourmash_sketch.py
+++ b/tests/test_sourmash_sketch.py
@@ -885,7 +885,6 @@ def test_do_sourmash_sketchdna_with_bad_scaled():
                                             fail_ok=True)
 
         assert status != 0
-        # assert 'scaled is -1, must be >= 1' in err
         assert 'ERROR: scaled value must be positive' in err
 
         status, out, err = utils.runscript('sourmash',
@@ -905,7 +904,6 @@ def test_do_sourmash_sketchdna_with_bad_scaled():
                                             in_directory=location)
 
         assert status == 0
-        # assert 'WARNING: scaled value of 1000000000 is nonsensical!?' in err
         assert 'WARNING: scaled value should be <= 1e6. Continuing anyway.' in err
 
 

--- a/tests/test_sourmash_sketch.py
+++ b/tests/test_sourmash_sketch.py
@@ -847,7 +847,8 @@ def test_do_sourmash_sketchdna_with_bad_scaled():
                                             fail_ok=True)
 
         assert status != 0
-        assert 'scaled is -1, must be >= 1' in err
+        # assert 'scaled is -1, must be >= 1' in err
+        assert 'ERROR: --scaled value must be positive' in err
 
         status, out, err = utils.runscript('sourmash',
                                            ['sketch', 'dna',
@@ -866,7 +867,8 @@ def test_do_sourmash_sketchdna_with_bad_scaled():
                                             in_directory=location)
 
         assert status == 0
-        assert 'WARNING: scaled value of 1000000000 is nonsensical!?' in err
+        # assert 'WARNING: scaled value of 1000000000 is nonsensical!?' in err
+        assert 'WARNING: --scaled value should be <= 1e6. Continuing anyway.' in err
 
 
 def test_do_sketch_with_seed():

--- a/tests/test_sourmash_sketch.py
+++ b/tests/test_sourmash_sketch.py
@@ -29,6 +29,46 @@ from sourmash.command_sketch import _signatures_for_sketch_factory
 from sourmash_tst_utils import SourmashCommandFailed
 
 
+def test_do_sourmash_sketch_check_scaled_bounds_negative():
+    with utils.TempDirectory() as location:
+        testdata1 = utils.get_test_data('short.fa')
+        status, out, err = utils.runscript('sourmash',
+                                           ['sketch', 'translate',
+                                            '-p', 'scaled=-5',
+                                            testdata1],
+                                           in_directory=location,
+                                           fail_ok=True)
+
+        assert status != 0
+        assert "ERROR: --scaled value must be positive" in err
+
+
+def test_do_sourmash_sketch_check_scaled_bounds_less_than_minimum():
+    with utils.TempDirectory() as location:
+        testdata1 = utils.get_test_data('short.fa')
+        status, out, err = utils.runscript('sourmash',
+                                           ['sketch', 'translate',
+                                            '-p', 'scaled=50',
+                                            testdata1],
+                                           in_directory=location,
+                                           fail_ok=True)
+
+        assert "WARNING: --scaled value should be >= 100. Continuing anyway." in err
+
+
+def test_do_sourmash_sketch_check_scaled_bounds_more_than_maximum():
+    with utils.TempDirectory() as location:
+        testdata1 = utils.get_test_data('short.fa')
+        status, out, err = utils.runscript('sourmash',
+                                           ['sketch', 'translate',
+                                            '-p', 'scaled=1000000000',
+                                            testdata1],
+                                           in_directory=location,
+                                           fail_ok=True)
+
+        assert "WARNING: --scaled value should be <= 1e6. Continuing anyway." in err
+
+
 def test_dna_defaults():
     factory = _signatures_for_sketch_factory([], 'dna', False)
     params_list = list(factory.get_compute_params())


### PR DESCRIPTION
Fixes #1708

- Add checks for the values of `scaled` and `num` in `sourmash sketch`. 
- num values should always be > 0. if they are unreasonable, say > 50,000 or < 50, we should emit a warning.
- scaled values should always be > 0. if they are unreasonable, say > 1e6 or < 100, we should emit a warning.
- Add tests to check this behavior.