### PR TITLE
[MRG] Changing `sourmash compute` to `sourmash sketch` in test files

### DIFF
--- a/tests/test_cmd_signature.py
+++ b/tests/test_cmd_signature.py
@@ -2584,6 +2584,7 @@ def test_sig_describe_dayhoff(c):
 def test_sig_describe_1_hp(c):
     # get basic info on a signature
     testdata = utils.get_test_data('short.fa')
+    # working on this
     c.run_sourmash('compute', '-k', '21,30',
                    '--dayhoff', '--hp', '--protein',
                    '--dna',

--- a/tests/test_cmd_signature.py
+++ b/tests/test_cmd_signature.py
@@ -2584,11 +2584,11 @@ def test_sig_describe_dayhoff(c):
 def test_sig_describe_1_hp(c):
     # get basic info on a signature
     testdata = utils.get_test_data('short.fa')
-    # working on this
-    c.run_sourmash('compute', '-k', '21,30',
-                   '--dayhoff', '--hp', '--protein',
-                   '--dna',
-                   testdata)
+    # c.run_sourmash('compute', '-k', '21,30',
+    #                '--dayhoff', '--hp', '--protein',
+    #                '--dna',
+    #                testdata)
+    c.run_sourmash('sketch', 'translate', '-p', 'k=21,num=500', '-p', 'k=30,num=500', '--dayhoff', '--hp', testdata)             
     # stdout should be new signature
     computed_sig = os.path.join(c.location, 'short.fa.sig')
     c.run_sourmash('sig', 'describe', computed_sig)
@@ -2910,7 +2910,7 @@ def test_import_mash_csv_to_sig(runtmp):
 
     runtmp.sourmash('sig', 'import', '--csv', testdata1, '-o', 'xxx.sig')
 
-    runtmp.sourmash('compute', '-k', '31', '-n', '970', testdata2)
+    runtmp.sourmash('sketch', 'dna', '-p', 'k=31,num=970', testdata2)
 
     runtmp.sourmash('search', '-k', '31', 'short.fa.sig', 'xxx.sig')
 

--- a/tests/test_cmd_signature.py
+++ b/tests/test_cmd_signature.py
@@ -2584,11 +2584,10 @@ def test_sig_describe_dayhoff(c):
 def test_sig_describe_1_hp(c):
     # get basic info on a signature
     testdata = utils.get_test_data('short.fa')
-    # c.run_sourmash('compute', '-k', '21,30',
-    #                '--dayhoff', '--hp', '--protein',
-    #                '--dna',
-    #                testdata)
-    c.run_sourmash('sketch', 'translate', '-p', 'k=21,num=500', '-p', 'k=30,num=500', '--dayhoff', '--hp', testdata)             
+    c.run_sourmash('compute', '-k', '21,30',
+                   '--dayhoff', '--hp', '--protein',
+                   '--dna',
+                   testdata) 
     # stdout should be new signature
     computed_sig = os.path.join(c.location, 'short.fa.sig')
     c.run_sourmash('sig', 'describe', computed_sig)

--- a/tests/test_cmd_signature.py
+++ b/tests/test_cmd_signature.py
@@ -2587,7 +2587,7 @@ def test_sig_describe_1_hp(c):
     c.run_sourmash('compute', '-k', '21,30',
                    '--dayhoff', '--hp', '--protein',
                    '--dna',
-                   testdata) 
+                   testdata)
     # stdout should be new signature
     computed_sig = os.path.join(c.location, 'short.fa.sig')
     c.run_sourmash('sig', 'describe', computed_sig)

--- a/tests/test_lca.py
+++ b/tests/test_lca.py
@@ -2101,7 +2101,7 @@ def test_compare_csv_real():
 def test_incompat_lca_db_ksize_2(c):
     # test on gather - create a database with ksize of 25
     testdata1 = utils.get_test_data('lca/TARA_ASE_MAG_00031.fa.gz')
-    c.run_sourmash('compute', '-k', '25', '--scaled', '1000', testdata1,
+    c.run_sourmash('sketch', 'dna', '-p', 'k=25,scaled=1000', testdata1,
                    '-o', 'test_db.sig')
     print(c)
 


### PR DESCRIPTION
Fixes #1710

Replace `compute` with `sketch` in:
- `tests/test_cmd_signature.py`
- `tests/test_lca.py`

NOTE: One test: `tests/test_cmd_signature.py::test_sig_describe_1_hp` can't be changed from `compute` to `sketch`.