### PR TITLE
[MRG] CI: Fix build errors with cbindgen

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - 'src/core/**'
       - 'tests/test-data/**'
+      - '.github/workflows/rust.yml'
   schedule:
     - cron: "0 0 * * *" # daily
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -281,11 +281,10 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -e .
 
-      - name: Run tests
+      - name: Check if it builds properly
         uses: actions-rs/cargo@v1
         with:
-          command: test
-          args: --no-fail-fast
+          command: build
 
   check_cbindgen:
     name: "Check if cbindgen runs cleanly for generating the C headers"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -300,7 +300,7 @@ jobs:
       - uses: actions-rs/install@v0.1
         with:
           crate: cbindgen
-          version: 0.19.0
+          version: 0.20.0
           use-tool-cache: true
 
       - run: make include/sourmash.h


### PR DESCRIPTION
cbindgen is currently failing in CI because a nightly feature was removed and `0.20.0` is needed to fix it.