### PR TITLE
[MRG] Replacing `notify` format usage with f-strings instead

### DIFF
--- a/src/sourmash/cli/__init__.py
+++ b/src/sourmash/cli/__init__.py
@@ -52,7 +52,7 @@ class SourmashParser(ArgumentParser):
         if cls._citation_printed:
             return
         from sourmash.logging import notify
-        notify("\n== This is sourmash version {version}. ==", version=sourmash.VERSION)
+        notify(f"\n== This is sourmash version {sourmash.VERSION}. ==")
         notify("== Please cite Brown and Irber (2016), doi:10.21105/joss.00027. ==\n")
         cls._citation_printed = True
 

--- a/src/sourmash/cli/info.py
+++ b/src/sourmash/cli/info.py
@@ -15,16 +15,16 @@ def subparser(subparsers):
 
 def info(verbose=False):
     "Report sourmash version + version of installed dependencies."
-    notify('sourmash version {}', sourmash.VERSION)
-    notify('- loaded from path: {}', os.path.dirname(__file__))
+    notify(f'sourmash version {sourmash.VERSION}')
+    notify(f'- loaded from path: {os.path.dirname(__file__)}')
     notify('')
 
     if verbose:
         notify('khmer version: None (internal Nodegraph)')
         notify('')
 
-        notify('screed version {}', screed.__version__)
-        notify('- loaded from path: {}', os.path.dirname(screed.__file__))
+        notify(f'screed version {screed.__version__}')
+        notify(f'- loaded from path: {os.path.dirname(screed.__file__)}')
 
 
 def main(args):

--- a/src/sourmash/command_sketch.py
+++ b/src/sourmash/command_sketch.py
@@ -172,7 +172,7 @@ def _execute_sketch(args, signatures_factory):
         error('error: sourmash only supports CC0-licensed signatures. sorry!')
         sys.exit(-1)
 
-    notify('computing signatures for files: {}', ", ".join(args.filenames))
+    notify(f'computing signatures for files: {", ".join(args.filenames)}')
 
     if args.merge and not args.output:
         error("ERROR: must specify -o with --merge")
@@ -184,7 +184,7 @@ def _execute_sketch(args, signatures_factory):
 
     # get number of output sigs:
     num_sigs = len(signatures_factory.params_list)
-    notify('Computing a total of {} signature(s).', num_sigs)
+    notify(f'Computing a total of {num_sigs} signature(s).')
 
     if num_sigs == 0:
         error('...nothing to calculate!? Exiting!')

--- a/src/sourmash/commands.py
+++ b/src/sourmash/commands.py
@@ -585,8 +585,7 @@ def categorize(args):
         if loc in already_names:
             continue
 
-        notify('loaded query: {}... (k={}, {})', str(orig_query)[:30],
-               orig_query.minhash.ksize, orig_query.minhash.moltype)
+        notify(f'loaded query: {str(orig_query)[:30]}... (k={orig_query.minhash.ksize}, {orig_query.minhash.moltype})')
 
         if args.ignore_abundance:
             query = orig_query.copy()
@@ -608,15 +607,13 @@ def categorize(args):
         if results:
             results.sort(key=lambda x: -x[0])   # reverse sort on similarity
             best_hit_sim, best_hit_query = results[0]
-            notify('for {}, found: {:.2f} {}', query,
-                                               best_hit_sim,
-                                               best_hit_query)
+            notify(f'for {query}, found: {best_hit_sim:.2f} {best_hit_query}')
             best_hit_query_name = best_hit_query.name
             if csv_w:
                 csv_w.writerow([loc, query, best_hit_query_name,
                                best_hit_sim])
         else:
-            notify('for {}, no match found', query)
+            notify(f'for {query}, no match found')
 
     if csv_fp:
         csv_fp.close()
@@ -634,9 +631,7 @@ def gather(args):
                                                ksize=args.ksize,
                                                select_moltype=moltype,
                                                select_md5=args.md5)
-    notify('loaded query: {}... (k={}, {})', str(query)[:30],
-                                             query.minhash.ksize,
-                                             sourmash_args.get_moltype(query))
+    notify(f'loaded query: {str(query)[:30]}... (k={query.minhash.ksize}, {sourmash_args.get_moltype(query)})')
 
     # verify signature was computed right.
     if not query.minhash.scaled:
@@ -644,8 +639,7 @@ def gather(args):
         sys.exit(-1)
 
     if args.scaled:
-        notify('downsampling query from scaled={} to {}',
-            query.minhash.scaled, int(args.scaled))
+        notify(f'downsampling query from scaled={query.minhash.scaled} to {int(args.scaled)}')
         query.minhash = query.minhash.downsample(scaled=args.scaled)
 
     # empty?

--- a/src/sourmash/commands.py
+++ b/src/sourmash/commands.py
@@ -42,6 +42,7 @@ def compare(args):
     ksizes = set()
     moltypes = set()
     for filename in inp_files:
+        # working on this
         notify("loading '{}'", filename, end='\r')
         loaded = sourmash_args.load_file_as_signatures(filename,
                                                        ksize=args.ksize,

--- a/src/sourmash/commands.py
+++ b/src/sourmash/commands.py
@@ -42,8 +42,7 @@ def compare(args):
     ksizes = set()
     moltypes = set()
     for filename in inp_files:
-        # working on this
-        notify("loading '{}'", filename, end='\r')
+        notify(f"loading '{filename}'", end='\r')
         loaded = sourmash_args.load_file_as_signatures(filename,
                                                        ksize=args.ksize,
                                                        select_moltype=moltype,
@@ -52,7 +51,7 @@ def compare(args):
                                                        progress=progress)
         loaded = list(loaded)
         if not loaded:
-            notify('\nwarning: no signatures loaded at given ksize/molecule type/picklist from {}', filename)
+            notify(f'\nwarning: no signatures loaded at given ksize/molecule type/picklist from {filename}')
         siglist.extend(loaded)
 
         # track ksizes/moltypes
@@ -80,7 +79,7 @@ def compare(args):
         sys.exit(-1)
 
     notify(' '*79, end='\r')
-    notify('loaded {} signatures total.'.format(len(siglist)))
+    notify(f'loaded {format(len(siglist))} signatures total.')
 
     if picklist:
         sourmash_args.report_picklist(args, picklist)
@@ -122,7 +121,7 @@ def compare(args):
         for s in siglist:
             if s.minhash.scaled != max_scaled:
                 if not printed_scaled_msg:
-                    notify('downsampling to scaled value of {}'.format(max_scaled))
+                    notify(f'downsampling to scaled value of {format(max_scaled)}')
                     printed_scaled_msg = True
                 s.minhash = s.minhash.downsample(scaled=max_scaled)
 
@@ -158,11 +157,11 @@ def compare(args):
     # shall we output a matrix?
     if args.output:
         labeloutname = args.output + '.labels.txt'
-        notify('saving labels to: {}', labeloutname)
+        notify(f'saving labels to: {labeloutname}')
         with open(labeloutname, 'w') as fp:
             fp.write("\n".join(labeltext))
 
-        notify('saving comparison matrix to: {}', args.output)
+        notify(f'saving comparison matrix to: {args.output}')
         with open(args.output, 'wb') as fp:
             numpy.save(fp, similarity)
 
@@ -192,13 +191,14 @@ def plot(args):
     D_filename = args.distances
     labelfilename = D_filename + '.labels.txt'
 
-    notify('loading comparison matrix from {}...', D_filename)
+    notify(f'loading comparison matrix from {D_filename}...')
     D = numpy.load(open(D_filename, 'rb'))
+    # not sure how to change this to use f-strings
     notify('...got {} x {} matrix.', *D.shape)
 
     if args.labeltext:
         labelfilename = args.labeltext
-    notify('loading labels from {}', labelfilename)
+    notify(f'loading labels from {labelfilename}')
     labeltext = [ x.strip() for x in open(labelfilename) ]
     if len(labeltext) != D.shape[0]:
         error('{} labels != matrix size, exiting', len(labeltext))
@@ -232,7 +232,7 @@ def plot(args):
         hist_out = os.path.join(args.output_dir, hist_out)
 
     # make the histogram
-    notify('saving histogram of matrix values => {}', hist_out)
+    notify(f'saving histogram of matrix values => {hist_out}')
     fig = pylab.figure(figsize=(8,5))
     pylab.hist(numpy.array(D.flat), bins=100)
     fig.savefig(hist_out)
@@ -259,7 +259,7 @@ def plot(args):
     Y = sch.linkage(D, method='single')
     sch.dendrogram(Y, orientation='right', labels=labeltext)
     fig.savefig(dendrogram_out)
-    notify('wrote dendrogram to: {}', dendrogram_out)
+    notify(f'wrote dendrogram to: {dendrogram_out}')
 
     ### make the dendrogram+matrix:
     (fig, rlabels, rmat) = sourmash_fig.plot_composite_matrix(D, labeltext,
@@ -269,7 +269,7 @@ def plot(args):
                                              vmax=args.vmax,
                                              force=args.force)
     fig.savefig(matrix_out)
-    notify('wrote numpy distance matrix to: {}', matrix_out)
+    notify(f'wrote numpy distance matrix to: {matrix_out}')
 
     if len(labeltext) < 30:
         # for small matrices, print out sample numbering for FYI.
@@ -287,7 +287,7 @@ def plot(args):
                 for j in range(len(rlabels)):
                     y.append('{}'.format(rmat[i][j]))
                 w.writerow(y)
-        notify('Wrote clustered matrix and labels out to {}', args.csv)
+        notify(f'Wrote clustered matrix and labels out to {args.csv}')
 
 
 def import_csv(args):

--- a/src/sourmash/commands.py
+++ b/src/sourmash/commands.py
@@ -314,16 +314,16 @@ def import_csv(args):
             e.add_many(hashes)
             s = sig.SourmashSignature(e, filename=name)
             siglist.append(s)
-            notify('loaded signature: {} {}', name, s.md5sum()[:8])
+            notify(f'loaded signature: {name} {s.md5sum()[:8]}')
 
-        notify('saving {} signatures to JSON', len(siglist))
+        notify(f'saving {len(siglist)} signatures to JSON')
         with FileOutput(args.output, 'wt') as outfp:
             sig.save_signatures(siglist, outfp)
 
 
 def sbt_combine(args):
     inp_files = list(args.sbts)
-    notify('combining {} SBTs', len(inp_files))
+    notify(f'combining {len(inp_files)} SBTs')
 
     tree = load_sbt_index(inp_files.pop(0))
 
@@ -332,7 +332,7 @@ def sbt_combine(args):
         # TODO: check if parameters are the same for both trees!
         tree.combine(new_tree)
 
-    notify('saving SBT under "{}".', args.sbt_name)
+    notify(f'saving SBT under "{args.sbt_name}".')
     tree.save(args.sbt_name)
 
 

--- a/src/sourmash/commands.py
+++ b/src/sourmash/commands.py
@@ -842,8 +842,7 @@ def multigather(args):
         for query in sourmash_args.load_file_as_signatures(queryfile,
                                                        ksize=args.ksize,
                                                        select_moltype=moltype):
-            notify('loaded query: {}... (k={}, {})', str(query)[:30],
-                   query.minhash.ksize, sourmash_args.get_moltype(query))
+            notify(f'loaded query: {str(query)[:30]}... (k={query.minhash.ksize}, {sourmash_args.get_moltype(query)})')
 
             # verify signature was computed right.
             if not query.minhash.scaled:
@@ -851,8 +850,7 @@ def multigather(args):
                 continue
 
             if args.scaled:
-                notify('downsampling query from scaled={} to {}',
-                    query.minhash.scaled, int(args.scaled))
+                notify(f'downsampling query from scaled={query.minhash.scaled} to {int(args.scaled)}')
                 query.minhash = query.minhash.downsample(scaled=args.scaled)
  
             # empty?
@@ -949,7 +947,7 @@ def multigather(args):
             output_matches = output_base + '.matches.sig'
             with open(output_matches, 'wt') as fp:
                 outname = output_matches
-                notify('saving all matches to "{}"', outname)
+                notify(f'saving all matches to "{outname}"')
                 sig.save_signatures([ r.match for r in found ], fp)
 
             output_unassigned = output_base + '.unassigned.sig'
@@ -965,14 +963,14 @@ def multigather(args):
                 elif not remaining_query:
                     notify('no unassigned hashes! not saving.')
                 else:
-                    notify('saving unassigned hashes to "{}"', output_unassigned)
+                    notify(f'saving unassigned hashes to "{output_unassigned}"')
 
                     # CTB: note, multigather does not save abundances
                     sig.save_signatures([ remaining_query ], fp)
             n += 1
 
         # fini, next query!
-    notify('\nconducted gather searches on {} signatures', n)
+    notify(f'\nconducted gather searches on {n} signatures')
 
 
 def watch(args):
@@ -1019,7 +1017,7 @@ def watch(args):
 
     E = MinHash(ksize=ksize, n=args.num_hashes, is_protein=is_protein, dayhoff=dayhoff, hp=hp)
 
-    notify('Computing signature for k={}, {} from stdin', ksize, moltype)
+    notify(f'Computing signature for k={ksize}, {moltype} from stdin')
 
     def do_search():
         results = []
@@ -1042,7 +1040,7 @@ def watch(args):
     for n, record in enumerate(screed_iter):
         # at each watermark, print status & check cardinality
         if n >= watermark:
-            notify('\r... read {} sequences', n, end='')
+            notify(f'\r... read {n} sequences', end='')
             watermark += WATERMARK_SIZE
 
             if do_search():
@@ -1055,7 +1053,7 @@ def watch(args):
 
     results = do_search()
     if not results:
-        notify('... read {} sequences, no matches found.', n)
+        notify(f'... read {n} sequences, no matches found.')
     else:
         results.sort(key=lambda x: -x[0])   # take best
         similarity, found_sig = results[0]
@@ -1063,7 +1061,7 @@ def watch(args):
                similarity)
 
     if args.output:
-        notify('saving signature to {}', args.output)
+        notify(f'saving signature to {args.output}')
         with FileOutput(args.output, 'wt') as fp:
             streamsig = sig.SourmashSignature(E, filename='stdin',
                                               name=args.name)

--- a/src/sourmash/commands.py
+++ b/src/sourmash/commands.py
@@ -1072,7 +1072,7 @@ def migrate(args):
     "Migrate an SBT database to the latest version."
     tree = load_sbt_index(args.sbt_name, print_version_warning=False)
 
-    notify('saving SBT under "{}".', args.sbt_name)
+    notify(f'saving SBT under "{args.sbt_name}".')
     tree.save(args.sbt_name, structure_only=True)
 
 
@@ -1102,9 +1102,7 @@ def prefetch(args):
                                                ksize=args.ksize,
                                                select_moltype=moltype,
                                                select_md5=args.md5)
-    notify('loaded query: {}... (k={}, {})', str(query)[:30],
-                                             query.minhash.ksize,
-                                             sourmash_args.get_moltype(query))
+    notify(f'loaded query: {str(query)[:30]}... (k={query.minhash.ksize}, {sourmash_args.get_moltype(query)})')
 
     # verify signature was computed with scaled.
     if not query.minhash.scaled:
@@ -1145,8 +1143,7 @@ def prefetch(args):
     matches_out = SaveSignaturesToLocation(args.save_matches)
     matches_out.open()
     if args.save_matches:
-        notify("saving all matching database signatures to '{}'",
-               args.save_matches)
+        notify(f"saving all matching database signatures to '{args.save_matches}'")
 
     # iterate over signatures in db one at a time, for each db;
     # find those with sufficient overlap

--- a/src/sourmash/commands.py
+++ b/src/sourmash/commands.py
@@ -354,7 +354,7 @@ def index(args):
 
     if args.scaled:
         args.scaled = int(args.scaled)
-        notify('downsampling signatures to scaled={}', args.scaled)
+        notify(f'downsampling signatures to scaled={args.scaled}')
 
     inp_files = list(args.signatures)
     if args.from_file:
@@ -365,7 +365,7 @@ def index(args):
         error("ERROR: no files to index!? Supply on command line or use --from-file")
         sys.exit(-1)
 
-    notify('loading {} files into SBT', len(inp_files))
+    notify(f'loading {len(inp_files)} files into SBT')
 
     progress = sourmash_args.SignatureLoadingProgress()
 
@@ -429,7 +429,7 @@ def index(args):
     if picklist:
         sourmash_args.report_picklist(args, picklist)
 
-    notify('loaded {} sigs; saving SBT under "{}"', n, args.sbt_name)
+    notify(f'loaded {n} sigs; saving SBT under "{args.sbt_name}"')
     tree.save(args.sbt_name, sparseness=args.sparseness)
     if tree.storage:
         tree.storage.close()
@@ -448,17 +448,14 @@ def search(args):
                                                ksize=args.ksize,
                                                select_moltype=moltype,
                                                select_md5=args.md5)
-    notify('loaded query: {}... (k={}, {})', str(query)[:30],
-                                             query.minhash.ksize,
-                                             sourmash_args.get_moltype(query))
+    notify(f'loaded query: {str(query)[:30]}... (k={query.minhash.ksize}, {sourmash_args.get_moltype(query)})')
 
     if args.scaled:
         if not query.minhash.scaled:
             error('cannot downsample a signature not created with --scaled')
             sys.exit(-1)
         if args.scaled != query.minhash.scaled:
-            notify('downsampling query from scaled={} to {}',
-                query.minhash.scaled, int(args.scaled))
+            notify(f'downsampling query from scaled={query.minhash.scaled} to {int(args.scaled)}')
         query.minhash = query.minhash.downsample(scaled=args.scaled)
 
     # set up the search databases
@@ -537,7 +534,7 @@ def search(args):
 
     # save matching signatures upon request
     if args.save_matches:
-        notify('saving all matched signatures to "{}"', args.save_matches)
+        notify(f'saving all matched signatures to "{args.save_matches}"')
 
         with SaveSignaturesToLocation(args.save_matches) as save_sig:
             for sr in results:

--- a/src/sourmash/compare.py
+++ b/src/sourmash/compare.py
@@ -117,10 +117,7 @@ def get_similarities_at_index(index, ignore_abundance, downsample, siglist):
                    downsample=downsample)
     similarity_list = list(map(func, sig_iterator))
     notify(
-        "comparison for index {} done in {:.5f} seconds",
-        index,
-        time.time() - startt,
-        end='\r')
+        f"comparison for index {index} done in {time.time() - startt:.5f} seconds", end='\r')
     return similarity_list
 
 
@@ -191,16 +188,13 @@ def compare_parallel(siglist, ignore_abundance, downsample, n_jobs):
         for idx_condensed, item in enumerate(l):
             memmap_similarities[index, col_idx + idx_condensed] = memmap_similarities[idx_condensed + col_idx, index] = item
         notify(
-            "Setting similarities matrix for index {} done in {:.5f} seconds",
-            index,
-            time.time() - startt,
-            end='\r')
+            f"Setting similarities matrix for index {index} done in {time.time() - startt:.5f} seconds", end='\r')
     notify("Setting similarities completed")
 
     pool.close()
     pool.join()
 
-    notify("Time taken to compare all pairs parallely is {:.5f} seconds ", time.time() - start_initial)
+    notify(f"Time taken to compare all pairs parallely is {time.time() - start_initial:.5f} seconds ")
     return np.memmap(filename, dtype=np.float64, shape=(length_siglist, length_siglist))
 
 

--- a/src/sourmash/lca/command_classify.py
+++ b/src/sourmash/lca/command_classify.py
@@ -113,7 +113,7 @@ def classify(args):
 
     # set up output
     csvfp = csv.writer(sys.stdout)
-    notify("outputting classifications to {}", args.output)
+    notify(f"outputting classifications to {args.output}")
     with sourmash_args.FileOutputCSV(args.output) as outfp:
         csvfp = csv.writer(outfp)
 
@@ -128,8 +128,7 @@ def classify(args):
             for query_sig in load_file_as_signatures(query_filename,
                                                      ksize=ksize):
                 notify(u'\r\033[K', end=u'')
-                notify('... classifying {} (file {} of {})', query_sig,
-                       n, total_n, end='\r')
+                notify(f'... classifying {query_sig} (file {n} of {total_n})', end='\r')
                 debug('classifying', query_sig)
                 total_count += 1
 
@@ -151,7 +150,7 @@ def classify(args):
                 csvfp.writerow(row)
 
         notify(u'\r\033[K', end=u'')
-        notify('classified {} signatures total', total_count)
+        notify(f'classified {total_count} signatures total')
 
 
 if __name__ == '__main__':

--- a/src/sourmash/lca/command_compare_csv.py
+++ b/src/sourmash/lca/command_compare_csv.py
@@ -19,13 +19,12 @@ def compare_csv(args):
     set_quiet(args.quiet, args.debug)
 
     # first, load classify-style spreadsheet
-    notify('loading classify output from: {}', args.csv1)
+    notify(f'loading classify output from: {args.csv1}')
     assignments0, num_rows0 = load_taxonomy_assignments(args.csv1,
                                                         start_column=3,
                                                         force=args.force)
 
-    notify('loaded {} distinct lineages, {} rows',
-           len(set(assignments0.values())), num_rows0)
+    notify(f'loaded {len(set(assignments0.values()))} distinct lineages, {num_rows0} rows')
     notify('----')
 
     # next, load custom taxonomy spreadsheet
@@ -33,22 +32,21 @@ def compare_csv(args):
     if args.tabs:
         delimiter = '\t'
 
-    notify('loading custom spreadsheet from: {}', args.csv2)
+    notify(f'loading custom spreadsheet from: {args.csv2}')
     assignments, num_rows = load_taxonomy_assignments(args.csv2,
                                                delimiter=delimiter,
                                                start_column=args.start_column,
                                                use_headers=not args.no_headers,
                                                force=args.force)
-    notify('loaded {} distinct lineages, {} rows',
-           len(set(assignments.values())), num_rows)
+    notify(f'loaded {len(set(assignments.values()))} distinct lineages, {num_rows} rows')
 
     # now, compute basic differences:
     missing_1 = set(assignments0.keys()) - set(assignments.keys())
     missing_2 = set(assignments.keys()) - set(assignments0.keys())
     if missing_2:
-        notify('missing {} assignments in classify spreadsheet.', len(missing_2))
+        notify(f'missing {len(missing_2)} assignments in classify spreadsheet.')
     if missing_1:
-        notify('missing {} assignments in custom spreadsheet.', len(missing_1))
+        notify(f'missing {len(missing_1)} assignments in custom spreadsheet.')
     if missing_1 or missing_2:
         notify('(these will not be evaluated any further)')
     else:
@@ -84,16 +82,13 @@ def compare_csv(args):
                     rank = lca[-1].rank
                 incompat_rank[rank] += 1
 
-    notify("{} total assignments, {} differ between spreadsheets.",
-           n_total, n_different)
-    notify("{} are compatible (one lineage is ancestor of another.",
-           n_compat)
-    notify("{} are incompatible (there is a disagreement in the trees).",
-           n_incompat)
+    notify(f"{n_total} total assignments, {n_different} differ between spreadsheets.")
+    notify(f"{n_compat} are compatible (one lineage is ancestor of another.")
+    notify(f"{n_incompat} are incompatible (there is a disagreement in the trees).")
 
     if n_incompat:
         for rank in lca_utils.taxlist():
-            notify('{} incompatible at rank {}', incompat_rank[rank], rank)
+            notify(f'{incompat_rank[rank]} incompatible at rank {rank}')
         
 
 if __name__ == '__main__':

--- a/src/sourmash/lca/command_index.py
+++ b/src/sourmash/lca/command_index.py
@@ -43,8 +43,7 @@ def load_taxonomy_assignments(filename, *, delimiter=',', start_column=2,
                 continue
 
             if column.lower() != value.lower():
-                notify("** assuming column '{}' is {} in spreadsheet",
-                       value, column)
+                notify(f"** assuming column '{value}' is {column} in spreadsheet")
                 n_disagree += 1
                 if n_disagree > 2:
                     error('whoa, too many assumptions. are the headers right?')
@@ -156,8 +155,7 @@ def index(args):
     moltype = sourmash_args.calculate_moltype(args, default='DNA')
     picklist = sourmash_args.load_picklist(args)
 
-    notify('Building LCA database with ksize={} scaled={} moltype={}.',
-           args.ksize, args.scaled, moltype)
+    notify(f'Building LCA database with ksize={args.ksize} scaled={args.scaled} moltype={moltype}.')
 
     # first, load taxonomy spreadsheet
     delimiter = ','
@@ -172,10 +170,8 @@ def index(args):
                                                keep_identifier_versions=args.keep_identifier_versions
     )
 
-    notify('{} distinct identities in spreadsheet out of {} rows.',
-           len(assignments), num_rows)
-    notify('{} distinct lineages in spreadsheet out of {} rows.',
-           len(set(assignments.values())), num_rows)
+    notify(f'{len(assignments)} distinct identities in spreadsheet out of {num_rows} rows.')
+    notify(f'{len(set(assignments.values()))} distinct lineages in spreadsheet out of {num_rows} rows.')
 
     db = LCA_Database(args.ksize, args.scaled, moltype)
 
@@ -207,7 +203,7 @@ def index(args):
                                      yield_all_files=args.force)
         for sig in it:
             notify(u'\r\033[K', end=u'')
-            notify('\r... loading signature {} ({} of {}); skipped {} so far', str(sig)[:30], n, total_n, n_skipped, end='')
+            notify(f'\r... loading signature {str(sig)[:30]} ({n} of {total_n}); skipped {n_skipped} so far', end='')
             debug(filename, sig)
 
             # block off duplicates.
@@ -271,9 +267,9 @@ def index(args):
     # end main add signatures loop
 
     if n_skipped:
-        notify('... loaded {} signatures; skipped {} because of --require-taxonomy.', total_n, n_skipped)
+        notify(f'... loaded {total_n} signatures; skipped {n_skipped} because of --require-taxonomy.')
     else:
-        notify('... loaded {} signatures.', total_n)
+        notify(f'... loaded {total_n} signatures.')
 
     # check -- did we find any signatures?
     if n == 0:
@@ -284,19 +280,16 @@ def index(args):
     if not db.hashval_to_idx:
         error('ERROR: no hash values found - are there any signatures?')
         sys.exit(1)
-    notify('loaded {} hashes at ksize={} scaled={}', len(db.hashval_to_idx),
-           args.ksize, args.scaled)
+    notify(f'loaded {len(db.hashval_to_idx)} hashes at ksize={args.ksize} scaled={args.scaled}')
 
     if picklist:
         sourmash_args.report_picklist(args, picklist)
 
     # summarize:
-    notify('{} assigned lineages out of {} distinct lineages in spreadsheet.',
-           len(record_used_lineages), len(set(assignments.values())))
+    notify(f'{len(record_used_lineages)} assigned lineages out of {len(set(assignments.values()))} distinct lineages in spreadsheet.')
     unused_lineages = set(assignments.values()) - record_used_lineages
 
-    notify('{} identifiers used out of {} distinct identifiers in spreadsheet.',
-           len(record_used_idents), len(set(assignments)))
+    notify(f'{len(record_used_idents)} identifiers used out of {len(set(assignments))} distinct identifiers in spreadsheet.')
 
     assert record_used_idents.issubset(set(assignments))
     unused_identifiers = set(assignments) - record_used_idents
@@ -306,7 +299,7 @@ def index(args):
     if not (db_outfile.endswith('.lca.json') or \
                 db_outfile.endswith('.lca.json.gz')):   # logic -> db.save
         db_outfile += '.lca.json'
-    notify('saving to LCA DB: {}'.format(db_outfile))
+    notify(f'saving to LCA DB: {format(db_outfile)}')
 
     db.save(db_outfile)
 
@@ -315,21 +308,19 @@ def index(args):
     # output a record of stuff if requested/available:
     if record_duplicates or record_no_lineage or record_remnants or unused_lineages:
         if record_duplicates:
-            notify('WARNING: {} duplicate signatures.', len(record_duplicates))
+            notify(f'WARNING: {len(record_duplicates)} duplicate signatures.')
         if record_no_lineage:
-            notify('WARNING: no lineage provided for {} signatures.',
-                   len(record_no_lineage))
+            notify(f'WARNING: no lineage provided for {len(record_no_lineage)} signatures.')
         if record_remnants:
-            notify('WARNING: no signatures for {} spreadsheet rows.',
-                   len(record_remnants))
+            notify(f'WARNING: no signatures for {len(record_remnants)} spreadsheet rows.')
         if unused_lineages:
-            notify('WARNING: {} unused lineages.', len(unused_lineages))
+            notify(f'WARNING: {len(unused_lineages)} unused lineages.')
 
         if unused_identifiers:
-            notify('WARNING: {} unused identifiers.', len(unused_identifiers))
+            notify(f'WARNING: {len(unused_identifiers)} unused identifiers.')
 
         if args.report:
-            notify("generating a report and saving in '{}'", args.report)
+            notify(f"generating a report and saving in '{args.report}'")
             generate_report(record_duplicates, record_no_lineage,
                             record_remnants, unused_lineages,
                             unused_identifiers, args.report)

--- a/src/sourmash/lca/lca_db.py
+++ b/src/sourmash/lca/lca_db.py
@@ -531,7 +531,7 @@ def load_databases(filenames, scaled=None, verbose=True):
     for db_name in filenames:
         if verbose:
             notify(u'\r\033[K', end=u'')
-            notify('... loading database {}'.format(db_name), end='\r')
+            notify(f'... loading database {format(db_name)}', end='\r')
 
         lca_db = LCA_Database.load(db_name)
 
@@ -555,7 +555,6 @@ def load_databases(filenames, scaled=None, verbose=True):
 
     if verbose:
         notify(u'\r\033[K', end=u'')
-        notify('loaded {} LCA databases. ksize={}, scaled={} moltype={}',
-               len(dblist), ksize, scaled, moltype)
+        notify(f'loaded {len(dblist)} LCA databases. ksize={ksize}, scaled={scaled} moltype={moltype}')
 
     return dblist, ksize, scaled

--- a/src/sourmash/sbt.py
+++ b/src/sourmash/sbt.py
@@ -720,7 +720,7 @@ class SBT(Index):
                     manifest_rows.append(row)
 
             if n % 100 == 0:
-                notify("{} of {} nodes saved".format(n+1, total_nodes), end='\r')
+                notify(f"{format(n+1)} of {format(total_nodes)} nodes saved", end='\r')
 
         # now, save the index file and manifests.
         #
@@ -772,7 +772,7 @@ class SBT(Index):
             with open(index_filename, 'wb') as tree_fp:
                 tree_fp.write(tree_data)
 
-        notify("Finished saving SBT index, available at {0}\n".format(index_filename))
+        notify(f"Finished saving SBT index, available at {format(index_filename)}\n")
 
         return path
 

--- a/src/sourmash/sig/__main__.py
+++ b/src/sourmash/sig/__main__.py
@@ -103,17 +103,17 @@ def cat(args):
 
         save_sigs.add(ss)
 
-    notify('loaded {} signatures total.', len(save_sigs))
+    notify(f'loaded {len(save_sigs)} signatures total.')
     if picklist:
         sourmash_args.report_picklist(args, picklist)
 
     save_sigs.close()
 
-    notify('output {} signatures', len(save_sigs))
+    notify(f'output {len(save_sigs)} signatures')
 
     multiple_md5 = [ 1 for cnt in encountered_md5sums.values() if cnt > 1 ]
     if multiple_md5:
-        notify('encountered {} MinHashes multiple times', sum(multiple_md5))
+        notify(f'encountered {sum(multiple_md5)} MinHashes multiple times')
         if args.unique:
             notify('...and removed the duplicates, because --unique was specified.')
 
@@ -133,7 +133,7 @@ def split(args):
 
     if args.outdir:
         if not os.path.exists(args.outdir):
-            notify('Creating --outdir {}', args.outdir)
+            notify(f'Creating --outdir {args.outdir}')
             os.mkdir(args.outdir)
 
     progress = sourmash_args.SignatureLoadingProgress()
@@ -181,12 +181,12 @@ def split(args):
             output_name = os.path.join(args.outdir, output_name)
 
         if os.path.exists(output_name):
-            notify("** overwriting existing file {}".format(output_name))
+            notify(f"** overwriting existing file {format(output_name)}")
 
         # save!
         with open(output_name, 'wt') as outfp:
             sourmash.save_signatures([sig], outfp)
-            notify('writing sig to {}', output_name)
+            notify(f'writing sig to {output_name}')
 
     notify(f'loaded and split {len(progress)} signatures total.')
     if picklist:
@@ -321,8 +321,7 @@ def overlap(args):
     sig2 = sourmash.load_one_signature(args.signature2, ksize=args.ksize,
                                        select_moltype=moltype)
 
-    notify('loaded one signature each from {} and {}', args.signature1,
-           args.signature2)
+    notify(f'loaded one signature each from {args.signature1} and {args.signature2}')
 
     try:
         similarity = sig1.similarity(sig2)
@@ -493,8 +492,7 @@ def intersect(args):
         intersect_mh.add_many(mins)
         intersect_sigobj = sourmash.SourmashSignature(intersect_mh)
     else:
-        notify('loading signature from {}, keeping abundances',
-               args.abundances_from)
+        notify(f'loading signature from {args.abundances_from}, keeping abundances')
         abund_sig = sourmash.load_one_signature(args.abundances_from,
                                                 ksize=args.ksize,
                                                 select_moltype=moltype)
@@ -536,7 +534,7 @@ def subtract(args):
 
     subtract_mins = set(from_mh.hashes)
 
-    notify('loaded signature from {}...', from_sigfile, end='\r')
+    notify(f'loaded signature from {from_sigfile}...', end='\r')
 
     progress = sourmash_args.SignatureLoadingProgress()
 
@@ -555,7 +553,7 @@ def subtract(args):
 
             subtract_mins -= set(sigobj.minhash.hashes)
 
-            notify('loaded and subtracted signatures from {}...', sigfile, end='\r')
+            notify(f'loaded and subtracted signatures from {sigfile}...', end='\r')
 
     if not len(progress):
         error("no signatures to subtract!?")
@@ -654,8 +652,7 @@ def extract(args):
 
     save_sigs.close()
 
-    notify("extracted {} signatures from {} file(s)", len(save_sigs),
-           len(args.signatures))
+    notify(f"extracted {len(save_sigs)} signatures from {len(args.signatures)} file(s)")
 
     if picklist:
         sourmash_args.report_picklist(args, picklist)
@@ -689,8 +686,7 @@ def filter(args):
         for ss in siglist:
             mh = ss.minhash
             if not mh.track_abundance:
-                notify('ignoring signature {} - track_abundance not set.',
-                       ss)
+                notify(f'ignoring signature {ss} - track_abundance not set.')
                 continue
 
             abunds = mh.hashes
@@ -711,8 +707,7 @@ def filter(args):
     save_sigs.close()
 
     notify(f"loaded {len(progress)} total that matched ksize & molecule type")
-    notify("extracted {} signatures from {} file(s)", len(save_sigs),
-           len(args.signatures))
+    notify(f"extracted {len(save_sigs)} signatures from {len(args.signatures)} file(s)")
 
 
 def flatten(args):
@@ -752,8 +747,7 @@ def flatten(args):
     save_sigs.close()
 
     notify(f"loaded {len(progress)} total that matched ksize & molecule type")
-    notify("extracted {} signatures from {} file(s)", len(save_sigs),
-           len(args.signatures))
+    notify(f"extracted {len(save_sigs)} signatures from {len(args.signatures)} file(s)")
     if picklist:
         sourmash_args.report_picklist(args, picklist)
 
@@ -861,7 +855,7 @@ def sig_import(args):
                     e.add_many(hashes)
                     s = sourmash.SourmashSignature(e, filename=name)
                     siglist.append(s)
-                    notify('loaded signature: {} {}', name, s.md5sum()[:8])
+                    notify(f'loaded signature: {name} {s.md5sum()[:8]}')
     else:
         for filename in args.filenames:
             with open(filename) as fp:
@@ -883,7 +877,7 @@ def sig_import(args):
             s = sourmash.SourmashSignature(mh, filename=filename)
             siglist.append(s)
 
-    notify('saving {} signatures to JSON', len(siglist))
+    notify(f'saving {len(siglist)} signatures to JSON')
     with FileOutput(args.output, 'wt') as fp:
         sourmash.save_signatures(siglist, fp)
 
@@ -914,7 +908,7 @@ def export(args):
 
     with FileOutput(args.output, 'wt') as fp:
         print(json.dumps(x), file=fp)
-    notify("exported signature {} ({})", query, query.md5sum()[:8])
+    notify(f"exported signature {query} ({query.md5sum()[:8]})")
 
 
 def kmers(args):

--- a/src/sourmash/sourmash_args.py
+++ b/src/sourmash/sourmash_args.py
@@ -622,11 +622,11 @@ def load_many_signatures(locations, progress, *, yield_all_files=False,
         except ValueError as exc:
             # trap expected errors, and either power through or display + exit.
             if force:
-                notify("ERROR: {}", str(exc))
+                notify(f"ERROR: {str(exc)}")
                 notify("(continuing)")
                 continue
             else:
-                notify("ERROR: {}", str(exc))
+                notify(f"ERROR: {str(exc)}")
                 sys.exit(-1)
         except KeyboardInterrupt:
             notify("Received CTRL-C - exiting.")
@@ -698,8 +698,7 @@ class SaveSignatures_Directory(_BaseSaveSignaturesToLocation):
         except FileExistsError:
             pass
         except:
-            notify("ERROR: cannot create signature output directory '{}'",
-                   self.location)
+            notify(f"ERROR: cannot create signature output directory '{self.location}'")
             sys.exit(-1)
 
     def add(self, ss):


### PR DESCRIPTION
Partly fixes #1409

Done:
Throughout the Python code base, replace calls like,
```
notify("file {} is bad", filename)
```
(which uses string.format underneath)
with f-strings, e.g.
```
notify(f"file {filename} is bad")
```