### PR TITLE
update coverage from 10x to 20x per description in documentation page

### DIFF
--- a/doc/classifying-signatures.md
+++ b/doc/classifying-signatures.md
@@ -238,7 +238,7 @@ data set abundances of 2x each, and a third read data set with 20x.
 First, we make some synthetic data sets:
 
 * r1.fa with 2x coverage of genome s10
-* r2.fa with 10x coverage of genome s10.
+* r2.fa with 20x coverage of genome s10.
 * r3.fa with 2x coverage of genome s11.
 
 then we make signature s10-s11 with r1 and r3, i.e. 1:1 abundance, and

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -4472,7 +4472,7 @@ def test_gather_abund_1_1(runtmp, linear_gather, prefetch_gather):
     c = runtmp
     #
     # make r1.fa with 2x coverage of genome s10
-    # make r2.fa with 10x coverage of genome s10.
+    # make r2.fa with 20x coverage of genome s10.
     # make r3.fa with 2x coverage of genome s11.
     #
     # nullgraph/make-reads.py -S 1 -r 200 -C 2 tests/test-data/genome-s10.fa.gz > r1.fa


### PR DESCRIPTION
Data description states:
```
Below is a discussion of a synthetic set of test cases using three randomly generated (fake) genomes of the same size, with two even read data set abundances of 2x each, and a third read data set with 20x.
```

But then says:
```
First, we make some synthetic data sets:

    r1.fa with 2x coverage of genome s10
    r2.fa with 10x coverage of genome s10.
    r3.fa with 2x coverage of genome s11.
```

I think s10 should be 20x coverage, so I changed it to that. 

@bluegenes @ctb ready for review & merge