### PR TITLE
[MRG] update release note docs with -m for `git tag`

### DIFF
--- a/doc/release.md
+++ b/doc/release.md
@@ -45,7 +45,7 @@ rc=rc1
 ```
 and then tag the release candidate with the new version number prefixed by the letter 'v':
 ```
-git tag -a v${new_version}${rc}
+git tag -a v${new_version}${rc} -m "${new_version} release candidate ${rc}"
 git push --tags origin
 ```
 


### PR DESCRIPTION
Fixes https://github.com/sourmash-bio/sourmash/issues/1753

This PR updates the instructions for the git tag command when doing release candidates so that it is friendlier to copy-paste.