### PR TITLE
[MRG] CI: Update cibuildwheel usage

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,5 @@
+[target.x86_64-unknown-linux-musl]
+rustflags = ["-C", "target-feature=-crt-static"]
+
+[target.aarch64-unknown-linux-musl]
+rustflags = ["-C", "target-feature=-crt-static"]

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -54,10 +54,6 @@ jobs:
         with:
           python-version: '3.9'
 
-      - name: Install cibuildwheel
-        run: |
-          python -m pip install cibuildwheel==1.8.0
-
       - name: Set up QEMU
         if: runner.os == 'Linux'
         uses: docker/setup-qemu-action@v1
@@ -65,6 +61,7 @@ jobs:
           platforms: all
 
       - name: Build wheels
+        uses: pypa/cibuildwheel@v2.2.0
         env:
           CIBW_BUILD: "cp39-*"
           CIBW_SKIP: "*-win32 *-manylinux_i686"
@@ -74,13 +71,10 @@ jobs:
           CIBW_BUILD_VERBOSITY: 3
           CIBW_ARCHS_LINUX: ${{ matrix.arch }}
           CIBW_ARCHS_MACOS: ${{ matrix.arch }}
-        run: |
-          python -m cibuildwheel --output-dir dist
-          ls -lR ./dist
 
       - uses: actions/upload-artifact@v2
         with:
-          path: './dist/sourmash*.whl'
+          path: './wheelhouse/sourmash*.whl'
 
   release:
     name: Publish wheels

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -64,7 +64,7 @@ jobs:
         uses: pypa/cibuildwheel@v2.2.0
         env:
           CIBW_BUILD: "cp39-*"
-          CIBW_SKIP: "*-win32 *-manylinux_i686"
+          CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux_ppc64le *-musllinux_s390x"
           CIBW_BEFORE_BUILD: 'source .ci/install_cargo.sh'
           CIBW_ENVIRONMENT: 'PATH="$HOME/.cargo/bin:$PATH"'
           CIBW_ENVIRONMENT_MACOS: ${{ matrix.macos_target }}


### PR DESCRIPTION
We are running a fairly old version of cibuildwheel (`1.8.0`, newest is `2.2.0`), so let's try to benefit from all the good features in the new one (like `musllinux` wheel support)