### PR TITLE
[MRG] Clippy fixes for 1.57 beta

### DIFF
--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -61,7 +61,7 @@ jobs:
           platforms: all
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.2.0
+        uses: pypa/cibuildwheel@v2.2.2
         env:
           CIBW_BUILD: "cp39-*"
           CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux_ppc64le *-musllinux_s390x"

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://github.com/nmattia/niv",
         "owner": "nmattia",
         "repo": "niv",
-        "rev": "1819632b5823e0527da28ad82fecd6be5136c1e9",
-        "sha256": "08jz17756qchq0zrqmapcm33nr4ms9f630mycc06i6zkfwl5yh5i",
+        "rev": "65a61b147f307d24bfd0a5cd56ce7d7b7cc61d2e",
+        "sha256": "17mirpsx5wyw262fpsd6n6m47jcgw8k2bwcp1iwdnrlzy4dhcgqh",
         "type": "tarball",
-        "url": "https://github.com/nmattia/niv/archive/1819632b5823e0527da28ad82fecd6be5136c1e9.tar.gz",
+        "url": "https://github.com/nmattia/niv/archive/65a61b147f307d24bfd0a5cd56ce7d7b7cc61d2e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "84aa23742f6c72501f9cc209f29c438766f5352d",
-        "sha256": "0h7xl6q0yjrbl9vm3h6lkxw692nm8bg3wy65gm95a2mivhrdjpxp",
+        "rev": "a3f85aedb1d66266b82d9f8c0a80457b4db5850c",
+        "sha256": "1qq0d8nc3c16xxrx8awilz57kq6k23nzpq6782h7701zi7gikcax",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/84aa23742f6c72501f9cc209f29c438766f5352d.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/a3f85aedb1d66266b82d9f8c0a80457b4db5850c.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "rust-overlay": {
@@ -29,10 +29,10 @@
         "homepage": null,
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "7368784b67f963508b67064ee758537b7c8e40c8",
-        "sha256": "1sr0lsk5m6c0dqp3429c0fj0picrvsaw1hjn6nd83pzxm54g7fcr",
+        "rev": "f977b1f50d54e80b8efdc516b62a4e3c7987e012",
+        "sha256": "1r9zvqaka10a6xz2sfqaswmz9pj57025aa67a716zf0qiqagg3gb",
         "type": "tarball",
-        "url": "https://github.com/oxalica/rust-overlay/archive/7368784b67f963508b67064ee758537b7c8e40c8.tar.gz",
+        "url": "https://github.com/oxalica/rust-overlay/archive/f977b1f50d54e80b8efdc516b62a4e3c7987e012.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/src/core/benches/compute.rs
+++ b/src/core/benches/compute.rs
@@ -25,7 +25,7 @@ fn add_sequence(c: &mut Criterion) {
     let data_errors: Vec<u8> = data
         .iter()
         .enumerate()
-        .map(|(i, x)| if i % 89 == 1 { 'N' as u8 } else { *x })
+        .map(|(i, x)| if i % 89 == 1 { b'N' } else { *x })
         .collect();
 
     let mut group = c.benchmark_group("add_sequence");

--- a/src/core/src/index/bigsi.rs
+++ b/src/core/src/index/bigsi.rs
@@ -201,7 +201,7 @@ mod test {
         assert_eq!(results_sbt.len(), 1);
 
         let data = leaf.data.get().unwrap();
-        let results_bigsi = bigsi.search(&data, 0.5, false).unwrap();
+        let results_bigsi = bigsi.search(data, 0.5, false).unwrap();
         assert_eq!(results_bigsi.len(), 1);
 
         assert_eq!(results_sbt.len(), results_bigsi.len());
@@ -210,7 +210,7 @@ mod test {
         assert_eq!(results_sbt.len(), 2);
 
         let data = leaf.data.get().unwrap();
-        let results_bigsi = bigsi.search(&data, 0.1, false).unwrap();
+        let results_bigsi = bigsi.search(data, 0.1, false).unwrap();
         assert_eq!(results_bigsi.len(), 2);
 
         assert_eq!(results_sbt.len(), results_bigsi.len());

--- a/src/core/src/index/sbt/mod.rs
+++ b/src/core/src/index/sbt/mod.rs
@@ -475,7 +475,7 @@ where
                 // Case 2: parent is a node and has an empty child spot available
                 // (if there isn't an empty spot, it was already covered by case 1)
                 Entry::Occupied(mut pnode) => {
-                    dataset.update(&mut pnode.get_mut())?;
+                    dataset.update(pnode.get_mut())?;
                     self.leaves.entry(pos).or_insert_with(|| dataset.into());
                     final_pos = pos;
                 }
@@ -500,7 +500,7 @@ where
                 //TODO: use children for this node to update, instead of dragging
                 // dataset up to the root? It would be more generic, but this
                 // works for minhash, draff signatures and nodegraphs...
-                data.update(&mut pnode.get_mut())?;
+                data.update(pnode.get_mut())?;
             }
             parent_pos = ppos;
         }

--- a/src/core/tests/minhash.rs
+++ b/src/core/tests/minhash.rs
@@ -729,8 +729,8 @@ fn seq_to_hashes(seq in "ACGTGTAGCTAGACACTGACTGACTGAC") {
         }
     }
 
-    mh.mins().sort();
-    hashes.sort();
+    mh.mins().sort_unstable();
+    hashes.sort_unstable();
     assert_eq!(mh.mins(), hashes);
 
 }
@@ -752,8 +752,8 @@ fn seq_to_hashes_2(seq in "QRMTHINK") {
         }
     }
 
-    mh.mins().sort();
-    hashes.sort();
+    mh.mins().sort_unstable();
+    hashes.sort_unstable();
     assert_eq!(mh.mins(), hashes);
 
 }


### PR DESCRIPTION
There are two erros in clippy for `latest` due to incoming changes in `clippy` (currently in 1.57 beta, to be stabilized in a few weeks). This PR fixes them and apply `cargo clippy --fix` (which landed with `1.56`), an automated way of applying fixes with clippy.

(Also updates nix packaging, so `1.56` is the new stable version when developing)