### PR TITLE
[MRG] set `pickfile` attribute on `SourmashPicklist.load(...)`

### DIFF
--- a/src/sourmash/picklist.py
+++ b/src/sourmash/picklist.py
@@ -172,6 +172,7 @@ class SignaturePicklist:
                 else:
                     self.add(col)
 
+        self.pickfile = pickfile
         return n_empty_val, dup_vals
 
     def add(self, value):


### PR DESCRIPTION
The `load` method on `SourmashPicklist` did not set the `pickfile` attribute, while the class method `from_picklist_args(...)` did set it. This PR fixes `load` to be consistent with `from_picklist_args`.

Fixes https://github.com/sourmash-bio/sourmash/issues/1773