### PR TITLE
[MRG] check to make sure that .zip files exist before trying to load from them.

### DIFF
--- a/src/sourmash/index.py
+++ b/src/sourmash/index.py
@@ -576,8 +576,11 @@ class ZipFileLinearIndex(Index):
     def load(cls, location, traverse_yield_all=False, use_manifest=True):
         "Class method to load a zipfile."
         from .sbt_storage import ZipStorage
+
+        # we can only load from existing zipfiles in this method.
         if not os.path.exists(location):
             raise FileNotFoundError(location)
+
         storage = ZipStorage(location)
         return cls(storage, traverse_yield_all=traverse_yield_all,
                    use_manifest=use_manifest)

--- a/src/sourmash/index.py
+++ b/src/sourmash/index.py
@@ -576,6 +576,8 @@ class ZipFileLinearIndex(Index):
     def load(cls, location, traverse_yield_all=False, use_manifest=True):
         "Class method to load a zipfile."
         from .sbt_storage import ZipStorage
+        if not os.path.exists(location):
+            raise FileNotFoundError(location)
         storage = ZipStorage(location)
         return cls(storage, traverse_yield_all=traverse_yield_all,
                    use_manifest=use_manifest)

--- a/src/sourmash/sourmash_args.py
+++ b/src/sourmash/sourmash_args.py
@@ -325,8 +325,14 @@ def _load_zipfile(filename, **kwargs):
     db = None
     if filename.endswith('.zip'):
         traverse_yield_all = kwargs['traverse_yield_all']
-        db = ZipFileLinearIndex.load(filename,
-                                     traverse_yield_all=traverse_yield_all)
+        try:
+            db = ZipFileLinearIndex.load(filename,
+                                         traverse_yield_all=traverse_yield_all)
+        except FileNotFoundError as exc:
+            # turn this into a ValueError => proper exception handling by
+            # _load_database.
+            raise ValueError(exc)
+
     return db
 
 

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -2241,7 +2241,7 @@ def test_lazy_loaded_index_1(runtmp):
     assert len(db) == 2
 
     # ...but we should get an error when we call signatures.
-    with pytest.raises(FileNotFoundError):
+    with pytest.raises(ValueError):
         list(db.signatures())
 
     # but put it back, and all is forgiven. yay!

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -717,6 +717,18 @@ def test_index_same_md5sum_sbt_zipstorage(c):
     assert len([f for f in zout.namelist() if f.startswith(".sbt.zzz/")]) == 5
 
 
+def test_zipfile_does_not_exist(runtmp):
+    with pytest.raises(SourmashCommandFailed) as exc:
+        runtmp.sourmash('sig', 'describe', 'no-exist.zip')
+
+    # old behavior, pre PR #1777
+    assert 'FileNotFoundError: SOURMASH-MANIFEST.csv' not in str(exc)
+    assert not os.path.exists(runtmp.output('no-exist.zip'))
+
+    # correct behavior
+    assert "ERROR: Error while reading signatures from 'no-exist.zip'." in str(exc)
+
+
 @utils.in_thisdir
 def test_zipfile_protein_command_search(c):
     # test command-line search/gather of zipfile with protein sigs


### PR DESCRIPTION
This PR changes `ZipStorage.load(...)` to check to see if a zipfile exists before trying to open it. In turn, this means that an empty zipfile will no longer be _created_ by `ZipStorage` :)

Fixes https://github.com/sourmash-bio/sourmash/issues/1774

- [x] needs a new test for non-existent zip file!
