### PR TITLE
[MRG] fix `sourmash search --containment` with two abund signatures

### DIFF
--- a/src/sourmash/commands.py
+++ b/src/sourmash/commands.py
@@ -473,12 +473,18 @@ def search(args):
         error('Nothing found to search!')
         sys.exit(-1)
 
-    # forcibly ignore abundances if query has no abundances
-    if not query.minhash.track_abundance:
-        args.ignore_abundance = True
-    else:
+    # handle signatures with abundance
+    if query.minhash.track_abundance:
         if args.ignore_abundance:
+            # abund sketch + ignore abundance => flatten sketch.
             query.minhash = query.minhash.flatten()
+        elif args.containment or args.max_containment:
+            # abund sketch + keep abundance => no containment searches
+            notify("ERROR: cannot do containment searches on an abund signature; maybe specify --ignore-abundance?")
+            sys.exit(-1)
+    else:
+        # forcibly ignore abundances if query has no abundances
+        args.ignore_abundance = True
 
     # do the actual search
     if query.minhash.track_abundance:

--- a/src/sourmash/search.py
+++ b/src/sourmash/search.py
@@ -211,6 +211,9 @@ def search_databases_with_abund_query(query, databases, **kwargs):
     results = []
     found_md5 = set()
 
+    assert not 'do_containment' in kwargs
+    assert not 'do_max_containment' in kwargs
+
     for db in databases:
         search_iter = db.search_abund(query, **kwargs)
         for (score, match, filename) in search_iter:

--- a/src/sourmash/search.py
+++ b/src/sourmash/search.py
@@ -211,8 +211,8 @@ def search_databases_with_abund_query(query, databases, **kwargs):
     results = []
     found_md5 = set()
 
-    assert not 'do_containment' in kwargs
-    assert not 'do_max_containment' in kwargs
+    if kwargs.get('do_containment') or kwargs.get('do_max_containment'):
+        raise TypeError("containment searches cannot be done with abund sketches")
 
     for db in databases:
         search_iter = db.search_abund(query, **kwargs)

--- a/tests/test_minhash.py
+++ b/tests/test_minhash.py
@@ -2604,20 +2604,10 @@ def test_translate_dayhoff_hashes_2():
         assert _hash_fwd_only(mh_translate, kmer) == h
 
 
-def test_containment():
-    mh1 = MinHash(0, 21, scaled=1, track_abundance=False)
-    mh2 = MinHash(0, 21, scaled=1, track_abundance=False)
-
-    mh1.add_many((1, 2, 3, 4))
-    mh2.add_many((1, 5))
-
-    assert mh1.contained_by(mh2) == 1/4
-    assert mh2.contained_by(mh1) == 1/2
-
-
-def test_containment_with_abund():
-    mh1 = MinHash(0, 21, scaled=1, track_abundance=True)
-    mh2 = MinHash(0, 21, scaled=1, track_abundance=True)
+def test_containment(track_abundance):
+    "basic containment test. note: containment w/abundance ignores abundance."
+    mh1 = MinHash(0, 21, scaled=1, track_abundance=track_abundance)
+    mh2 = MinHash(0, 21, scaled=1, track_abundance=track_abundance)
 
     mh1.add_many((1, 2, 3, 4))
     mh1.add_many((1, 2))
@@ -2625,18 +2615,5 @@ def test_containment_with_abund():
     mh2.add_many((1, 5))
     mh2.add_many((1, 5))
 
-    print(mh1.hashes)
-
     assert mh1.contained_by(mh2) == 1/4
     assert mh2.contained_by(mh1) == 1/2
-
-    import sourmash
-    x = sourmash.SourmashSignature(mh1, name='a')
-    y = sourmash.SourmashSignature(mh2, name='b')
-
-    with open('a.sig', 'wt') as fp:
-        sourmash.save_signatures([x], fp)
-    with open('b.sig', 'wt') as fp:
-        sourmash.save_signatures([y], fp)
-
-    assert 0

--- a/tests/test_minhash.py
+++ b/tests/test_minhash.py
@@ -2602,3 +2602,41 @@ def test_translate_dayhoff_hashes_2():
 
         assert kmer == k
         assert _hash_fwd_only(mh_translate, kmer) == h
+
+
+def test_containment():
+    mh1 = MinHash(0, 21, scaled=1, track_abundance=False)
+    mh2 = MinHash(0, 21, scaled=1, track_abundance=False)
+
+    mh1.add_many((1, 2, 3, 4))
+    mh2.add_many((1, 5))
+
+    assert mh1.contained_by(mh2) == 1/4
+    assert mh2.contained_by(mh1) == 1/2
+
+
+def test_containment_with_abund():
+    mh1 = MinHash(0, 21, scaled=1, track_abundance=True)
+    mh2 = MinHash(0, 21, scaled=1, track_abundance=True)
+
+    mh1.add_many((1, 2, 3, 4))
+    mh1.add_many((1, 2))
+    mh2.add_many((1, 5))
+    mh2.add_many((1, 5))
+    mh2.add_many((1, 5))
+
+    print(mh1.hashes)
+
+    assert mh1.contained_by(mh2) == 1/4
+    assert mh2.contained_by(mh1) == 1/2
+
+    import sourmash
+    x = sourmash.SourmashSignature(mh1, name='a')
+    y = sourmash.SourmashSignature(mh2, name='b')
+
+    with open('a.sig', 'wt') as fp:
+        sourmash.save_signatures([x], fp)
+    with open('b.sig', 'wt') as fp:
+        sourmash.save_signatures([y], fp)
+
+    assert 0

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -233,3 +233,18 @@ def test_index_gather_passthru():
     idx = FakeIndex(validate_kwarg_passthru)
 
     idx.search(query, threshold=0.0, this_kw_arg=5)
+
+
+def test_search_with_abund_query():
+    mh = MinHash(n=0, ksize=31, scaled=1, track_abundance=True)
+    query = SourmashSignature(mh)
+
+    with pytest.raises(TypeError):
+        search.search_databases_with_abund_query(query, [],
+                                                 threshold=0,
+                                                 do_containment=True)
+
+    with pytest.raises(TypeError):
+        search.search_databases_with_abund_query(query, [],
+                                                 threshold=0,
+                                                 do_max_containment=True)

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -1348,7 +1348,7 @@ def test_search_containment_abund(runtmp):
     with open(runtmp.output('b.sig'), 'wt') as fp:
         sourmash.save_signatures([y], fp)
 
-    # run sourmash search --containent
+    # run sourmash search --containment
     with pytest.raises(SourmashCommandFailed) as exc:
         runtmp.sourmash('search', 'a.sig', 'b.sig', '-o', 'xxx.csv',
                         '--containment')

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -1325,6 +1325,44 @@ def test_search_containment(runtmp):
     assert '95.6%' in runtmp.last_result.out
 
 
+def test_search_containment_abund(runtmp):
+    "Construct some signatures with abund, make sure that containment flattens"
+
+    # build minhashes
+    mh1 = MinHash(0, 21, scaled=1, track_abundance=True)
+    mh2 = MinHash(0, 21, scaled=1, track_abundance=True)
+
+    mh1.add_many((1, 2, 3, 4))
+    mh1.add_many((1, 2))
+    mh2.add_many((1, 5))
+    mh2.add_many((1, 5))
+    mh2.add_many((1, 5))
+
+    # build signatures
+    x = sourmash.SourmashSignature(mh1, name='a')
+    y = sourmash.SourmashSignature(mh2, name='b')
+
+    # save!
+    with open(runtmp.output('a.sig'), 'wt') as fp:
+        sourmash.save_signatures([x], fp)
+    with open(runtmp.output('b.sig'), 'wt') as fp:
+        sourmash.save_signatures([y], fp)
+
+    # run sourmash search
+    runtmp.sourmash('search', 'a.sig', 'b.sig', '-o', 'xxx.csv', '--containment')
+
+    # check results
+    with open(runtmp.output('xxx.csv'), 'rt') as fp:
+        r = csv.DictReader(fp)
+        row = next(r)
+        similarity = row['similarity']
+        print(f'search output: similarity is {similarity}')
+    print(mh1.contained_by(mh2))
+
+    assert float(similarity) == mh1.contained_by(mh2)
+    assert float(similarity) == 0.25
+
+
 def test_search_containment_sbt(runtmp):
     # search with --containment in an SBT
     testdata1 = utils.get_test_data('short.fa')


### PR DESCRIPTION
When query and subject signatures are both created with `track_abundance=True`, `sourmash search --containment silently returns similarity and not containment. This PR fixes that issue by:

* adding a CLI error message when `--containment/--max-containment` is used without `--ignore-abundance`
* checking for `containment` or `max_containment` flags in `search_databases_with_abund_query`
* adding tests to check the behavior.

- [x] add appropriate checking in `search_databases_with_abund_query`
- [x] complain when abund signature is used for `--containment` and `--max-containment` in `commands.py::search(...)`
- [x] add test for `search_databases_with_abund_query(...)` in `search.py`
- [x] add test for proper command line behavior

Fixes https://github.com/sourmash-bio/sourmash/issues/1779
