### PR TITLE
[EXP] add an Index class that loads directly from a screed-loadable file

### DIFF
--- a/src/sourmash/screed_index.py
+++ b/src/sourmash/screed_index.py
@@ -1,0 +1,79 @@
+#! /usr/bin/env python
+import screed
+import sourmash
+from sourmash.index import Index
+
+
+class ScreedIndex(Index):
+    def __init__(self, filename, selection_dict=None):
+        self.filename = filename
+        if selection_dict:
+            self.selection_dict = selection_dict
+        else:
+            self.selection_dict = dict(abund=False)
+
+    def __len__(self):
+        return 1
+
+    @property
+    def location(self):
+        return self.filename
+
+    def signatures(self):
+        sd = self.selection_dict
+        assert 'ksize' in sd
+        assert 'moltype' in sd
+        assert 'scaled' in sd or 'num' in sd
+        assert 'abund' in sd
+
+        if sd.get('containment'):
+            assert sd.get('num')
+
+        ksize = sd['ksize']
+        moltype = sd['moltype']
+        scaled = sd.get('scaled', 0)
+        num = sd.get('num', 0)
+        track_abundance = sd.get('abund', False)
+
+        is_protein = False
+        dayhoff = False
+        hp = False
+        if moltype == 'DNA':
+            pass
+        elif moltype == 'protein':
+            is_protein=True
+        elif moltype == 'dayhoff':
+            dayhoff = True
+        elif moltype == 'hp':
+            hp = True
+
+        mh = sourmash.MinHash(num, ksize, is_protein=is_protein,
+                              dayhoff=dayhoff, hp=hp,
+                              track_abundance=track_abundance,
+                              scaled=scaled)
+                              
+        for record in screed.open(self.filename):
+            this_mh = mh.copy_and_clear()
+            this_mh.add_sequence(record.sequence, force=True)
+
+            ss = sourmash.SourmashSignature(this_mh, name=record.name)
+            yield ss
+
+    def select(self, **kwargs):
+        selection_dict = dict(self.selection_dict)
+        for k, v in kwargs.items():
+            if k in selection_dict:
+                if selection_dict[k] != v:
+                    raise ValueError(f"cannot select on two different values for {k}")
+            selection_dict[k] = v
+
+        return ScreedIndex(self.filename, selection_dict)
+
+    def insert(self, signature):
+        raise NotImplemented
+
+    def save(self, *args, **kwargs):
+        raise NotImplemented
+
+    def load(self, *args, **kwargs):
+        raise NotImplemented

--- a/src/sourmash/sourmash_args.py
+++ b/src/sourmash/sourmash_args.py
@@ -22,6 +22,7 @@ from . import signature as sigmod
 from .picklist import SignaturePicklist, PickStyle
 from .manifest import CollectionManifest
 import argparse
+from .screed_index import ScreedIndex
 
 
 DEFAULT_LOAD_K = 31
@@ -329,6 +330,13 @@ def _load_zipfile(filename, **kwargs):
                                      traverse_yield_all=traverse_yield_all)
     return db
 
+def _load_screed(filename, **kwargs):
+    db = None
+    for suffix in '.fa', '.fasta', '.fq', '.fq.gz', '.fa.gz', '.fasta.gz':
+        if filename.endswith(suffix):
+            db = ScreedIndex(filename)
+            return db
+
 
 # all loader functions, in order.
 _loader_functions = [
@@ -338,6 +346,7 @@ _loader_functions = [
     ("load SBT", _load_sbt),
     ("load revindex", _load_revindex),
     ("load collection from zipfile", _load_zipfile),
+    ("load from FASTA/FASTQ", _load_screed),
     ]
 
 


### PR DESCRIPTION
This class makes the following command work:

```
sourmash search podar-ref/1.fa.sig podar-ref/?.fa
```
by wrapping FASTA/FASTQ files in an `Index` subclass that generates the "right" MinHash sketches dynamically.

Proof of concept/thought experiment for now. Relevant to https://github.com/sourmash-bio/sourmash/issues/1647, although it does the dirty work via `Index` rather than via a `SourmashSignature`.

## Options I considered and may try --

* can implement as a container (e.g. a zip container or whatever) that tracks selects and builds compatible MinHash when needed - WHAT I DID
* can provide an individual Signature-style wrapper that overloads .minhash
* can provide load_signature???
* can subclass MinHash to be a sequence-containing-class that dynamically produces a MinHash from a sequence

## other thoughts for this PR

should probably add options for (a) multiple fasta files/one signature per, (b) overriding name.

this could connect to sketch lists, too.