### PR TITLE
Fix new clippy lints in beta (1.59, next stable)

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1b29f6fdb8ca9389f5000f479cdec42ceb67e161",
-        "sha256": "0ka8md0ll07c643p2nm0s2z6fsnhgkczaj111nmll5h0m3wgjk3b",
+        "rev": "46821ea01c8f54d2a20f5a503809abfc605269d7",
+        "sha256": "093daxh4yib44ddq2xgbnvk0kxgk754sfagqiplgd5rh7zmb1bpb",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/1b29f6fdb8ca9389f5000f479cdec42ceb67e161.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/46821ea01c8f54d2a20f5a503809abfc605269d7.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "rust-overlay": {
@@ -29,10 +29,10 @@
         "homepage": null,
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "7abe01071a9fe8b43e0ad4aa031163c14c19cda9",
-        "sha256": "1yg4h3xl252gniymkrjicai4sb8wpy9hjgzn4y91vkvam7inl45s",
+        "rev": "27fb59f3f4c687d599ec63a6c328e8432cd61101",
+        "sha256": "0mxqj0zrm4qyrjdhgyx243x2wknrp3032x91a6nff2zbfnc64wn2",
         "type": "tarball",
-        "url": "https://github.com/oxalica/rust-overlay/archive/7abe01071a9fe8b43e0ad4aa031163c14c19cda9.tar.gz",
+        "url": "https://github.com/oxalica/rust-overlay/archive/27fb59f3f4c687d599ec63a6c328e8432cd61101.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/src/core/src/signature.rs
+++ b/src/core/src/signature.rs
@@ -198,12 +198,11 @@ impl SeqToHashes {
         }
 
         // By setting _max_index to 0, the iterator will return None and exit
-        let _max_index: usize;
-        if seq.len() >= ksize {
-            _max_index = seq.len() - ksize + 1;
+        let _max_index = if seq.len() >= ksize {
+            seq.len() - ksize + 1
         } else {
-            _max_index = 0;
-        }
+            0
+        };
 
         SeqToHashes {
             // Here we convert the sequence to upper case

--- a/src/core/src/sketch/minhash.rs
+++ b/src/core/src/sketch/minhash.rs
@@ -185,20 +185,17 @@ impl KmerMinHash {
         track_abundance: bool,
         num: u32,
     ) -> KmerMinHash {
-        let mins: Vec<u64>;
-        let abunds: Option<Vec<u64>>;
-
-        if num > 0 {
-            mins = Vec::with_capacity(num as usize);
+        let mins = if num > 0 {
+            Vec::with_capacity(num as usize)
         } else {
-            mins = Vec::with_capacity(1000);
-        }
+            Vec::with_capacity(1000)
+        };
 
-        if track_abundance {
-            abunds = Some(Vec::with_capacity(mins.capacity()));
+        let abunds = if track_abundance {
+            Some(Vec::with_capacity(mins.capacity()))
         } else {
-            abunds = None
-        }
+            None
+        };
 
         let max_hash = max_hash_for_scaled(scaled);
 
@@ -435,19 +432,8 @@ impl KmerMinHash {
             let mut self_iter = self.mins.iter();
             let mut other_iter = other.mins.iter();
 
-            let mut self_abunds_iter: Option<std::slice::Iter<'_, u64>>;
-            if let Some(ref mut abunds) = self.abunds {
-                self_abunds_iter = Some(abunds.iter());
-            } else {
-                self_abunds_iter = None;
-            }
-
-            let mut other_abunds_iter: Option<std::slice::Iter<'_, u64>>;
-            if let Some(ref abunds) = other.abunds {
-                other_abunds_iter = Some(abunds.iter());
-            } else {
-                other_abunds_iter = None;
-            }
+            let mut self_abunds_iter = self.abunds.as_mut().map(|a| a.iter());
+            let mut other_abunds_iter = other.abunds.as_ref().map(|a| a.iter());
 
             let mut self_value = self_iter.next();
             let mut other_value = other_iter.next();


### PR DESCRIPTION
Next Rust stable (1.59) will include some new clippy lints that are currently failing our CI (on the beta channel).

Code is clearer with the suggestions, so merging it now.