### PR TITLE
[MRG] fix `sketch` stdout info

### DIFF
--- a/src/sourmash/command_compute.py
+++ b/src/sourmash/command_compute.py
@@ -105,7 +105,7 @@ def compute(args):
             error('bad ksizes: {}', ", ".join(bad_ksizes))
             sys.exit(-1)
 
-    notify('Computing a total of {} signature(s).', num_sigs)
+    notify('Computing a total of {} signature(s) for each input.', num_sigs)
 
     if num_sigs == 0:
         error('...nothing to calculate!? Exiting!')
@@ -183,6 +183,7 @@ def _compute_individual(args, signatures_factory):
             notify('... reading sequences from {}', filename)
             name = None
             n = None
+
             for n, record in enumerate(screed.open(filename)):
                 if n % 10000 == 0:
                     if n:
@@ -199,7 +200,7 @@ def _compute_individual(args, signatures_factory):
                 set_sig_name(sigs, filename, name)
                 siglist.extend(sigs)
 
-                notify(f'calculated {len(siglist)} signatures for {n+1} sequences in {filename}')
+                notify(f'calculated {len(sigs)} signatures for {n+1} sequences in {filename}')
             else:
                 notify(f"no sequences found in '{filename}'?!")
 

--- a/src/sourmash/command_sketch.py
+++ b/src/sourmash/command_sketch.py
@@ -184,7 +184,7 @@ def _execute_sketch(args, signatures_factory):
 
     # get number of output sigs:
     num_sigs = len(signatures_factory.params_list)
-    notify(f'Computing a total of {num_sigs} signature(s).')
+    notify(f'Computing a total of {num_sigs} signature(s) for each input.')
 
     if num_sigs == 0:
         error('...nothing to calculate!? Exiting!')


### PR DESCRIPTION
Print out the right output - unlike #1793, `sourmash sketch dna` now outputs the following:

```
Computing a total of 1 signature(s) for each input.
... reading sequences from podar-ref/0.fa
calculated 1 signatures for 1 sequences in podar-ref/0.fa
... reading sequences from podar-ref/1.fa
calculated 1 signatures for 1 sequences in podar-ref/1.fa
... reading sequences from podar-ref/2.fa
calculated 1 signatures for 1 sequences in podar-ref/2.fa
... reading sequences from podar-ref/3.fa
...
```

Fixes https://github.com/sourmash-bio/sourmash/issues/1793