### PR TITLE
[MRG] fix, refactor, and test `sourmash sketch` output information.

### DIFF
--- a/src/sourmash/command_compute.py
+++ b/src/sourmash/command_compute.py
@@ -233,7 +233,7 @@ def _compute_individual(args, signatures_factory):
         # if not args.output, close output for every input filename.
         if open_output_each_time:
             save_sigs.close()
-            notify(f"saved {len(save_sigs)} signature(s) to '{save_sigs.location}'. Note: signature license is CC0.'")
+            notify(f"saved {len(save_sigs)} signature(s) to '{save_sigs.location}'. Note: signature license is CC0.")
             save_sigs = None
 
 
@@ -241,7 +241,7 @@ def _compute_individual(args, signatures_factory):
     # and we need to close here.
     if args.output and save_sigs is not None:
         save_sigs.close()
-        notify(f"saved {len(save_sigs)} signature(s) to '{save_sigs.location}'. Note: signature license is CC0.'")
+        notify(f"saved {len(save_sigs)} signature(s) to '{save_sigs.location}'. Note: signature license is CC0.")
 
 
 def _compute_merged(args, signatures_factory):
@@ -294,41 +294,22 @@ def set_sig_name(sigs, filename, name=None):
 
 
 def save_siglist(siglist, sigfile_name):
-    import sourmash
+    "Save multiple signatures to a filename."
 
     # save!
     with sourmash_args.SaveSignaturesToLocation(sigfile_name) as save_sig:
         for ss in siglist:
-            try:
-                save_sig.add(ss)
-            except sourmash.exceptions.Panic:
-                # this deals with a disconnect between the way Rust
-                # and Python handle signatures; Python expects one
-                # minhash (and hence one md5sum) per signature, while
-                # Rust supports multiple. For now, go through serializing
-                # and deserializing the signature! See issue #1167 for more.
-                json_str = sourmash.save_signatures([ss])
-                for ss in sourmash.load_signatures(json_str):
-                    save_sig.add(ss)
+            save_sig.add(ss)
 
         notify(f"saved {len(save_sig)} signature(s) to '{save_sig.location}'")
 
 
 def save_sigs_to_location(siglist, save_sig):
+    "Save multiple signatures to an already-open location."
     import sourmash
 
     for ss in siglist:
-        try:
-            save_sig.add(ss)
-        except sourmash.exceptions.Panic:
-            # this deals with a disconnect between the way Rust
-            # and Python handle signatures; Python expects one
-            # minhash (and hence one md5sum) per signature, while
-            # Rust supports multiple. For now, go through serializing
-            # and deserializing the signature! See issue #1167 for more.
-            json_str = sourmash.save_signatures([ss])
-            for ss in sourmash.load_signatures(json_str):
-                save_sig.add(ss)
+        save_sig.add(ss)
 
 
 class ComputeParameters(RustObject):

--- a/tests/test_sourmash_sketch.py
+++ b/tests/test_sourmash_sketch.py
@@ -967,6 +967,43 @@ def test_do_sourmash_check_knowngood_protein_comparisons(runtmp):
     assert sig2_trans.similarity(good_trans) == 1.0
 
 
+def test_do_sourmash_singleton_multiple_files_no_out_specified(runtmp):
+    # this test checks that --singleton -o works
+    testdata1 = utils.get_test_data('ecoli.faa')
+    testdata2 = utils.get_test_data('shewanella.faa')
+
+    runtmp.sourmash('sketch', 'protein', '-p', 'k=7', '--singleton',
+                    testdata1, testdata2)
+
+    print(runtmp.last_result.err)
+    assert "saved 2 signature(s) to 'ecoli.faa.sig'. Note: signature license is CC0." in runtmp.last_result.err
+    assert "saved 2 signature(s) to 'shewanella.faa.sig'. Note: signature license is CC0." in runtmp.last_result.err
+
+    sig1 = runtmp.output('ecoli.faa.sig')
+    assert os.path.exists(sig1)
+    sig2 = runtmp.output('shewanella.faa.sig')
+    assert os.path.exists(sig2)
+
+    x = list(signature.load_signatures(sig1))
+    for ss in x:
+        print(ss.name)
+
+    y = list(signature.load_signatures(sig2))
+    for ss in y:
+        print(ss.name)
+
+    assert len(x) == 2
+    assert len(y) == 2
+
+    idents = [ ss.name.split()[0] for ss in x ]
+    print(idents)
+    assert set(['NP_414543.1', 'NP_414544.1' ]) == set(idents)
+
+    idents = [ ss.name.split()[0] for ss in y ]
+    print(idents)
+    assert set(['WP_006079348.1', 'WP_006079351.1']) == set(idents)
+
+
 def test_do_sourmash_singleton_multiple_files_output(runtmp):
     # this test checks that --singleton -o works
     testdata1 = utils.get_test_data('ecoli.faa')
@@ -975,10 +1012,38 @@ def test_do_sourmash_singleton_multiple_files_output(runtmp):
     runtmp.sourmash('sketch', 'protein', '-p', 'k=7', '--singleton',
                     testdata1, testdata2, '-o', 'output.sig')
 
+    print(runtmp.last_result.err)
+    assert "saved 4 signature(s) to 'output.sig'. Note: signature license is CC0." in runtmp.last_result.err
+
     sig1 = runtmp.output('output.sig')
     assert os.path.exists(sig1)
 
     x = list(signature.load_signatures(sig1))
+    for ss in x:
+        print(ss.name)
+
+    assert len(x) == 4
+
+    idents = [ ss.name.split()[0] for ss in x ]
+    print(idents)
+    assert set(['NP_414543.1', 'NP_414544.1', 'WP_006079348.1', 'WP_006079351.1']) == set(idents)
+
+
+def test_do_sourmash_singleton_multiple_files_output_zip(runtmp):
+    # this test checks that --singleton -o works
+    testdata1 = utils.get_test_data('ecoli.faa')
+    testdata2 = utils.get_test_data('shewanella.faa')
+
+    runtmp.sourmash('sketch', 'protein', '-p', 'k=7', '--singleton',
+                    testdata1, testdata2, '-o', 'output.zip')
+
+    print(runtmp.last_result.err)
+    assert "saved 4 signature(s) to 'output.zip'. Note: signature license is CC0." in runtmp.last_result.err
+
+    sig1 = runtmp.output('output.zip')
+    assert os.path.exists(sig1)
+
+    x = list(sourmash.load_file_as_signatures(sig1))
     for ss in x:
         print(ss.name)
 


### PR DESCRIPTION
This PR:
* fixes a misplaced ' after the 'CC0' text, a nit introduced by mistake in https://github.com/sourmash-bio/sourmash/pull/1810
* refactors the panic handling code caused by Rust/Python mismatch (ref #1167) and moves it over to sourmash_args, where it is arguably better handled.
* in the process of refactoring the panic handling code, fixes a problem with zipfile output where signatures were getting double-counted due to the panic handling code.

This PR also adds explicit checks on sourmash output signature counts, which hopefully will start locking down the repeated mistakes I'm making when I change this code 🙄 .

Fixes https://github.com/sourmash-bio/sourmash/issues/1824