### PR TITLE
[MRG] re-inflate prefetch output sketches

### DIFF
--- a/src/sourmash/commands.py
+++ b/src/sourmash/commands.py
@@ -1161,6 +1161,7 @@ def prefetch(args):
 
     # if with track_abund, flatten me
     query_mh = query.minhash
+    orig_query_mh = query_mh
     if query_mh.track_abundance:
         query_mh = query_mh.flatten()
 
@@ -1273,8 +1274,8 @@ def prefetch(args):
             sig_name = f"{query.name}-known"
 
         # restore abundances, if present in original query
-        if query.minhash.track_abundance:
-            ident_mh = ident_mh.inflate(query.minhash)
+        if orig_query_mh.track_abundance:
+            ident_mh = ident_mh.inflate(orig_query_mh)
 
         ss = sig.SourmashSignature(ident_mh, name=sig_name)
         with open(filename, "wt") as fp:
@@ -1290,8 +1291,8 @@ def prefetch(args):
         notify(f"saving {len(noident_mh)} unmatched hashes to '{filename}'")
 
         # restore abundances, if present in original query
-        if query.minhash.track_abundance:
-            noident_mh = noident_mh.inflate(query.minhash)
+        if orig_query_mh.track_abundance:
+            noident_mh = noident_mh.inflate(orig_query_mh)
 
         ss = sig.SourmashSignature(noident_mh, name=sig_name)
         with open(filename, "wt") as fp:

--- a/src/sourmash/commands.py
+++ b/src/sourmash/commands.py
@@ -1272,6 +1272,10 @@ def prefetch(args):
         if query.name:
             sig_name = f"{query.name}-known"
 
+        # restore abundances, if present in original query
+        if query.minhash.track_abundance:
+            ident_mh = ident_mh.inflate(query.minhash)
+
         ss = sig.SourmashSignature(ident_mh, name=sig_name)
         with open(filename, "wt") as fp:
             sig.save_signatures([ss], fp)
@@ -1284,6 +1288,11 @@ def prefetch(args):
             sig_name = f"{query.name}-unknown"
 
         notify(f"saving {len(noident_mh)} unmatched hashes to '{filename}'")
+
+        # restore abundances, if present in original query
+        if query.minhash.track_abundance:
+            noident_mh = noident_mh.inflate(query.minhash)
+
         ss = sig.SourmashSignature(noident_mh, name=sig_name)
         with open(filename, "wt") as fp:
             sig.save_signatures([ss], fp)

--- a/tests/test_prefetch.py
+++ b/tests/test_prefetch.py
@@ -535,3 +535,23 @@ def test_prefetch_with_picklist_exclude(runtmp):
     assert "total of 9 matching signatures." in err
     assert "of 1466 distinct query hashes, 1013 were found in matches above threshold." in err
     assert "a total of 453 query hashes remain unmatched." in err
+
+
+def test_prefetch_output_with_abundance(runtmp, prefetch_gather, linear_gather):
+    c = runtmp
+    query = utils.get_test_data('gather-abund/reads-s10x10-s11.sig')
+    against = utils.get_test_data('gather-abund/genome-s10.fa.gz.sig')
+
+    c.run_sourmash('prefetch', linear_gather, query, against,
+                   '--save-matching-hashes', c.output('match-hash.sig'),
+                   '--save-unmatched-hashes', c.output('nomatch-hash.sig'))
+
+    print(c.last_result.out)
+
+    assert os.path.exists(c.output('match-hash.sig'))
+    ss = list(sourmash.load_file_as_signatures(c.output('match-hash.sig')))[0]
+    assert ss.minhash.track_abundance
+
+    assert os.path.exists(c.output('nomatch-hash.sig'))
+    ss = list(sourmash.load_file_as_signatures(c.output('nomatch-hash.sig')))[0]
+    assert ss.minhash.track_abundance


### PR DESCRIPTION
This fixes the `prefetch` CLI so that `--save-matching-hashes` and `--save-unmatched-hashes` keep abundances if they are present in the input sketch.

Addresses https://github.com/sourmash-bio/sourmash/issues/1828 but does not fix it complete.y

- [x] add tests
- [x] update description