### PR TITLE
[EXP] extract signatures from a database

### DIFF
--- a/src/sourmash/__init__.py
+++ b/src/sourmash/__init__.py
@@ -117,6 +117,7 @@ from . import sbtmh
 from . import sbt_storage
 from . import signature
 from . import sig
+from . import database
 from . import cli
 from . import commands
 from .sourmash_args import load_file_as_index

--- a/src/sourmash/cli/__init__.py
+++ b/src/sourmash/cli/__init__.py
@@ -38,6 +38,7 @@ from . import sig as signature
 from . import sketch
 from . import storage
 from . import tax
+from . import database
 
 
 class SourmashParser(ArgumentParser):
@@ -97,10 +98,13 @@ def get_parser():
         'lca': 'Taxonomic operations',
         'sketch': 'Create signatures',
         'sig': 'Manipulate signature files',
+        'database': 'Manipulate indexed databases',
         'storage': 'Operations on storage',
     }
     alias = {
-        "sig": "signature"
+        "sig": "signature",
+        "database": "db",
+        "tax": "taxonomy"
     }
     expert = set(['categorize', 'import_csv', 'migrate', 'multigather', 'sbt_combine', 'watch'])
 

--- a/src/sourmash/cli/database/__init__.py
+++ b/src/sourmash/cli/database/__init__.py
@@ -1,0 +1,30 @@
+"""Define the command line interface for sourmash database
+
+The top level CLI is defined in ../__init__.py. This module defines the CLI for
+`sourmash database` operations.
+"""
+
+from . import extract
+from ..utils import command_list
+from argparse import SUPPRESS, RawDescriptionHelpFormatter
+import os
+import sys
+
+
+def subparser(subparsers):
+    subparser = subparsers.add_parser('database', formatter_class=RawDescriptionHelpFormatter, usage=SUPPRESS, aliases=['db'])
+    desc = 'Operations\n'
+    clidir = os.path.dirname(__file__)
+    ops = command_list(clidir)
+    for subcmd in ops:
+        docstring = getattr(sys.modules[__name__], subcmd).__doc__
+        helpstring = 'sourmash database {op:s} --help'.format(op=subcmd)
+        desc += '        {hs:33s} {ds:s}\n'.format(hs=helpstring, ds=docstring)
+    s = subparser.add_subparsers(
+        title='Manipulate indexed databases', dest='subcmd', metavar='subcmd', help=SUPPRESS,
+        description=desc
+    )
+    for subcmd in ops:
+        getattr(sys.modules[__name__], subcmd).subparser(s)
+    subparser._action_groups.reverse()
+    subparser._optionals.title = 'Options'

--- a/src/sourmash/cli/database/extract.py
+++ b/src/sourmash/cli/database/extract.py
@@ -18,10 +18,14 @@ def subparser(subparsers):
     )
     subparser.add_argument(
         '--md5', default=None,
-        help='select signatures whose md5 contains this substring'
+        help='select signatures whose md5 exactly matches this string'
     )
     subparser.add_argument(
-        '--name', default=None,
+        '--name', '--ident', default=None,
+        help='select signatures whose name exactly matches this string'
+    )
+    subparser.add_argument(
+        '--identprefix', default=None,
         help='select signatures whose name contains this substring'
     )
     subparser.add_argument(

--- a/src/sourmash/cli/database/extract.py
+++ b/src/sourmash/cli/database/extract.py
@@ -1,0 +1,42 @@
+"""extract one or more signatures from an indexed database"""
+
+from sourmash.cli.utils import (add_moltype_args, add_ksize_arg,
+                                add_picklist_args)
+
+
+def subparser(subparsers):
+    subparser = subparsers.add_parser('extract')
+    subparser.add_argument('databases')#, nargs='*')
+    subparser.add_argument(
+        '-q', '--quiet', action='store_true',
+        help='suppress non-error output'
+    )
+    subparser.add_argument(
+        '-o', '--output', metavar='FILE',
+        help='output signature to this file (default stdout)',
+        default='-',
+    )
+    subparser.add_argument(
+        '--md5', default=None,
+        help='select signatures whose md5 contains this substring'
+    )
+    subparser.add_argument(
+        '--name', default=None,
+        help='select signatures whose name contains this substring'
+    )
+    subparser.add_argument(
+        '-f', '--force', action='store_true',
+        help='try to load all files as signatures'
+    )
+    subparser.add_argument(
+        '--from-file',
+        help='a text file containing a list of files to load signatures from'
+    )
+    add_ksize_arg(subparser, 31)
+    add_moltype_args(subparser)
+    add_picklist_args(subparser)
+
+
+def main(args):
+    import sourmash
+    return sourmash.database.__main__.extract(args)

--- a/src/sourmash/database/__init__.py
+++ b/src/sourmash/database/__init__.py
@@ -1,0 +1,1 @@
+from .__main__ import main

--- a/src/sourmash/database/__main__.py
+++ b/src/sourmash/database/__main__.py
@@ -38,6 +38,10 @@ def create_picklist_from_args(args):
         name = str(args.name)
         picklist = SignaturePicklist('name')
         picklist.init([name])
+    elif args.identprefix:
+        ip = str(args.identprefix)
+        picklist = SignaturePicklist("identprefix")
+        picklist.init([ip])
     elif args.md5:
         md5 = str(args.md5)
         if len(md5) == 8:

--- a/src/sourmash/database/__main__.py
+++ b/src/sourmash/database/__main__.py
@@ -1,0 +1,98 @@
+"""
+Command-line entry point for 'python -m sourmash.database'
+"""
+import sys
+import csv
+import json
+import os
+from collections import defaultdict
+
+import screed
+import sourmash
+from sourmash.sourmash_args import FileOutput
+
+from sourmash.logging import set_quiet, error, notify, print_results, debug
+from sourmash import sourmash_args
+from sourmash.minhash import _get_max_hash_for_scaled
+#from sourmash.sig import _extend_signatures_with_from_file
+from sourmash.picklist import SignaturePicklist, PickStyle
+
+usage='''
+sourmash database <command> [<args>] - manipulate/work with signature files.
+
+** Commands can be:
+
+extract <database> [<database> ... ]     - extract signature(s) from database(s)
+
+** Use '-h' to get subcommand-specific help, e.g.
+
+sourmash database extract -h
+'''
+
+##### actual command line functions
+
+def create_picklist_from_args(args):
+    # construct a picklist from commandline args
+    picklist=None
+    if args.name:
+        name = str(args.name)
+        picklist = SignaturePicklist('name')
+        picklist.init([name])
+    elif args.md5:
+        md5 = str(args.md5)
+        if len(md5) == 8:
+            picklist = SignaturePicklist('md5prefix8')
+        else:
+            picklist = SignaturePicklist('md5')
+        picklist.init([md5])
+    return picklist
+
+
+
+def extract(args):
+    """
+    extract signature(s) from database(s)
+    """
+    set_quiet(args.quiet)
+    moltype = sourmash_args.calculate_moltype(args)
+    #sourmash.signature._extend_signatures_with_from_file(args)
+    picklist = sourmash_args.load_picklist(args)
+    if picklist is None:
+        picklist = create_picklist_from_args(args)
+    
+    save_sigs = sourmash_args.SaveSignaturesToLocation(args.output)
+    save_sigs.open()
+    
+    # start loading! Use manifest + picklist(s)
+    progress = sourmash_args.SignatureLoadingProgress()
+    loader = sourmash_args.load_file_as_signatures(args.databases,
+                                                   select_moltype=moltype,
+                                                   ksize=args.ksize,
+                                                   picklist=picklist,
+                                                   progress=progress)
+
+    for ss in loader:
+        #if filter_fn(ss):
+        save_sigs.add(ss)
+
+    notify(f"loaded {len(progress)} total that matched ksize & molecule type")
+    if not save_sigs:
+        error("no matching signatures to save!")
+        sys.exit(-1)
+
+    save_sigs.close()
+
+    notify(f"extracted {len(save_sigs)} signatures from {len(args.databases)} file(s)")
+
+    if picklist:
+        sourmash_args.report_picklist(args, picklist)
+
+def main(arglist=None):
+    args = sourmash.cli.get_parser().parse_args(arglist)
+    submod = getattr(sourmash.cli.database, args.subcmd)
+    mainmethod = getattr(submod, 'main')
+    return mainmethod(args)
+
+
+if __name__ == '__main__':
+    main(sys.argv)

--- a/tests/test_cmd_database.py
+++ b/tests/test_cmd_database.py
@@ -73,3 +73,30 @@ def test_database_extract_picklist_md5(runtmp):
     #           md5short='09a08691ce5295215',
     #           fullIdent='NC_009665.1',
     #           nodotIdent='NC_009665')
+
+
+def test_database_extract_picklist_identprefix(runtmp):
+    # extract 47 from 47, using a picklist w/full md5
+    c=runtmp
+    sig47 = utils.get_test_data('47.fa.sig')
+    sig63 = utils.get_test_data('63.fa.sig')
+
+    c.run_sourmash('index', '-k', '31', 'zzz.sbt.zip', sig47, sig63)
+    assert c.last_result.status == 0
+
+    test_sbt = c.output('zzz.sbt.zip')
+    assert os.path.exists(test_sbt)
+    name = "NC_009665.1 Shewanella baltica OS185, complete genome"
+    identprefix= "NC_009665"
+    md5 = "09a08691ce52952152f0e866a59f6261"
+    md5prefix = "09a08691"
+
+    c.sourmash('database', 'extract', test_sbt, '--identprefix', identprefix)
+
+    # stdout should be new signature
+    out = c.last_result.out
+
+    test_extract_sig = sourmash.load_one_signature(sig47)
+    actual_extract_sig = sourmash.load_one_signature(out)
+
+    assert actual_extract_sig == test_extract_sig

--- a/tests/test_cmd_database.py
+++ b/tests/test_cmd_database.py
@@ -1,0 +1,75 @@
+"""
+Tests for the 'sourmash database' command line.
+"""
+import csv
+import shutil
+import os
+import glob
+
+import pytest
+import screed
+
+import sourmash_tst_utils as utils
+import sourmash
+from sourmash.signature import load_signatures
+from sourmash.manifest import CollectionManifest
+from sourmash_tst_utils import SourmashCommandFailed
+
+
+def test_database_extract_picklist_name(runtmp):
+    # extract 47 from 47, using a picklist w/full md5
+    c=runtmp
+    sig47 = utils.get_test_data('47.fa.sig')
+    sig63 = utils.get_test_data('63.fa.sig')
+
+    c.run_sourmash('index', '-k', '31', 'zzz.sbt.zip', sig47, sig63)
+    assert c.last_result.status == 0
+
+    test_sbt = c.output('zzz.sbt.zip')
+    assert os.path.exists(test_sbt)
+    name = "NC_009665.1 Shewanella baltica OS185, complete genome"
+    md5 = "09a08691ce52952152f0e866a59f6261"
+    md5prefix = "09a08691"
+
+    c.sourmash('database', 'extract', test_sbt, '--name', name)
+
+    # stdout should be new signature
+    out = c.last_result.out
+
+    test_extract_sig = sourmash.load_one_signature(sig47)
+    actual_extract_sig = sourmash.load_one_signature(out)
+
+    assert actual_extract_sig == test_extract_sig
+
+
+def test_database_extract_picklist_md5(runtmp):
+    # extract 47 from 47, using a picklist w/full md5
+    c=runtmp
+    sig47 = utils.get_test_data('47.fa.sig')
+    sig63 = utils.get_test_data('63.fa.sig')
+
+    c.run_sourmash('index', '-k', '31', 'zzz.sbt.zip', sig47, sig63)
+    assert c.last_result.status == 0
+
+    test_sbt = c.output('zzz.sbt.zip')
+    assert os.path.exists(test_sbt)
+    name = "NC_009665.1 Shewanella baltica OS185, complete genome"
+    md5 = "09a08691ce52952152f0e866a59f6261"
+    md5prefix = "09a08691"
+
+    c.sourmash('database', 'extract', test_sbt, '--md5', md5)
+
+    # stdout should be new signature
+    out = c.last_result.out
+
+    test_extract_sig = sourmash.load_one_signature(sig47)
+    actual_extract_sig = sourmash.load_one_signature(out)
+
+    assert actual_extract_sig == test_extract_sig
+
+    # select on any of these attributes
+    #row = dict(exactName='NC_009665.1 Shewanella baltica OS185, complete genome',
+    #           md5full='09a08691ce52952152f0e866a59f6261',
+    #           md5short='09a08691ce5295215',
+    #           fullIdent='NC_009665.1',
+    #           nodotIdent='NC_009665')


### PR DESCRIPTION
Since I do a lot of work with large databases, it's nice to extract signatures directly from the database, rather than finding or re-building the signature of interest. I finally realized that while `sourmash sig extract <database>` works, it can't take advantage of manifests (SLOW for large databases)!

I probably should have just modified that command, but instead I started a `sourmash database` subcommand and added an `extract` function that can make use of manifests. User can select sigs with `--picklist`, `--name`, or `--md5`.

Hacky for now, bc some conventions don't match the rest of sourmash:
I didn't know how to use manifests to select on `md5` and `name` args (maybe db.select??), so I build a picklist and pass that in to `load_file_as_signatures` instead. However, using picklist here means we only do exact matching, not partial matching, plus we can't select on multiple criteria at once (though multiple picklists could).

@ctb is there a straightforward way to select on name/md5 using manifests?
