### PR TITLE
[MRG] Drop Python 3.7, default most of CI to Python 3.10

### DIFF
--- a/.github/workflows/asv.yml
+++ b/.github/workflows/asv.yml
@@ -22,10 +22,10 @@ jobs:
         git checkout latest
         git checkout -
 
-    - name: Set up Python 3.7
+    - name: Set up Python 3.10
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7
+        python-version: "3.10"
 
     - uses: actions-rs/toolchain@v1
       with:

--- a/.github/workflows/hypothesis.yml
+++ b/.github/workflows/hypothesis.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
-      - name: Set up Python 3.7
+      - name: Set up Python 3.10
         uses: actions/setup-python@v1
         with:
-          python-version: "3.7"
+          python-version: "3.10"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/khmer.yml
+++ b/.github/workflows/khmer.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
-      - name: Set up Python 3.7
+      - name: Set up Python 3.10
         uses: actions/setup-python@v1
         with:
-          python-version: "3.7"
+          python-version: "3.10"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-18.04, macos-latest]
-        py: [3.9, 3.8, 3.7]
+        py: ["3.10", "3.9", "3.8"]
       fail-fast: false
 
     steps:

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -6,7 +6,7 @@
     "branches": ["latest"],
     "dvcs": "git",
     "environment_type": "virtualenv",
-    "pythons": ["3.7"],
+    "pythons": ["3.10"],
     "env_dir": ".asv/env",
     "results_dir": ".asv/results",
     "html_dir": ".asv/html",

--- a/doc/developer.md
+++ b/doc/developer.md
@@ -6,7 +6,7 @@ You can get the latest development branch with:
 ```
 git clone https://github.com/sourmash-bio/sourmash.git
 ```
-sourmash runs under Python 3.7 and later.
+sourmash runs under Python 3.8 and later.
 
 We recommend using `conda` or `Nix` for setting up an environment for developing
 new features, running tests and code quality checks.

--- a/doc/requirements.md
+++ b/doc/requirements.md
@@ -11,7 +11,7 @@ in a second or so on a rather slow 2016 Mac laptop.
 MinHash sketches and signatures are quite small on disk.
 
 sourmash should run with no modification on Linux and Mac OS X,
-under Python 3.7 and later.  Please see [the development repository README][0]
+under Python 3.8 and later.  Please see [the development repository README][0]
 for
 information on source code, tests, and continuous integration.
 

--- a/doc/support.md
+++ b/doc/support.md
@@ -103,8 +103,8 @@ and our intent is that it will support as-yet unreleased versions of Python 3.x
 For future versions of sourmash, we plan to follow the
 [Numpy NEP 29](https://numpy.org/neps/nep-0029-deprecation_policy.html)
 proposal for Python version support. For example, this
-would mean that we would drop support for Python 3.7 on December 26,
-2021.
+would mean that we would drop support for Python 3.8 on April 14,
+2023.
 
 ### Rust API
 

--- a/shell.nix
+++ b/shell.nix
@@ -17,9 +17,9 @@ in
 
       git
       stdenv.cc.cc.lib
-      (python38.withPackages(ps: with ps; [ virtualenv tox setuptools ]))
+      (python310.withPackages(ps: with ps; [ virtualenv tox setuptools ]))
       (python39.withPackages(ps: with ps; [ virtualenv setuptools ]))
-      (python37.withPackages(ps: with ps; [ virtualenv setuptools ]))
+      (python38.withPackages(ps: with ps; [ virtualenv setuptools ]))
 
       rust-cbindgen
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,12 @@
 [tox]
 envlist =
+  py310,
   py39,
   coverage,
   codecov,
   docs,
   package_description
   py38,
-  py37,
   fix_lint,
   hypothesis,
   khmer,
@@ -63,6 +63,7 @@ commands = pytest \
            {posargs:.}
 
 [testenv:khmer]
+basepython = python3.8
 deps =
   khmer
 commands = pytest \
@@ -74,6 +75,7 @@ commands = pytest \
            {posargs:.}
 
 [testenv:khmer_master]
+basepython = python3.8
 deps =
   -e git+https://github.com/dib-lab/khmer.git#egg=khmer
 commands = pytest \
@@ -197,9 +199,9 @@ source = src/sourmash/
 
 [gh-actions]
 python =
-  3.7: py37, coverage, codecov
-  3.8: py38, docs, package_description, coverage, codecov
+  3.10: py310, docs, package_description, coverage, codecov
   3.9: py39, coverage, codecov
+  3.8: py38, coverage, codecov
 
 [flake8]
 max-complexity = 22


### PR DESCRIPTION
Python 3.7 is deprecated following [NEP 29](https://numpy.org/neps/nep-0029-deprecation_policy.html), might as well update `tox` and CI.