### PR TITLE
[MRG] clean up `sig describe` code a little bit & add a picklist test

### DIFF
--- a/doc/command-line.md
+++ b/doc/command-line.md
@@ -1399,8 +1399,10 @@ Identifiers are constructed by using the first space delimited word in
 the signature name.
 
 One way to build a picklist is to use `sourmash sig describe --csv
-out.csv <signatures>` to construct an initial CSV file that you can
-then edit further.
+out.csv <signatures>` or `sourmash sig manifest -o out.csv
+<filename_or_db>` to construct an initial CSV file that you can then
+edit further; after editing, these can be passed in via the picklist
+argument `--picklist out.csv::manifest`.
 
 The picklist functionality also supports excluding (rather than
 including) signatures matching the picklist arguments. To specify a

--- a/src/sourmash/sig/__main__.py
+++ b/src/sourmash/sig/__main__.py
@@ -206,14 +206,16 @@ def describe(args):
 
     # write CSV?
     w = None
-    csv_fp = None
+    csv_obj = None
     if args.csv:
+        csv_obj = sourmash_args.FileOutputCSV(args.csv)
+        csv_fp = csv_obj.open()
+
         # CTB: might want to switch to sourmash_args.FileOutputCSV here?
-        csv_fp = open(args.csv, 'w', newline='')
         w = csv.DictWriter(csv_fp,
-                           ['signature_file', 'md5', 'ksize', 'moltype', 'num',
-                            'scaled', 'n_hashes', 'seed', 'with_abundance',
-                            'name', 'filename', 'license'],
+                           ['signature_file', 'md5', 'ksize', 'moltype',
+                            'num', 'scaled', 'n_hashes', 'seed',
+                            'with_abundance', 'name', 'filename', 'license'],
                            extrasaction='ignore')
         w.writeheader()
 
@@ -260,8 +262,8 @@ size: {n_hashes}
 signature license: {license}
 ''', **locals())
 
-    if csv_fp:
-        csv_fp.close()
+    if csv_obj:
+        csv_obj.close()
 
     if picklist:
         sourmash_args.report_picklist(args, picklist)

--- a/tests/test_cmd_signature.py
+++ b/tests/test_cmd_signature.py
@@ -2928,9 +2928,10 @@ def test_sig_describe_empty(c):
     assert 'source file: ** no name **' in c.last_result.out
 
 
-@utils.in_tempdir
-def test_sig_describe_2(c):
-    # get info in CSV spreadsheet
+def test_sig_describe_2_csv(runtmp):
+    # output info in CSV spreadsheet
+    c = runtmp
+
     sig47 = utils.get_test_data('47.fa.sig')
     sig63 = utils.get_test_data('63.fa.sig')
     c.run_sourmash('sig', 'describe', sig47, sig63, '--csv', 'out.csv')
@@ -2948,6 +2949,35 @@ def test_sig_describe_2(c):
             n += 1
 
         assert n == 2
+
+
+def test_sig_describe_2_csv_as_picklist(runtmp):
+    # generate an output CSV from describe and then use it as a manifest
+    # pickfile
+    c = runtmp
+
+    sig47 = utils.get_test_data('47.fa.sig')
+    outcsv = runtmp.output('out.csv')
+
+    c.run_sourmash('sig', 'describe', sig47,
+                   '--csv', outcsv)
+
+    c.run_sourmash('sig', 'describe', sig47,
+                   '--picklist', f'{outcsv}::manifest')
+
+    out = c.last_result.out
+    print(c.last_result)
+
+    expected_output = """\
+signature: NC_009665.1 Shewanella baltica OS185, complete genome
+source file: 47.fa
+md5: 09a08691ce52952152f0e866a59f6261
+k=31 molecule=DNA num=0 scaled=1000 seed=42 track_abundance=0
+size: 5177
+signature license: CC0
+""".splitlines()
+    for line in expected_output:
+        assert line.strip() in out
 
 
 @utils.in_tempdir


### PR DESCRIPTION
While digging into `sig describe` CSV output (see https://github.com/sourmash-bio/sourmash/issues/1854), I decided to do some maintenance and refactoring, resolve a TODO comment, and add a test. Nothing to see here.
