### PR TITLE
[MRG] Fix containment calculation for nodegraphs

### DIFF
--- a/src/core/src/sketch/nodegraph.rs
+++ b/src/core/src/sketch/nodegraph.rs
@@ -309,7 +309,7 @@ impl Nodegraph {
             .zip(&other.bs)
             .map(|(bs, bs_other)| bs.intersection(bs_other).count())
             .sum();
-        let size: usize = self.bs.iter().map(|bs| bs.len()).sum();
+        let size: usize = self.bs.iter().map(|bs| bs.count_ones(..)).sum();
         result as f64 / size as f64
     }
 }

--- a/src/core/src/sketch/nodegraph.rs
+++ b/src/core/src/sketch/nodegraph.rs
@@ -436,6 +436,24 @@ mod test {
     }
 
     #[test]
+    fn containment() {
+        let mut ng1: Nodegraph = Nodegraph::new(&[31], 3);
+        let mut ng2: Nodegraph = Nodegraph::new(&[31], 3);
+
+        (0..20).for_each(|i| {
+            if i % 2 == 0 {
+                ng1.count(i);
+            };
+            ng2.count(i);
+        });
+
+        assert_eq!(ng1.containment(&ng2), 1.0);
+        assert_eq!(ng1.similarity(&ng2), 0.5);
+        assert_eq!(ng1.unique_kmers(), 10);
+        assert_eq!(ng2.unique_kmers(), 20);
+    }
+
+    #[test]
     fn load_save_nodegraph() {
         let mut datadir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         datadir.push("../../tests/test-data/.sbt.v3/");


### PR DESCRIPTION
You might think after all these years I would not mess how to calculate containment from a Bloom Filter. Sadly, you are mistaken. Sigh.

This also means that #1138 probably works properly now :see_no_evil: 

Ready for review and merge @sourmash-bio/devs 