### PR TITLE
[MRG] pin setuptools < 60

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "setuptools >= 48",
+    "setuptools >= 48, <60",
     "setuptools_scm[toml] >= 4, <6",
     "setuptools_scm_git_archive",
     "milksnake",


### PR DESCRIPTION
When testing out [sourmash v4.3.0](https://github.com/sourmash-bio/sourmash/issues/1873) rc1, I ran into an error linking to libthread on farm, and when I revisited https://github.com/sourmash-bio/sourmash/issues/1772, I saw a new reverse link from this issue:

https://github.com/sherpa/sherpa/issues/1456

which recommended that we downgrade setuptools to `<60`. I tested it on farm, and that indeed allowed the build to proceed.

I'm going to merge this when tests pass, so I can cut the release.