### PR TITLE
[WIP] add support for `sourmash sketch fromfile` functionality.

### DIFF
--- a/src/sourmash/command_compute.py
+++ b/src/sourmash/command_compute.py
@@ -328,6 +328,20 @@ class ComputeParameters(RustObject):
         self.track_abundance = track_abundance
         self.scaled = scaled
 
+    def __repr__(self):
+        return f"ComputeParameters({self.ksizes}, {self.seed}, {self.protein}, {self.dayhoff}, {self.hp}, {self.dna}, {self.num_hashes}, {self.track_abundance}, {self.scaled})"
+
+    def __eq__(self, other):
+        return (self.ksizes == other.ksizes and
+                self.seed == other.seed and
+                self.protein == other.protein and
+                self.dayhoff == other.dayhoff and
+                self.hp == other.hp and
+                self.dna == other.dna and
+                self.num_hashes == other.num_hashes and
+                self.track_abundance == other.track_abundance and
+                self.scaled == other.scaled)
+
     @staticmethod
     def from_args(args):
         ptr = lib.computeparams_new()

--- a/src/sourmash/command_compute.py
+++ b/src/sourmash/command_compute.py
@@ -330,7 +330,10 @@ class ComputeParameters(RustObject):
 
     def to_param_str(self):
         x = []
-        kstr = [f"k={k}" for k in self.ksizes]
+        if self.dna:
+            kstr = [f"k={k}" for k in self.ksizes]
+        else:
+            kstr = [f"k={k//3}" for k in self.ksizes]
         x.extend(kstr)
 
         if self.seed != 42:

--- a/src/sourmash/command_compute.py
+++ b/src/sourmash/command_compute.py
@@ -328,6 +328,30 @@ class ComputeParameters(RustObject):
         self.track_abundance = track_abundance
         self.scaled = scaled
 
+    def to_param_str(self):
+        x = []
+        kstr = [f"k={k}" for k in self.ksizes]
+        x.extend(kstr)
+
+        if self.seed != 42:
+            x.append(f"seed={self.seed}")
+        if self.num_hashes != 0:
+            x.append(f"num={self.num_hashes}")
+        if self.scaled != 0:
+            x.append(f"scaled={self.scaled}")
+        if self.track_abundance:
+            x.append("abund")
+        if self.dna:
+            x.append("dna")
+        if self.protein:
+            x.append("protein")
+        if self.hp:
+            x.append("hp")
+        if self.dayhoff:
+            x.append("dayhoff")
+
+        return ",".join(x)
+
     def __repr__(self):
         return f"ComputeParameters({self.ksizes}, {self.seed}, {self.protein}, {self.dayhoff}, {self.hp}, {self.dna}, {self.num_hashes}, {self.track_abundance}, {self.scaled})"
 

--- a/src/sourmash/command_compute.py
+++ b/src/sourmash/command_compute.py
@@ -329,31 +329,44 @@ class ComputeParameters(RustObject):
         self.scaled = scaled
 
     def to_param_str(self):
-        x = []
+        "Convert object to equivalent params str."
+        pi = []
+
+        if self.dna:
+            pi.append("dna")
+        elif self.protein:
+            pi.append("protein")
+        elif self.hp:
+            pi.append("hp")
+        elif self.dayhoff:
+            pi.append("dayhoff")
+        else:
+            assert 0            # must be one of the previous
+
         if self.dna:
             kstr = [f"k={k}" for k in self.ksizes]
         else:
+            # for protein, divide ksize by three.
             kstr = [f"k={k//3}" for k in self.ksizes]
-        x.extend(kstr)
+        assert kstr
+        pi.extend(kstr)
+
+        if self.num_hashes != 0:
+            pi.append(f"num={self.num_hashes}")
+        elif self.scaled != 0:
+            pi.append(f"scaled={self.scaled}")
+        else:
+            assert 0
+
+        if self.track_abundance:
+            pi.append("abund")
+        # noabund is default
 
         if self.seed != 42:
-            x.append(f"seed={self.seed}")
-        if self.num_hashes != 0:
-            x.append(f"num={self.num_hashes}")
-        if self.scaled != 0:
-            x.append(f"scaled={self.scaled}")
-        if self.track_abundance:
-            x.append("abund")
-        if self.dna:
-            x.append("dna")
-        if self.protein:
-            x.append("protein")
-        if self.hp:
-            x.append("hp")
-        if self.dayhoff:
-            x.append("dayhoff")
+            pi.append(f"seed={self.seed}")
+        # self.seed
 
-        return ",".join(x)
+        return ",".join(pi)
 
     def __repr__(self):
         return f"ComputeParameters({self.ksizes}, {self.seed}, {self.protein}, {self.dayhoff}, {self.hp}, {self.dna}, {self.num_hashes}, {self.track_abundance}, {self.scaled})"

--- a/src/sourmash/command_sketch.py
+++ b/src/sourmash/command_sketch.py
@@ -106,13 +106,13 @@ class _signatures_for_sketch_factory(object):
                     raise ValueError(f"Incompatible sketch type ({default_moltype}) and parameter override ({moltype}) in '{params_str}'")
                 elif moltype is None:
                     if default_moltype is None:
-                        raise ValueError(f"No default moltype and none specificed in param string")
+                        raise ValueError(f"No default moltype and none specified in param string")
                     moltype = default_moltype
 
                 self.params_list.append((moltype, params))
         else:
             if default_moltype is None:
-                raise ValueError(f"No default moltype and none specificed in param string")
+                raise ValueError(f"No default moltype and none specified in param string")
             # no params str? default to a single sig, using default_moltype.
             self.params_list.append((default_moltype, {}))
 

--- a/src/sourmash/command_sketch.py
+++ b/src/sourmash/command_sketch.py
@@ -82,8 +82,7 @@ def _parse_params_str(params_str):
 
 class _signatures_for_sketch_factory(object):
     "Build sigs on demand, based on args input to 'sketch'."
-    def __init__(self, params_str_list, default_moltype, mult_ksize_by_3):
-
+    def __init__(self, params_str_list, default_moltype):
         # first, set up defaults per-moltype
         defaults = {}
         for moltype, pstr in DEFAULTS.items():
@@ -94,7 +93,7 @@ class _signatures_for_sketch_factory(object):
 
         # next, fill out params_list
         self.params_list = []
-        self.mult_ksize_by_3 = mult_ksize_by_3
+        self.mult_ksize_by_3 = True
 
         if params_str_list:
             # parse each params_str passed in, using default_moltype if none
@@ -103,9 +102,11 @@ class _signatures_for_sketch_factory(object):
                 moltype, params = _parse_params_str(params_str)
                 if moltype and moltype != 'dna' and default_moltype == 'dna':
                     raise ValueError(f"Incompatible sketch type ({default_moltype}) and parameter override ({moltype}) in '{params_str}'; maybe use 'sketch translate'?")
-                elif moltype == 'dna' and default_moltype != 'dna':
+                elif moltype == 'dna' and default_moltype and default_moltype != 'dna':
                     raise ValueError(f"Incompatible sketch type ({default_moltype}) and parameter override ({moltype}) in '{params_str}'")
                 elif moltype is None:
+                    if default_moltype is None:
+                        raise ValueError(f"No default moltype and none specificed in param string")
                     moltype = default_moltype
 
                 self.params_list.append((moltype, params))
@@ -113,7 +114,7 @@ class _signatures_for_sketch_factory(object):
             # no params str? default to a single sig, using default_moltype.
             self.params_list.append((default_moltype, {}))
 
-    def get_compute_params(self):
+    def get_compute_params(self, *, split_ksizes=False):
         for moltype, params_d in self.params_list:
             # get defaults for this moltype from self.defaults:
             default_params = self.defaults[moltype]
@@ -134,26 +135,33 @@ class _signatures_for_sketch_factory(object):
             if not ksizes:
                 ksizes = def_ksizes
 
-            if self.mult_ksize_by_3:
+            # 'command sketch' adjusts k-mer sizes by 3 if non-DNA sketch.
+            if self.mult_ksize_by_3 and not def_dna:
                 ksizes = [ k*3 for k in ksizes ]
 
-            params_obj = ComputeParameters(ksizes,
-                                           params_d.get('seed', def_seed),
-                                           def_protein,
-                                           def_dayhoff,
-                                           def_hp,
-                                           def_dna,
-                                           params_d.get('num', def_num),
-                                           params_d.get('track_abundance',
-                                                        def_abund),
-                                           params_d.get('scaled', def_scaled))
+            make_param = lambda ksizes: ComputeParameters(ksizes,
+                                            params_d.get('seed', def_seed),
+                                            def_protein,
+                                            def_dayhoff,
+                                            def_hp,
+                                            def_dna,
+                                            params_d.get('num', def_num),
+                                            params_d.get('track_abundance',
+                                                         def_abund),
+                                            params_d.get('scaled', def_scaled))
 
-            yield params_obj
+            if split_ksizes:
+                for ksize in ksizes:
+                    params_obj = make_param([ksize])
+                    yield params_obj
+            else:
+                params_obj = make_param(ksizes)
+                yield params_obj
 
-    def __call__(self):
+    def __call__(self, *, split_ksizes=False):
         "Produce a new set of signatures built to match the param strings."
         sigs = []
-        for params in self.get_compute_params():
+        for params in self.get_compute_params(split_ksizes=split_ksizes):
             sig = SourmashSignature.from_params(params)
             sigs.append(sig)
 
@@ -214,8 +222,7 @@ def dna(args):
 
     try:
         signatures_factory = _signatures_for_sketch_factory(args.param_string,
-                                                            'dna',
-                                                            mult_ksize_by_3=False)
+                                                            'dna')
     except ValueError as e:
         error(f"Error creating signatures: {str(e)}")
         sys.exit(-1)
@@ -244,8 +251,7 @@ def protein(args):
 
     try:
         signatures_factory = _signatures_for_sketch_factory(args.param_string,
-                                                            moltype,
-                                                            mult_ksize_by_3=True)
+                                                            moltype)
     except ValueError as e:
         error(f"Error creating signatures: {str(e)}")
         sys.exit(-1)
@@ -274,8 +280,7 @@ def translate(args):
 
     try:
         signatures_factory = _signatures_for_sketch_factory(args.param_string,
-                                                            moltype,
-                                                            mult_ksize_by_3=True)
+                                                            moltype)
     except ValueError as e:
         error(f"Error creating signatures: {str(e)}")
         sys.exit(-1)

--- a/src/sourmash/command_sketch.py
+++ b/src/sourmash/command_sketch.py
@@ -111,6 +111,8 @@ class _signatures_for_sketch_factory(object):
 
                 self.params_list.append((moltype, params))
         else:
+            if default_moltype is None:
+                raise ValueError(f"No default moltype and none specificed in param string")
             # no params str? default to a single sig, using default_moltype.
             self.params_list.append((default_moltype, {}))
 

--- a/src/sourmash/index/__init__.py
+++ b/src/sourmash/index/__init__.py
@@ -341,7 +341,7 @@ class Index(ABC):
 
 def select_signature(ss, *, ksize=None, moltype=None, scaled=0, num=0,
                      containment=False, abund=None, picklist=None):
-    "Check that the given signature matches the specificed requirements."
+    "Check that the given signature matches the specified requirements."
     # ksize match?
     if ksize and ksize != ss.minhash.ksize:
         return False

--- a/tests/test_sourmash_sketch.py
+++ b/tests/test_sourmash_sketch.py
@@ -411,6 +411,36 @@ def test_multiple_moltypes():
     assert params.protein
 
 
+def test_compute_parameters_to_param_str_1():
+    input_param_str = 'protein'
+    expected_output_str = 'k=10,scaled=200,protein'
+
+    factory = _signatures_for_sketch_factory([input_param_str], None)
+    params_list = list(factory.get_compute_params())
+    assert len(params_list) == 1
+    params = params_list[0]
+
+    actual_output_str = params.to_param_str()
+
+    assert actual_output_str == expected_output_str, (actual_output_str,
+                                                      expected_output_str)
+
+
+def test_compute_parameters_to_param_str_2():
+    input_param_str = 'dna'
+    expected_output_str = 'k=31,scaled=1000,dna'
+
+    factory = _signatures_for_sketch_factory([input_param_str], None)
+    params_list = list(factory.get_compute_params())
+    assert len(params_list) == 1
+    params = params_list[0]
+
+    actual_output_str = params.to_param_str()
+
+    assert actual_output_str == expected_output_str, (actual_output_str,
+                                                      expected_output_str)
+
+
 ### command line tests
 
 

--- a/tests/test_sourmash_sketch.py
+++ b/tests/test_sourmash_sketch.py
@@ -67,6 +67,69 @@ def test_do_sourmash_sketch_check_num_bounds_more_than_maximum(runtmp):
     assert "WARNING: num value should be <= 50000. Continuing anyway." in runtmp.last_result.err
 
 
+def test_empty_factory():
+    with pytest.raises(ValueError):
+        factory = _signatures_for_sketch_factory([], None)
+
+
+def test_factory_no_default_moltype_dna():
+    factory = _signatures_for_sketch_factory(['dna'], None)
+    params_list = list(factory.get_compute_params())
+    assert len(params_list) == 1
+
+    params = params_list[0]
+    assert params.dna
+
+
+def test_factory_no_default_moltype_protein():
+    factory = _signatures_for_sketch_factory(['protein'], None)
+    params_list = list(factory.get_compute_params())
+    assert len(params_list) == 1
+
+    params = params_list[0]
+    assert params.protein
+
+
+def test_factory_dna_nosplit():
+    factory = _signatures_for_sketch_factory(['k=31,k=51'], 'dna')
+    params_list = list(factory.get_compute_params(split_ksizes=False))
+    assert len(params_list) == 1
+
+    params = params_list[0]
+    assert params.ksizes == [31,51]
+
+
+def test_factory_dna_split():
+    factory = _signatures_for_sketch_factory(['k=31,k=51'], 'dna')
+    params_list = list(factory.get_compute_params(split_ksizes=True))
+    assert len(params_list) == 2
+
+    params = params_list[0]
+    assert params.ksizes == [31]
+    params = params_list[1]
+    assert params.ksizes == [51]
+
+
+def test_factory_protein_nosplit():
+    factory = _signatures_for_sketch_factory(['k=10,k=9'], 'protein')
+    params_list = list(factory.get_compute_params(split_ksizes=False))
+    assert len(params_list) == 1
+
+    params = params_list[0]
+    assert params.ksizes == [30, 27]
+
+
+def test_factory_protein_split():
+    factory = _signatures_for_sketch_factory(['k=10,k=9'], 'protein')
+    params_list = list(factory.get_compute_params(split_ksizes=True))
+    assert len(params_list) == 2
+
+    params = params_list[0]
+    assert params.ksizes == [30]
+    params = params_list[1]
+    assert params.ksizes == [27]
+
+
 def test_dna_defaults():
     factory = _signatures_for_sketch_factory([], 'dna')
     params_list = list(factory.get_compute_params())

--- a/tests/test_sourmash_sketch.py
+++ b/tests/test_sourmash_sketch.py
@@ -68,7 +68,7 @@ def test_do_sourmash_sketch_check_num_bounds_more_than_maximum(runtmp):
 
 
 def test_dna_defaults():
-    factory = _signatures_for_sketch_factory([], 'dna', False)
+    factory = _signatures_for_sketch_factory([], 'dna')
     params_list = list(factory.get_compute_params())
 
     assert len(params_list) == 1
@@ -87,7 +87,7 @@ def test_dna_defaults():
 
 def test_dna_override_1():
     factory = _signatures_for_sketch_factory(['k=21,scaled=2000,abund'],
-                                             'dna', False)
+                                             'dna')
     params_list = list(factory.get_compute_params())
 
     assert len(params_list) == 1
@@ -106,44 +106,41 @@ def test_dna_override_1():
 
 def test_scaled_param_requires_equal():
     with pytest.raises(ValueError):
-        factory = _signatures_for_sketch_factory(['k=21,scaled'],
-                                                 'dna', False)
+        factory = _signatures_for_sketch_factory(['k=21,scaled'], 'dna')
 
 
 def test_k_param_requires_equal():
     with pytest.raises(ValueError):
-        factory = _signatures_for_sketch_factory(['k'],
-                                                 'dna', False)
+        factory = _signatures_for_sketch_factory(['k'], 'dna')
 
 
 def test_k_param_requires_equal_2():
     with pytest.raises(ValueError) as exc:
-        factory = _signatures_for_sketch_factory(['k='],
-                                                 'dna', False)
+        factory = _signatures_for_sketch_factory(['k='], 'dna')
+
 
 def test_seed_param_requires_equal():
     with pytest.raises(ValueError) as exc:
-        factory = _signatures_for_sketch_factory(['seed='],
-                                                 'dna', False)
+        factory = _signatures_for_sketch_factory(['seed='], 'dna')
+
 
 def test_num_param_requires_equal():
     with pytest.raises(ValueError) as exc:
-        factory = _signatures_for_sketch_factory(['num='],
-                                                 'dna', False)
+        factory = _signatures_for_sketch_factory(['num='], 'dna')
+
 
 def test_dna_override_bad_1():
     with pytest.raises(ValueError):
         factory = _signatures_for_sketch_factory(['k=21,scaledFOO=2000,abund'],
-                                                 'dna', False)
+                                                 'dna')
 
 
 def test_dna_override_bad_2():
     with pytest.raises(ValueError):
-        factory = _signatures_for_sketch_factory(['k=21,protein'],
-                                                 'dna', False)
+        factory = _signatures_for_sketch_factory(['k=21,protein'], 'dna')
 
 def test_protein_defaults():
-    factory = _signatures_for_sketch_factory([], 'protein', True)
+    factory = _signatures_for_sketch_factory([], 'protein')
     params_list = list(factory.get_compute_params())
 
     assert len(params_list) == 1
@@ -162,12 +159,11 @@ def test_protein_defaults():
 
 def test_protein_override_bad_2():
     with pytest.raises(ValueError):
-        factory = _signatures_for_sketch_factory(['k=21,dna'],
-                                                 'protein', False)
+        factory = _signatures_for_sketch_factory(['k=21,dna'], 'protein')
 
 def test_protein_override_bad_rust_foo():
     # mimic 'sourmash sketch protein -p dna'
-    factory = _signatures_for_sketch_factory([], 'protein', False)
+    factory = _signatures_for_sketch_factory([], 'protein')
 
     # reach in and avoid error checking to construct a bad params_list.
     factory.params_list = [('dna', {})]
@@ -188,7 +184,7 @@ def test_protein_override_bad_rust_foo():
 
 
 def test_dayhoff_defaults():
-    factory = _signatures_for_sketch_factory([], 'dayhoff', True)
+    factory = _signatures_for_sketch_factory([], 'dayhoff')
     params_list = list(factory.get_compute_params())
 
     assert len(params_list) == 1
@@ -207,11 +203,10 @@ def test_dayhoff_defaults():
 
 def test_dayhoff_override_bad_2():
     with pytest.raises(ValueError):
-        factory = _signatures_for_sketch_factory(['k=21,dna'],
-                                                 'dayhoff', False)
+        factory = _signatures_for_sketch_factory(['k=21,dna'], 'dayhoff')
 
 def test_hp_defaults():
-    factory = _signatures_for_sketch_factory([], 'hp', True)
+    factory = _signatures_for_sketch_factory([], 'hp')
     params_list = list(factory.get_compute_params())
 
     assert len(params_list) == 1
@@ -230,8 +225,7 @@ def test_hp_defaults():
 
 def test_hp_override_bad_2():
     with pytest.raises(ValueError):
-        factory = _signatures_for_sketch_factory(['k=21,dna'],
-                                                 'hp', False)
+        factory = _signatures_for_sketch_factory(['k=21,dna'], 'hp')
 
 
 def test_multiple_moltypes():
@@ -239,7 +233,7 @@ def test_multiple_moltypes():
                   'k=19,num=400,dayhoff,abund',
                   'k=30,scaled=200,hp',
                   'k=30,scaled=200,seed=58']
-    factory = _signatures_for_sketch_factory(params_foo, 'protein', True)
+    factory = _signatures_for_sketch_factory(params_foo, 'protein')
     params_list = list(factory.get_compute_params())
 
     assert len(params_list) == 4

--- a/tests/test_sourmash_sketch.py
+++ b/tests/test_sourmash_sketch.py
@@ -72,6 +72,11 @@ def test_empty_factory():
         factory = _signatures_for_sketch_factory([], None)
 
 
+def test_no_default_moltype_factory_nonempty():
+    with pytest.raises(ValueError):
+        factory = _signatures_for_sketch_factory(["k=31"], None)
+
+
 def test_factory_no_default_moltype_dna():
     factory = _signatures_for_sketch_factory(['dna'], None)
     params_list = list(factory.get_compute_params())
@@ -128,6 +133,66 @@ def test_factory_protein_split():
     assert params.ksizes == [30]
     params = params_list[1]
     assert params.ksizes == [27]
+
+
+def test_factory_dna_equal():
+    factory1 = _signatures_for_sketch_factory(['dna'], None)
+    params_list1 = list(factory1.get_compute_params())
+    assert len(params_list1) == 1
+    params1 = params_list1[0]
+
+    factory2 = _signatures_for_sketch_factory([], 'dna')
+    params_list2 = list(factory2.get_compute_params())
+    assert len(params_list2) == 1
+    params2 = params_list2[0]
+
+    assert params1 == params2
+    assert repr(params1) == repr(params2)
+
+
+def test_factory_protein_equal():
+    factory1 = _signatures_for_sketch_factory(['protein'], None)
+    params_list1 = list(factory1.get_compute_params())
+    assert len(params_list1) == 1
+    params1 = params_list1[0]
+
+    factory2 = _signatures_for_sketch_factory([], 'protein')
+    params_list2 = list(factory2.get_compute_params())
+    assert len(params_list2) == 1
+    params2 = params_list2[0]
+
+    assert params1 == params2
+    assert repr(params1) == repr(params2)
+
+
+def test_factory_dna_multi_ksize_eq():
+    factory1 = _signatures_for_sketch_factory(['k=21,k=31,dna'], None)
+    params_list1 = list(factory1.get_compute_params())
+    assert len(params_list1) == 1
+    params1 = params_list1[0]
+
+    factory2 = _signatures_for_sketch_factory(['k=21,k=31'], 'dna')
+    params_list2 = list(factory2.get_compute_params())
+    assert len(params_list2) == 1
+    params2 = params_list2[0]
+
+    assert params1 == params2
+    assert repr(params1) == repr(params2)
+
+
+def test_factory_protein_multi_ksize_eq():
+    factory1 = _signatures_for_sketch_factory(['k=10,k=11,protein'], None)
+    params_list1 = list(factory1.get_compute_params())
+    assert len(params_list1) == 1
+    params1 = params_list1[0]
+
+    factory2 = _signatures_for_sketch_factory(['k=10,k=11'], 'protein')
+    params_list2 = list(factory2.get_compute_params())
+    assert len(params_list2) == 1
+    params2 = params_list2[0]
+
+    assert params1 == params2
+    assert repr(params1) == repr(params2)
 
 
 def test_dna_defaults():

--- a/tests/test_sourmash_sketch.py
+++ b/tests/test_sourmash_sketch.py
@@ -411,10 +411,17 @@ def test_multiple_moltypes():
     assert params.protein
 
 
-def test_compute_parameters_to_param_str_1():
-    input_param_str = 'protein'
-    expected_output_str = 'k=10,scaled=200,protein'
-
+@pytest.mark.parametrize("input_param_str, expected_output",
+                         [('protein', 'protein,k=10,scaled=200'),
+                          ('dna', 'dna,k=31,scaled=1000'),
+                          ('hp', 'hp,k=42,scaled=200'),
+                          ('dayhoff', 'dayhoff,k=16,scaled=200'),
+                          ('dna,seed=52', 'dna,k=31,scaled=1000,seed=52'),
+                          ('dna,num=500', 'dna,k=31,num=500'),
+                          ('scaled=1100,dna', 'dna,k=31,scaled=1100'),
+                          ('dna,abund', 'dna,k=31,scaled=1000,abund')
+                         ])
+def test_compute_parameters_to_param_str(input_param_str, expected_output):
     factory = _signatures_for_sketch_factory([input_param_str], None)
     params_list = list(factory.get_compute_params())
     assert len(params_list) == 1
@@ -422,23 +429,8 @@ def test_compute_parameters_to_param_str_1():
 
     actual_output_str = params.to_param_str()
 
-    assert actual_output_str == expected_output_str, (actual_output_str,
-                                                      expected_output_str)
-
-
-def test_compute_parameters_to_param_str_2():
-    input_param_str = 'dna'
-    expected_output_str = 'k=31,scaled=1000,dna'
-
-    factory = _signatures_for_sketch_factory([input_param_str], None)
-    params_list = list(factory.get_compute_params())
-    assert len(params_list) == 1
-    params = params_list[0]
-
-    actual_output_str = params.to_param_str()
-
-    assert actual_output_str == expected_output_str, (actual_output_str,
-                                                      expected_output_str)
+    assert actual_output_str == expected_output, (actual_output_str,
+                                                  expected_output)
 
 
 ### command line tests


### PR DESCRIPTION
This PR updates `command_sketch.py` and `command_compute.py` to support new `sourmash sketch fromfile` functionality, currently being developed in the [ctb/2022-sourmash-sketchfrom](https://github.com/ctb/2022-sourmash-sketchfrom) repo and also in https://github.com/sourmash-bio/sourmash/pull/1885.

This is an ongoing PR that separates the support code changes from the `fromfile` command itself.

This PR:
* updates the `ComputeParameters` class to support `__repr__` and `__eq__`.
* adds `ComputeParameters.to_param_str` method.
* refactors `_signatures_for_sketch_factory` to properly handle no default_moltype and produce one `ComputeParameters` object per ksize, along with general cleanup and refactoring.

Ref https://github.com/sourmash-bio/sourmash/issues/1671