### PR TITLE
[MRG] add `-A/--abundance-from` to  `sig subtract` & add `sig inflate`

### DIFF
--- a/doc/command-line.md
+++ b/doc/command-line.md
@@ -948,10 +948,7 @@ for an example use case.
 
 ## `sourmash signature` subcommands for signature manipulation
 
-These commands manipulate signatures from the command line. Currently
-supported subcommands are `merge`, `rename`, `intersect`,
-`extract`, `downsample`, `subtract`, `import`, `export`, `info`,
-`flatten`, `filter`, `cat`, and `split`.
+These commands manipulate signatures from the command line.
 
 The signature commands that combine or otherwise have multiple
 signatures interacting (`merge`, `intersect`, `subtract`) work only on
@@ -1184,10 +1181,23 @@ will output the intersection of all the hashes in those three files to
 
 The `intersect` command flattens all signatures, i.e. the abundances
 in any signatures will be ignored and the output signature will have
-`track_abundance` turned off.
+`track_abundance` turned off.  The `-A/--abundance-from` argument will
+borrow abundances from the specified signature (which will also be added
+to the intersection).
 
-Note: `intersect` only creates one output file, with one signature in it,
-in the JSON `.sig` format.
+### `sourmash signature inflate` - transfer abundances from one signature to others
+
+Use abundances from one signature to provide abundances on other signatures.
+
+For example,
+
+```
+sourmash signature inflate file1.sig file2.sig file3.sig -o inflated.sig
+```
+will take the abundances from hashes `file1.sig` and use them to set
+the abundances on matching hashes in `file2.sig` and `file3.sig`.
+Any hashes that are not present in `file1.sig` will be removed from
+`file2.sig` and `file3.sig` as they will now have zero abundance.
 
 ### `sourmash signature downsample` - decrease the size of a signature
 

--- a/src/sourmash/cli/sig/__init__.py
+++ b/src/sourmash/cli/sig/__init__.py
@@ -16,6 +16,7 @@ from . import fileinfo as summarize
 from . import grep
 from . import kmers
 from . import intersect
+from . import inflate
 from . import manifest
 from . import merge
 from . import rename

--- a/src/sourmash/cli/sig/inflate.py
+++ b/src/sourmash/cli/sig/inflate.py
@@ -13,7 +13,7 @@ def subparser(subparsers):
         help='suppress non-error output'
     )
     subparser.add_argument(
-        '-o', '--output', metavar='FILE',
+        '-o', '--output', metavar='FILE', default='-',
         help='output signature to this file (default stdout)'
     )
     subparser.add_argument(

--- a/src/sourmash/cli/sig/inflate.py
+++ b/src/sourmash/cli/sig/inflate.py
@@ -1,0 +1,30 @@
+"""borrow abundances from one signature => one or more other signatures"""
+
+from sourmash.cli.utils import (add_moltype_args, add_ksize_arg,
+                                add_picklist_args)
+
+
+def subparser(subparsers):
+    subparser = subparsers.add_parser('inflate')
+    subparser.add_argument('signature_from')
+    subparser.add_argument('other_sigs', nargs='+')
+    subparser.add_argument(
+        '-q', '--quiet', action='store_true',
+        help='suppress non-error output'
+    )
+    subparser.add_argument(
+        '-o', '--output', metavar='FILE',
+        help='output signature to this file (default stdout)'
+    )
+    subparser.add_argument(
+        '-f', '--force', action='store_true',
+        help='try to load all files as signatures'
+    )
+    add_ksize_arg(subparser, 31)
+    add_moltype_args(subparser)
+    add_picklist_args(subparser)
+
+
+def main(args):
+    import sourmash
+    return sourmash.sig.__main__.inflate(args)

--- a/src/sourmash/cli/sig/subtract.py
+++ b/src/sourmash/cli/sig/subtract.py
@@ -19,6 +19,10 @@ def subparser(subparsers):
         '--flatten', action='store_true',
         help='remove abundance from signatures before subtracting'
     )
+    subparser.add_argument(
+        '-A', '--abundances-from', metavar='FILE',
+        help='intersect with & take abundances from this signature'
+    )
     add_ksize_arg(subparser, 31)
     add_moltype_args(subparser)
 

--- a/src/sourmash/minhash.py
+++ b/src/sourmash/minhash.py
@@ -779,10 +779,15 @@ class MinHash(RustObject):
         return new_mh
 
     def inflate(self, from_mh):
-        "return a new MinHash object with abundances taken from 'from_mh'"
+        """return a new MinHash object with abundances taken from 'from_mh'
+
+        note that this implicitly does an intersection: hashes that have
+        no abundance in 'from_mh' are set to abundance 0 and removed from
+        'self'.
+        """
         if not self.track_abundance and from_mh.track_abundance:
             orig_abunds = from_mh.hashes
-            abunds = { h: orig_abunds[h] for h in self.hashes }
+            abunds = { h: orig_abunds.get(h, 0) for h in self.hashes }
 
             abund_mh = from_mh.copy_and_clear()
 

--- a/src/sourmash/sig/__main__.py
+++ b/src/sourmash/sig/__main__.py
@@ -461,7 +461,7 @@ def intersect(args):
     # start loading!
     progress = sourmash_args.SignatureLoadingProgress()
     loader = sourmash_args.load_many_signatures(args.signatures,
-                                                ksize=args.ksize,
+                                                ksize=ksize,
                                                 moltype=moltype,
                                                 picklist=picklist,
                                                 progress=progress,
@@ -481,7 +481,7 @@ def intersect(args):
 
         mins.intersection_update(sigobj.minhash.hashes)
 
-    if len(progress) == 0:
+    if len(progress) < 2:
         error("no signatures to intersect!?")
         sys.exit(-1)
 
@@ -548,7 +548,7 @@ def inflate(args):
 
             save_sigs.add(inflated_sigobj)
 
-    if len(save_sigs) == 0:
+    if len(progress) == 0:
         error("no signatures to inflate!?")
         sys.exit(-1)
 

--- a/src/sourmash/sig/__main__.py
+++ b/src/sourmash/sig/__main__.py
@@ -554,11 +554,11 @@ def subtract(args):
         error("no signatures to subtract!?")
         sys.exit(-1)
 
-    # @CTB did signatures get flattened before?
+    # build new minhash with new mins
     subtract_mh = from_sigobj.minhash.copy_and_clear().flatten()
     subtract_mh.add_many(subtract_mins)
 
-    # borrow abundances from a signature?
+    # borrow abundances from somewhere?
     if args.abundances_from:
         notify(f'loading signature from {args.abundances_from}, keeping abundances')
         abund_sig = sourmash.load_one_signature(args.abundances_from,

--- a/src/sourmash/sig/__main__.py
+++ b/src/sourmash/sig/__main__.py
@@ -461,7 +461,7 @@ def intersect(args):
     # start loading!
     progress = sourmash_args.SignatureLoadingProgress()
     loader = sourmash_args.load_many_signatures(args.signatures,
-                                                ksize=ksize,
+                                                ksize=args.ksize,
                                                 moltype=moltype,
                                                 picklist=picklist,
                                                 progress=progress,
@@ -480,10 +480,6 @@ def intersect(args):
                 sys.exit(-1)
 
         mins.intersection_update(sigobj.minhash.hashes)
-
-    if len(progress) < 2:
-        error("no signatures to intersect!?")
-        sys.exit(-1)
 
     # forcibly turn off track_abundance, unless --abundances-from set.
     intersect_mh = first_sig.minhash.copy_and_clear().flatten()

--- a/src/sourmash/sig/__main__.py
+++ b/src/sourmash/sig/__main__.py
@@ -525,6 +525,11 @@ def inflate(args):
     ksize = inflate_from_mh.ksize
     moltype = inflate_from_mh.moltype
 
+    if not inflate_from_mh.track_abundance:
+        error(f"ERROR: signature '{inflate_sig.name}' from ")
+        error(f"file '{args.signature_from}' has no abundances.")
+        sys.exit(-1)
+
     # start loading!
     progress = sourmash_args.SignatureLoadingProgress()
     loader = sourmash_args.load_many_signatures(args.other_sigs,
@@ -543,7 +548,7 @@ def inflate(args):
 
             save_sigs.add(inflated_sigobj)
 
-    if len(progress) == 0:
+    if len(save_sigs) == 0:
         error("no signatures to inflate!?")
         sys.exit(-1)
 

--- a/src/sourmash/sig/__main__.py
+++ b/src/sourmash/sig/__main__.py
@@ -484,7 +484,7 @@ def intersect(args):
         error("no signatures to merge!?")
         sys.exit(-1)
 
-    # @CTB did signatures get flattened before?
+    # forcibly turn off track_abundance, unless --abundances-from set.
     intersect_mh = first_sig.minhash.copy_and_clear().flatten()
     intersect_mh.add_many(mins)
 

--- a/tests/test_cmd_signature.py
+++ b/tests/test_cmd_signature.py
@@ -614,6 +614,59 @@ def test_sig_inflate_2(runtmp):
     assert actual_inflate_sig.minhash == test_mh
 
 
+def test_sig_inflate_3(runtmp):
+    # should fail on flat first sig
+    sig47 = utils.get_test_data('track_abund/47.fa.sig')
+    sig63 = utils.get_test_data('63.fa.sig')
+
+    with pytest.raises(SourmashCommandFailed) as exc:
+        runtmp.run_sourmash('sig', 'inflate', sig63, sig47)
+
+    assert 'has no abundances' in runtmp.last_result.err
+
+
+def test_sig_inflate_4_picklist(runtmp):
+    # try out picklists
+    sig47 = utils.get_test_data('track_abund/47.fa.sig')
+    sig63 = utils.get_test_data('63.fa.sig')
+    sig47_flat = utils.get_test_data('47.fa.sig')
+
+    ss63 = sourmash.load_one_signature(sig63, ksize=31)
+
+    picklist = _write_file(runtmp, 'pl.csv', ['md5', ss63.md5sum()])
+
+    print(ss63.md5sum())
+
+
+    runtmp.run_sourmash('sig', 'inflate', sig47, sig63, sig47_flat,
+                        '--picklist', f'pl.csv:md5:md5')
+
+    # stdout should be new signature
+    out = runtmp.last_result.out
+    err = runtmp.last_result.err
+
+    actual_inflate_sig = sourmash.load_one_signature(out)
+
+    # actually do an inflation ourselves for the test
+    mh47 = sourmash.load_one_signature(sig47).minhash
+    mh63 = sourmash.load_one_signature(sig63).minhash
+    mh47_abunds = mh47.hashes
+    mh63_mins = set(mh63.hashes.keys())
+
+    # get the set of mins that are in common
+    mh63_mins.intersection_update(mh47_abunds)
+
+    # take abundances from mh47 & create new sig
+    mh47_abunds = { k: mh47_abunds[k] for k in mh63_mins }
+    test_mh = mh47.copy_and_clear()
+    test_mh.set_abundances(mh47_abunds)
+
+    print(actual_inflate_sig.minhash)
+    print(out)
+
+    assert actual_inflate_sig.minhash == test_mh
+
+
 @utils.in_tempdir
 def test_sig_subtract_1(c):
     # subtract of 63 from 47

--- a/tests/test_cmd_signature.py
+++ b/tests/test_cmd_signature.py
@@ -667,6 +667,17 @@ def test_sig_inflate_4_picklist(runtmp):
     assert actual_inflate_sig.minhash == test_mh
 
 
+def test_sig_inflate_5_bad_moltype(runtmp):
+    # should fail when no signatures match moltype
+    sig47 = utils.get_test_data('track_abund/47.fa.sig')
+    prot = utils.get_test_data('prot/protein.zip')
+
+    with pytest.raises(SourmashCommandFailed) as exc:
+        runtmp.run_sourmash('sig', 'inflate', sig47, prot)
+
+    assert 'no signatures to inflate' in runtmp.last_result.err
+
+
 @utils.in_tempdir
 def test_sig_subtract_1(c):
     # subtract of 63 from 47
@@ -718,6 +729,18 @@ def test_sig_subtract_1_abund(runtmp):
     # this is really just to make sure that we have a sketch with some
     # abundances in it...
     assert max(distinct_abunds) > 1
+
+
+def test_sig_subtract_1_abund_is_flat(runtmp):
+    # subtract 63 from 47, with abundances borrowed from 47
+
+    c = runtmp
+    sig47 = utils.get_test_data('track_abund/47.fa.sig')
+    sig63 = utils.get_test_data('track_abund/63.fa.sig')
+    sig47_flat = utils.get_test_data('47.fa.sig')
+
+    with pytest.raises(SourmashCommandFailed):
+        c.run_sourmash('sig', 'subtract', sig47, sig63, '-A', sig47_flat)
 
 
 def test_sig_subtract_1_flatten(runtmp):
@@ -795,6 +818,17 @@ def test_sig_subtract_4_ksize_succeed(c):
 
     c.run_sourmash('sig', 'subtract', sig47, sig2, '-k', '31')
     assert 'loaded and subtracted 1 signatures' in c.last_result.err
+
+
+def test_sig_subtract_5_bad_moltype(runtmp):
+    # should fail when no matching sigs
+    sig47 = utils.get_test_data('47.fa.sig')
+    prot = utils.get_test_data('prot/protein.zip')
+
+    with pytest.raises(SourmashCommandFailed) as exc:
+        runtmp.run_sourmash('sig', 'subtract', '-k', '31', sig47, prot)
+
+    assert 'no signatures to subtract' in runtmp.last_result.err
 
 
 def test_sig_rename_1(runtmp):

--- a/tests/test_cmd_signature.py
+++ b/tests/test_cmd_signature.py
@@ -583,6 +583,50 @@ def test_sig_subtract_1(c):
     assert set(actual_subtract_sig.minhash.hashes.keys()) == set(mins)
 
 
+def test_sig_subtract_1_abund(runtmp):
+    # subtract 63 from 47, with abundances borrowed from 47
+
+    c = runtmp
+    sig47 = utils.get_test_data('track_abund/47.fa.sig')
+    sig63 = utils.get_test_data('track_abund/63.fa.sig')
+    c.run_sourmash('sig', 'subtract', sig47, sig63, '-A', sig47)
+
+    # stdout should be new signature
+    out = c.last_result.out
+
+    test1_sig = sourmash.load_one_signature(sig47)
+    test2_sig = sourmash.load_one_signature(sig63)
+    actual_subtract_sig = sourmash.load_one_signature(out)
+    assert actual_subtract_sig.minhash.track_abundance
+
+    mins = set(test1_sig.minhash.hashes.keys())
+    mins -= set(test2_sig.minhash.hashes.keys())
+
+    assert set(actual_subtract_sig.minhash.hashes.keys()) == set(mins)
+
+
+def test_sig_subtract_1_flatten(runtmp):
+    # subtract 63 from 47, with abund signatures originally and --flatten
+
+    c = runtmp
+    sig47 = utils.get_test_data('track_abund/47.fa.sig')
+    sig63 = utils.get_test_data('track_abund/63.fa.sig')
+    c.run_sourmash('sig', 'subtract', sig47, sig63, '--flatten')
+
+    # stdout should be new signature
+    out = c.last_result.out
+
+    test1_sig = sourmash.load_one_signature(sig47)
+    test2_sig = sourmash.load_one_signature(sig63)
+    actual_subtract_sig = sourmash.load_one_signature(out)
+    assert not actual_subtract_sig.minhash.track_abundance
+
+    mins = set(test1_sig.minhash.hashes.keys())
+    mins -= set(test2_sig.minhash.hashes.keys())
+
+    assert set(actual_subtract_sig.minhash.hashes.keys()) == set(mins)
+
+
 @utils.in_tempdir
 def test_sig_subtract_1_multisig(c):
     # subtract of everything from 47

--- a/tests/test_cmd_signature.py
+++ b/tests/test_cmd_signature.py
@@ -604,6 +604,17 @@ def test_sig_subtract_1_abund(runtmp):
 
     assert set(actual_subtract_sig.minhash.hashes.keys()) == set(mins)
 
+    distinct_abunds = set()
+    actual_sub_hashes = actual_subtract_sig.minhash.hashes
+    sig47_hashes = test1_sig.minhash.hashes
+    for h in mins:
+        assert actual_sub_hashes[h] == sig47_hashes[h]
+        distinct_abunds.add(sig47_hashes[h])
+
+    # this is really just to make sure that we have a sketch with some
+    # abundances in it...
+    assert max(distinct_abunds) > 1
+
 
 def test_sig_subtract_1_flatten(runtmp):
     # subtract 63 from 47, with abund signatures originally and --flatten

--- a/tests/test_minhash.py
+++ b/tests/test_minhash.py
@@ -1713,7 +1713,7 @@ def test_inflate():
 
 
 def test_inflate_error():
-    # test behavior of inflate function
+    # test behavior of inflate function with 'self' as an abund sketch
     scaled = _get_scaled_for_max_hash(35)
     mh = MinHash(0, 4, track_abundance=True, scaled=scaled)
     mh2 = MinHash(0, 4, track_abundance=True, scaled=scaled)
@@ -1744,6 +1744,39 @@ def test_inflate_error():
         mh = mh.inflate(mh2)
 
     assert "inflate operates on a flat MinHash and takes a MinHash object with track_abundance=True" in str(exc.value)
+
+
+def test_inflate_not_a_subset():
+    # test behavior of inflate function when 'from_mh' is not a subset.
+    scaled = _get_scaled_for_max_hash(35)
+    mh = MinHash(0, 4, track_abundance=False, scaled=scaled)
+    mh2 = MinHash(0, 4, track_abundance=True, scaled=scaled)
+    assert mh._max_hash == 35
+
+    mh.add_hash(10)
+    mh.add_hash(20)
+    mh.add_hash(30)
+
+    assert mh.hashes[10] == 1
+    assert mh.hashes[20] == 1
+    assert mh.hashes[30] == 1
+
+    mh2.add_hash(10)
+    mh2.add_hash(10)
+    mh2.add_hash(10)
+    mh2.add_hash(30)
+    mh2.add_hash(30)
+    mh2.add_hash(30)
+
+    assert mh2.hashes[10] == 3
+    assert 20 not in mh2.hashes
+    assert mh2.hashes[30] == 3
+
+    mh3 = mh.inflate(mh2)
+
+    assert mh3.hashes[10] == 3
+    assert 20 not in mh3.hashes
+    assert mh3.hashes[30] == 3
 
 
 def test_add_kmer(track_abundance):

--- a/tests/test_minhash.py
+++ b/tests/test_minhash.py
@@ -1775,7 +1775,7 @@ def test_inflate_not_a_subset():
     mh3 = mh.inflate(mh2)
 
     assert mh3.hashes[10] == 3
-    assert 20 not in mh3.hashes
+    assert 20 not in mh3.hashes # should intersect, in this case.
     assert mh3.hashes[30] == 3
 
 


### PR DESCRIPTION
This PR adds `-A/--abundance-from` to the `sourmash sig subtract` command, per #1888.

It also:
* implements implicit intersection in `MinHash.inflate(...)` in the situation where `self` is not a subset of `from_mh`
* adds tests for this feature of `MinHash.inflate(...)` 
* cleans up the abundance borrowing code in `sourmash sig intersect -A` to use `MinHash.inflate(...)`
* adds `sourmash sig inflate`

Fixes https://github.com/sourmash-bio/sourmash/issues/1888
Fixes https://github.com/sourmash-bio/sourmash/issues/1706

TODO:
- [x] add more tests for `sourmash sig inflate`
- [x] add docs for `sourmash sig inflate`
- [x] add a note about other places where `save_signatures` is being used (now in https://github.com/sourmash-bio/sourmash/issues/1890)