### PR TITLE
[MRG] fix SBT subdirectory loading error

### DIFF
--- a/src/sourmash/sbt.py
+++ b/src/sourmash/sbt.py
@@ -831,8 +831,12 @@ class SBT(Index):
         sbt_fn = os.path.join(dirname, sbt_name)
         if not sbt_fn.endswith('.sbt.json') and tempfile is None:
             sbt_fn += '.sbt.json'
-        with open(sbt_fn) as fp:
-            jnodes = json.load(fp)
+
+        try:
+            with open(sbt_fn) as fp:
+                jnodes = json.load(fp)
+        except NotADirectoryError as exc:
+            raise ValueError(str(exc))
 
         if tempfile is not None:
             tempfile.close()

--- a/tests/test_sbt.py
+++ b/tests/test_sbt.py
@@ -1205,3 +1205,15 @@ def test_build_sbt_json_with_dups_exists(runtmp):
     assert len(sbt_sigs) == 4
 
     assert all_sigs == sbt_sigs
+
+
+def test_load_fail_on_file_not_dir(runtmp):
+    # make sure the load function raises a ValueError for {filename}/sbt,
+    # rather than a NotADirectoryError
+
+    filename = runtmp.output('foo')
+    with open(filename, 'wt') as fp:
+        fp.write('something')
+
+    with pytest.raises(ValueError) as exc:
+        x = SBT.load(runtmp.output('foo/bar.sbt.json'))


### PR DESCRIPTION
This PR fixes a minor problem where trying to load `{filename}/sbt.json` where filename is NOT a directory raises a `NotADirectoryError` rather than a `ValueError`, which is what `_load_database` expects.
