### PR TITLE
[MRG] Oxidize ZipStorage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,22 @@
 version = 3
 
 [[package]]
+name = "Inflector"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
+
+[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
+name = "aliasable"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
 
 [[package]]
 name = "assert_matches"
@@ -636,6 +648,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
+name = "ouroboros"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f31a3b678685b150cba82b702dcdc5e155893f63610cf388d30cd988d4ca2bf"
+dependencies = [
+ "aliasable",
+ "ouroboros_macro",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "ouroboros_macro"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "084fd65d5dd8b3772edccb5ffd1e4b7eba43897ecd0f9401e330e8c542959408"
+dependencies = [
+ "Inflector",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "piz"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -998,6 +1034,7 @@ dependencies = [
  "nohash-hasher",
  "num-iter",
  "once_cell",
+ "ouroboros",
  "piz",
  "primal-check",
  "proptest",
@@ -1014,6 +1051,12 @@ dependencies = [
  "wasm-bindgen-test",
  "web-sys",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "static_assertions"

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ include/sourmash.h: src/core/src/lib.rs \
                     src/core/src/ffi/nodegraph.rs \
                     src/core/src/ffi/index/mod.rs \
                     src/core/src/ffi/index/revindex.rs \
+                    src/core/src/ffi/storage.rs \
                     src/core/src/errors.rs
 	cd src/core && \
 	RUSTC_BOOTSTRAP=1 cbindgen -c cbindgen.toml . -o ../../$@

--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -1,6 +1,10 @@
+import os
 import random
+from pathlib import Path
+from tempfile import mkdtemp
 
 
+from sourmash.sbt_storage import ZipStorage
 from sourmash.minhash import MinHash
 
 
@@ -139,3 +143,28 @@ class PeakmemMinAbundanceSuite(PeakmemMinHashSuite):
     def setup(self):
         PeakmemMinHashSuite.setup(self)
         self.mh = MinHash(500, 21, track_abundance=True)
+
+####################
+
+class TimeZipStorageSuite:
+
+    def setup(self):
+        self.tempdir = mkdtemp()
+        self.zipfile = Path(self.tempdir) / "temp.zip"
+
+        with ZipStorage(self.zipfile, mode="w") as storage:
+            # one big-ish entry
+            storage.save("sig1", b"9" * 1_000_000)
+            for i in range(100_000):
+                # just so we have lots of entries
+                storage.save(str(i), b"0")
+            storage.flush()
+
+    def time_load_from_zipstorage(self):
+        with ZipStorage(self.zipfile) as storage:
+            for i in range(20):
+                storage.load("sig1")
+
+    def teardown(self):
+        self.zipfile.unlink()
+        os.rmdir(self.tempdir)

--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -165,5 +165,10 @@ class TimeZipStorageSuite:
             for i in range(20):
                 storage.load("sig1")
 
+    def time_load_small_from_zipstorage(self):
+        with ZipStorage(self.zipfile.name) as storage:
+            for i in range(20):
+                storage.load("99999")
+
     def teardown(self):
         self.zipfile.close()

--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -172,3 +172,31 @@ class TimeZipStorageSuite:
 
     def teardown(self):
         self.zipfile.close()
+
+
+class PeakmemZipStorageSuite:
+    def setup(self):
+        import zipfile
+        self.zipfile = NamedTemporaryFile()
+
+        with zipfile.ZipFile(self.zipfile, mode='w',
+                          compression=zipfile.ZIP_STORED) as storage:
+            for i in range(100_000):
+                # just so we have lots of entries
+                storage.writestr(str(i), b"0")
+            # one big-ish entry
+            storage.writestr("sig1", b"9" * 1_000_000)
+
+
+    def peakmem_load_from_zipstorage(self):
+        with ZipStorage(self.zipfile.name) as storage:
+            for i in range(20):
+                storage.load("sig1")
+
+    def peakmem_load_small_from_zipstorage(self):
+        with ZipStorage(self.zipfile.name) as storage:
+            for i in range(20):
+                storage.load("99999")
+
+    def teardown(self):
+        self.zipfile.close()

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -3,4 +3,4 @@ channels:
   - defaults
 dependencies:
   - rust
-  - python =3.7
+  - python =3.8

--- a/flake.lock
+++ b/flake.lock
@@ -150,11 +150,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1648607660,
-        "narHash": "sha256-w1B0Yqt8DLlzPOT6qtjj1erQh9aqFkp/u+FcKTqCEdA=",
+        "lastModified": 1648866882,
+        "narHash": "sha256-yMs/RKA9pX47a03zupmQp8/RLRmKzdSDk+h5Yt7K9xU=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "f863d3f6c2339e80dacbd5895003d9b2e1eb4f8a",
+        "rev": "7c90e17cd7c0b9e81d5b23f78b482088ac9961d1",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -49,11 +49,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1639947939,
-        "narHash": "sha256-pGsM8haJadVP80GFq4xhnSpNitYNQpaXk4cnA796Cso=",
+        "lastModified": 1648544490,
+        "narHash": "sha256-EoBDcccV70tfz2LAs5lK0BjC7en5mzUVlgLsd5E6DW4=",
         "owner": "nix-community",
         "repo": "naersk",
-        "rev": "2fc8ce9d3c025d59fee349c1f80be9785049d653",
+        "rev": "e30ef9a5ce9b3de8bb438f15829c50f9525ca730",
         "type": "github"
       },
       "original": {
@@ -64,11 +64,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1645937171,
-        "narHash": "sha256-n9f9GZBNMe8UMhcgmmaXNObkH01jjgp7INMrUgBgcy4=",
+        "lastModified": 1648219316,
+        "narHash": "sha256-Ctij+dOi0ZZIfX5eMhgwugfvB+WZSrvVNAyAuANOsnQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "22dc22f8cedc58fcb11afe1acb08e9999e78be9c",
+        "rev": "30d3d79b7d3607d56546dd2a6b49e156ba0ec634",
         "type": "github"
       },
       "original": {
@@ -150,11 +150,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1645928338,
-        "narHash": "sha256-pNbkG19Nb4QTNRCIWwxv06JKKJNCUrDzgRrriEd7W1A=",
+        "lastModified": 1648607660,
+        "narHash": "sha256-w1B0Yqt8DLlzPOT6qtjj1erQh9aqFkp/u+FcKTqCEdA=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "4f6e6588b07427cd8ddc99b664bf0fab02799804",
+        "rev": "f863d3f6c2339e80dacbd5895003d9b2e1eb4f8a",
         "type": "github"
       },
       "original": {
@@ -165,11 +165,11 @@
     },
     "utils": {
       "locked": {
-        "lastModified": 1644229661,
-        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
+        "lastModified": 1648297722,
+        "narHash": "sha256-W+qlPsiZd8F3XkzXOzAoR+mpFqzm3ekQkJNa+PIh1BQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
+        "rev": "0f8662f1319ad6abf89b3380dd2722369fc51ade",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -77,6 +77,20 @@
             DYLD_LIBRARY_PATH = "${self.packages.${system}.lib}/lib";
             NO_BUILD = "1";
           };
+          docker =
+            let
+              bin = self.defaultPackage.${system};
+            in
+            pkgs.dockerTools.buildLayeredImage {
+              name = bin.pname;
+              tag = bin.version;
+              contents = [ bin ];
+
+              config = {
+                Cmd = [ "/bin/sourmash" ];
+                WorkingDir = "/";
+              };
+            };
         };
 
         defaultPackage = self.packages.${system}.sourmash;

--- a/include/sourmash.h
+++ b/include/sourmash.h
@@ -58,6 +58,8 @@ typedef struct SourmashSearchResult SourmashSearchResult;
 
 typedef struct SourmashSignature SourmashSignature;
 
+typedef struct SourmashZipStorage SourmashZipStorage;
+
 /**
  * Represents a string.
  */
@@ -455,5 +457,24 @@ void sourmash_str_free(SourmashStr *s);
 SourmashStr sourmash_str_from_cstr(const char *s);
 
 char sourmash_translate_codon(const char *codon);
+
+SourmashStr **zipstorage_filenames(const SourmashZipStorage *ptr, uintptr_t *size);
+
+void zipstorage_free(SourmashZipStorage *ptr);
+
+SourmashStr **zipstorage_list_sbts(const SourmashZipStorage *ptr, uintptr_t *size);
+
+const uint8_t *zipstorage_load(const SourmashZipStorage *ptr,
+                               const char *path_ptr,
+                               uintptr_t insize,
+                               uintptr_t *size);
+
+SourmashZipStorage *zipstorage_new(const char *ptr, uintptr_t insize);
+
+SourmashStr zipstorage_path(const SourmashZipStorage *ptr);
+
+void zipstorage_set_subdir(SourmashZipStorage *ptr, const char *path_ptr, uintptr_t insize);
+
+SourmashStr zipstorage_subdir(const SourmashZipStorage *ptr);
 
 #endif /* SOURMASH_H_INCLUDED */

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,8 +20,9 @@ classifiers =
     Operating System :: POSIX :: Linux
     Operating System :: MacOS :: MacOS X
     Programming Language :: Rust
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Topic :: Scientific/Engineering :: Bio-Informatics
 project_urls = 
     Documentation = https://sourmash.readthedocs.io
@@ -42,7 +43,7 @@ install_requires =
     scipy
     deprecation>=2.0.6
     cachetools>=4,<5
-python_requires = >=3.7
+python_requires = >=3.8
 
 [bdist_wheel]
 universal = 1

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -47,6 +47,7 @@ twox-hash = "1.6.0"
 vec-collections = "0.3.4"
 piz = "0.4.0"
 memmap2 = "0.5.0"
+ouroboros = "0.15.0"
 
 [dev-dependencies]
 assert_matches = "1.3.0"

--- a/src/core/src/ffi/mod.rs
+++ b/src/core/src/ffi/mod.rs
@@ -12,6 +12,7 @@ pub mod index;
 pub mod minhash;
 pub mod nodegraph;
 pub mod signature;
+pub mod storage;
 
 use std::ffi::CStr;
 use std::os::raw::c_char;

--- a/src/core/src/ffi/storage.rs
+++ b/src/core/src/ffi/storage.rs
@@ -18,7 +18,7 @@ unsafe fn zipstorage_new(ptr: *const c_char, insize: usize) -> Result<*mut Sourm
         let path = slice::from_raw_parts(ptr as *mut u8, insize);
         std::str::from_utf8(path)?
     };
-    let zipstorage = ZipStorage::new(path)?;
+    let zipstorage = ZipStorage::from_file(path)?;
 
     Ok(SourmashZipStorage::from_rust(zipstorage))
 }

--- a/src/core/src/ffi/storage.rs
+++ b/src/core/src/ffi/storage.rs
@@ -1,0 +1,140 @@
+use std::os::raw::c_char;
+use std::slice;
+
+use crate::ffi::utils::{ForeignObject, SourmashStr};
+use crate::prelude::*;
+use crate::storage::ZipStorage;
+
+pub struct SourmashZipStorage;
+
+impl ForeignObject for SourmashZipStorage {
+    type RustObject = ZipStorage<'static>;
+}
+
+ffi_fn! {
+unsafe fn zipstorage_new(ptr: *const c_char, insize: usize) -> Result<*mut SourmashZipStorage> {
+    let path = {
+        assert!(!ptr.is_null());
+        let path = slice::from_raw_parts(ptr as *mut u8, insize);
+        std::str::from_utf8(path)?
+    };
+    let zipstorage = ZipStorage::new(path)?;
+
+    Ok(SourmashZipStorage::from_rust(zipstorage))
+}
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn zipstorage_free(ptr: *mut SourmashZipStorage) {
+    SourmashZipStorage::drop(ptr);
+}
+
+ffi_fn! {
+unsafe fn zipstorage_load(ptr: *const SourmashZipStorage,
+    path_ptr: *const c_char,
+    insize: usize,
+    size: *mut usize) -> Result<*const u8> {
+
+    let storage = SourmashZipStorage::as_rust(ptr);
+
+    let path = {
+        assert!(!path_ptr.is_null());
+        let path = slice::from_raw_parts(path_ptr as *mut u8, insize);
+        std::str::from_utf8(path)?
+    };
+
+    let buffer = storage.load(path)?;
+
+    let b = buffer.into_boxed_slice();
+    *size = b.len();
+
+    Ok(Box::into_raw(b) as *const u8)
+}
+}
+
+ffi_fn! {
+unsafe fn zipstorage_list_sbts(
+    ptr: *const SourmashZipStorage,
+    size: *mut usize,
+) -> Result<*mut *mut SourmashStr> {
+    let storage = SourmashZipStorage::as_rust(ptr);
+
+    let sbts = storage.list_sbts()?;
+
+    // FIXME: use the ForeignObject trait, maybe define new method there...
+    let ptr_sigs: Vec<*mut SourmashStr> = sbts
+        .into_iter()
+        .map(|x| Box::into_raw(Box::new(SourmashStr::from_string(x))) as *mut SourmashStr)
+        .collect();
+
+    let b = ptr_sigs.into_boxed_slice();
+    *size = b.len();
+
+    Ok(Box::into_raw(b) as *mut *mut SourmashStr)
+}
+}
+
+ffi_fn! {
+unsafe fn zipstorage_filenames(
+    ptr: *const SourmashZipStorage,
+    size: *mut usize,
+) -> Result<*mut *mut SourmashStr> {
+    let storage = SourmashZipStorage::as_rust(ptr);
+
+    let files = storage.filenames()?;
+
+    // FIXME: use the ForeignObject trait, maybe define new method there...
+    let ptr_sigs: Vec<*mut SourmashStr> = files
+        .into_iter()
+        .map(|x| Box::into_raw(Box::new(SourmashStr::from_string(x))) as *mut SourmashStr)
+        .collect();
+
+    let b = ptr_sigs.into_boxed_slice();
+    *size = b.len();
+
+    Ok(Box::into_raw(b) as *mut *mut SourmashStr)
+}
+}
+
+ffi_fn! {
+unsafe fn zipstorage_set_subdir(
+    ptr: *mut SourmashZipStorage,
+    path_ptr: *const c_char,
+    insize: usize,
+) -> Result<()> {
+    let storage = SourmashZipStorage::as_rust_mut(ptr);
+
+    let path = {
+        assert!(!path_ptr.is_null());
+        let path = slice::from_raw_parts(path_ptr as *mut u8, insize);
+        std::str::from_utf8(path)?
+    };
+
+    storage.set_subdir(path.to_string());
+    Ok(())
+}
+}
+
+ffi_fn! {
+unsafe fn zipstorage_path(ptr: *const SourmashZipStorage) -> Result<SourmashStr> {
+    let storage = SourmashZipStorage::as_rust(ptr);
+
+    if let Some(ref path) = storage.path() {
+        Ok(path.clone().into())
+    } else {
+        Ok("".into())
+    }
+}
+}
+
+ffi_fn! {
+unsafe fn zipstorage_subdir(ptr: *const SourmashZipStorage) -> Result<SourmashStr> {
+    let storage = SourmashZipStorage::as_rust(ptr);
+
+    if let Some(ref path) = storage.subdir() {
+        Ok(path.clone().into())
+    } else {
+        Ok("".into())
+    }
+}
+}

--- a/src/core/src/ffi/storage.rs
+++ b/src/core/src/ffi/storage.rs
@@ -8,7 +8,7 @@ use crate::storage::ZipStorage;
 pub struct SourmashZipStorage;
 
 impl ForeignObject for SourmashZipStorage {
-    type RustObject = ZipStorage<'static>;
+    type RustObject = ZipStorage;
 }
 
 ffi_fn! {

--- a/src/core/src/storage.rs
+++ b/src/core/src/storage.rs
@@ -257,7 +257,7 @@ impl ZipStorage {
             metadata_builder: |archive: &piz::ZipArchive| {
                 archive
                     .entries()
-                    .into_iter()
+                    .iter()
                     .map(|entry| (entry.path.as_os_str(), entry))
                     .collect()
             },

--- a/src/core/src/storage.rs
+++ b/src/core/src/storage.rs
@@ -198,12 +198,12 @@ impl<'a> Storage for ZipStorage<'a> {
     fn load(&self, path: &str) -> Result<Vec<u8>, Error> {
         let load_from_archive = |archive: &piz::ZipArchive<'_>, path: &str| {
             // FIXME error
-            let entry = match find_path(&archive, path) {
+            let entry = match find_path(archive, path) {
                 Some(entry) => Ok(entry),
                 None => {
                     if let Some(subdir) = &self.subdir {
-                        find_path(&archive, subdir.to_owned() + path)
-                            .ok_or_else(|| StorageError::EmptyPathError)
+                        find_path(archive, subdir.to_owned() + path)
+                            .ok_or(StorageError::EmptyPathError)
                     } else {
                         Err(StorageError::EmptyPathError)
                     }
@@ -255,9 +255,8 @@ impl<'a> ZipStorage<'a> {
         Ok(Self {
             mapping: Some(mapping),
             archive: None,
-            subdir: subdir,
             path: Some(location.to_string()),
-            //metadata: tree,
+            subdir, //metadata: tree,
         })
     }
 
@@ -274,11 +273,10 @@ impl<'a> ZipStorage<'a> {
         Ok(Self {
             archive: Some(archive),
             mapping: None,
-            subdir: subdir,
             path: None,
-            /*            metadata: archive
-            .as_tree()
-            .map_err(|_| StorageError::EmptyPathError)?, */
+            subdir, /*            metadata: archive
+                    .as_tree()
+                    .map_err(|_| StorageError::EmptyPathError)?, */
         })
     }
 
@@ -311,7 +309,7 @@ impl<'a> ZipStorage<'a> {
         };
 
         if let Some(archive) = &self.archive {
-            sbts_in_archive(&archive)
+            sbts_in_archive(archive)
         } else {
             //FIXME
             let archive = piz::ZipArchive::new((&self.mapping.as_ref()).unwrap())
@@ -330,7 +328,7 @@ impl<'a> ZipStorage<'a> {
         };
 
         if let Some(archive) = &self.archive {
-            filenames(&archive)
+            filenames(archive)
         } else {
             //FIXME
             let archive = piz::ZipArchive::new((&self.mapping.as_ref()).unwrap())

--- a/src/core/tests/storage.rs
+++ b/src/core/tests/storage.rs
@@ -1,4 +1,3 @@
-use std::fs::File;
 use std::path::PathBuf;
 
 use sourmash::storage::{Storage, ZipStorage};
@@ -8,25 +7,7 @@ fn zipstorage_load_file() -> Result<(), Box<dyn std::error::Error>> {
     let mut filename = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     filename.push("../../tests/test-data/v6.sbt.zip");
 
-    let zs = ZipStorage::new(filename.to_str().unwrap())?;
-
-    let data = zs.load("v6.sbt.json")?;
-
-    let description: serde_json::Value = serde_json::from_slice(&data[..])?;
-    assert_eq!(description["version"], 6);
-
-    Ok(())
-}
-
-#[test]
-fn zipstorage_load_slice() -> Result<(), Box<dyn std::error::Error>> {
-    let mut filename = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    filename.push("../../tests/test-data/v6.sbt.zip");
-
-    let zip_file = File::open(filename)?;
-    let mapping = unsafe { memmap2::Mmap::map(&zip_file)? };
-
-    let zs = ZipStorage::from_slice(&mapping)?;
+    let zs = ZipStorage::from_file(filename.to_str().unwrap())?;
 
     let data = zs.load("v6.sbt.json")?;
 
@@ -41,12 +22,9 @@ fn zipstorage_load_manifest() -> Result<(), Box<dyn std::error::Error>> {
     let mut filename = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     filename.push("../../tests/test-data/prot/protein.sbt.zip");
 
-    let zs = ZipStorage::new(filename.to_str().unwrap())?;
+    let zs = ZipStorage::from_file(filename.to_str().unwrap())?;
 
-    let data = zs.load("protein.manifest.csv").expect("error loading file");
-
-    //let description: serde_json::Value = serde_json::from_slice(&data[..])?;
-    //assert_eq!(description["version"], 6);
+    let _data = zs.load("protein.manifest.csv").expect("error loading file");
 
     Ok(())
 }
@@ -56,10 +34,7 @@ fn zipstorage_list_sbts() -> Result<(), Box<dyn std::error::Error>> {
     let mut filename = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     filename.push("../../tests/test-data/v6.sbt.zip");
 
-    let zip_file = File::open(filename)?;
-    let mapping = unsafe { memmap2::Mmap::map(&zip_file)? };
-
-    let zs = ZipStorage::from_slice(&mapping)?;
+    let zs = ZipStorage::from_file(filename.to_str().unwrap())?;
 
     let sbts = zs.list_sbts()?;
 

--- a/src/core/tests/storage.rs
+++ b/src/core/tests/storage.rs
@@ -35,3 +35,35 @@ fn zipstorage_load_slice() -> Result<(), Box<dyn std::error::Error>> {
 
     Ok(())
 }
+
+#[test]
+fn zipstorage_load_manifest() -> Result<(), Box<dyn std::error::Error>> {
+    let mut filename = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    filename.push("../../tests/test-data/prot/protein.sbt.zip");
+
+    let zs = ZipStorage::new(filename.to_str().unwrap())?;
+
+    let data = zs.load("protein.manifest.csv").expect("error loading file");
+
+    //let description: serde_json::Value = serde_json::from_slice(&data[..])?;
+    //assert_eq!(description["version"], 6);
+
+    Ok(())
+}
+
+#[test]
+fn zipstorage_list_sbts() -> Result<(), Box<dyn std::error::Error>> {
+    let mut filename = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    filename.push("../../tests/test-data/v6.sbt.zip");
+
+    let zip_file = File::open(filename)?;
+    let mapping = unsafe { memmap2::Mmap::map(&zip_file)? };
+
+    let zs = ZipStorage::from_slice(&mapping)?;
+
+    let sbts = zs.list_sbts()?;
+
+    assert_eq!(sbts.len(), 1);
+
+    Ok(())
+}

--- a/src/sourmash/index/__init__.py
+++ b/src/sourmash/index/__init__.py
@@ -607,7 +607,7 @@ class ZipFileLinearIndex(Index):
         if not os.path.exists(location):
             raise FileNotFoundError(location)
 
-        storage = ZipStorage(location, read_only=True)
+        storage = ZipStorage(location)
         return cls(storage, traverse_yield_all=traverse_yield_all,
                    use_manifest=use_manifest)
 

--- a/src/sourmash/index/__init__.py
+++ b/src/sourmash/index/__init__.py
@@ -554,7 +554,7 @@ class ZipFileLinearIndex(Index):
         "Load a manifest if one exists"
         try:
             manifest_data = self.storage.load('SOURMASH-MANIFEST.csv')
-        except KeyError:
+        except (KeyError, FileNotFoundError):
             self.manifest = None
         else:
             debug_literal(f'found manifest on load for {self.storage.path}')
@@ -607,7 +607,7 @@ class ZipFileLinearIndex(Index):
         if not os.path.exists(location):
             raise FileNotFoundError(location)
 
-        storage = ZipStorage(location)
+        storage = ZipStorage(location, read_only=True)
         return cls(storage, traverse_yield_all=traverse_yield_all,
                    use_manifest=use_manifest)
 
@@ -616,18 +616,16 @@ class ZipFileLinearIndex(Index):
 
         Note: does not limit signatures to subsets.
         """
-        zf = self.storage.zipfile
-
         # list all the files, without using the Storage interface; currently,
         # 'Storage' does not provide a way to list all the files, so :shrug:.
-        for zipinfo in zf.infolist():
+        for filename in self.storage._filenames():
             # should we load this file? if it ends in .sig OR we are forcing:
-            if zipinfo.filename.endswith('.sig') or \
-               zipinfo.filename.endswith('.sig.gz') or \
+            if filename.endswith('.sig') or \
+               filename.endswith('.sig.gz') or \
                self.traverse_yield_all:
-                fp = zf.open(zipinfo)
-                for ss in load_signatures(fp):
-                    yield ss, zipinfo.filename
+                sig_data = self.storage.load(filename)
+                for ss in load_signatures(sig_data):
+                    yield ss, filename
 
     def signatures(self):
         "Load all signatures in the zip file."
@@ -652,10 +650,10 @@ class ZipFileLinearIndex(Index):
             # if no manifest here, break Storage class encapsulation
             # and go for all the files. (This is necessary to support
             # ad-hoc zipfiles that have no manifests.)
-            for zipinfo in storage.zipfile.infolist():
+            for filename in storage._filenames():
                 # should we load this file? if it ends in .sig OR force:
-                if zipinfo.filename.endswith('.sig') or \
-                   zipinfo.filename.endswith('.sig.gz') or \
+                if filename.endswith('.sig') or \
+                   filename.endswith('.sig.gz') or \
                    self.traverse_yield_all:
                     if selection_dict:
                         select = lambda x: select_signature(x,
@@ -663,7 +661,7 @@ class ZipFileLinearIndex(Index):
                     else:
                         select = lambda x: True
 
-                    data = self.storage.load(zipinfo.filename)
+                    data = self.storage.load(filename)
                     for ss in load_signatures(data):
                         if select(ss):
                             yield ss

--- a/src/sourmash/sbt.py
+++ b/src/sourmash/sbt.py
@@ -625,7 +625,7 @@ class SBT(Index):
             kind = "Zip"
             if not path.endswith('.sbt.zip'):
                 path += '.sbt.zip'
-            storage = ZipStorage(path, read_only=False)
+            storage = ZipStorage(path, mode="w")
             backend = "FSStorage"
 
             assert path[-8:] == '.sbt.zip'
@@ -1435,11 +1435,12 @@ def filter_distance(filter_a, filter_b, n=1000):
 def convert_cmd(name, backend):
     "Convert an SBT to use a different back end."
     from .sbtmh import SigLeaf
-    from .sbt_storage import RwZipStorage
 
     options = backend.split('(')
     backend = options.pop(0)
     backend = backend.lower().strip("'")
+
+    kwargs = {}
 
     if options:
       print(options)
@@ -1454,7 +1455,8 @@ def convert_cmd(name, backend):
     elif backend.lower() in ('redis', 'redisstorage'):
         backend = RedisStorage
     elif backend.lower() in ('zip', 'zipstorage'):
-        backend = RwZipStorage
+        backend = ZipStorage
+        kwargs['mode'] = 'w'
     elif backend.lower() in ('fs', 'fsstorage'):
         backend = FSStorage
         if options:
@@ -1470,6 +1472,6 @@ def convert_cmd(name, backend):
     else:
         error('backend not recognized: {}'.format(backend))
 
-    with backend(*options) as storage:
+    with backend(*options, **kwargs) as storage:
         sbt = SBT.load(name, leaf_loader=SigLeaf.load)
         sbt.save(name, storage=storage)

--- a/src/sourmash/sbt.py
+++ b/src/sourmash/sbt.py
@@ -625,7 +625,7 @@ class SBT(Index):
             kind = "Zip"
             if not path.endswith('.sbt.zip'):
                 path += '.sbt.zip'
-            storage = ZipStorage(path)
+            storage = ZipStorage(path, read_only=False)
             backend = "FSStorage"
 
             assert path[-8:] == '.sbt.zip'
@@ -1435,6 +1435,7 @@ def filter_distance(filter_a, filter_b, n=1000):
 def convert_cmd(name, backend):
     "Convert an SBT to use a different back end."
     from .sbtmh import SigLeaf
+    from .sbt_storage import RwZipStorage
 
     options = backend.split('(')
     backend = options.pop(0)
@@ -1453,7 +1454,7 @@ def convert_cmd(name, backend):
     elif backend.lower() in ('redis', 'redisstorage'):
         backend = RedisStorage
     elif backend.lower() in ('zip', 'zipstorage'):
-        backend = ZipStorage
+        backend = RwZipStorage
     elif backend.lower() in ('fs', 'fsstorage'):
         backend = FSStorage
         if options:

--- a/src/sourmash/sourmash_args.py
+++ b/src/sourmash/sourmash_args.py
@@ -966,7 +966,7 @@ class SaveSignatures_ZipFile(_BaseSaveSignaturesToLocation):
         if os.path.exists(self.location):
             do_create = False
 
-        storage = ZipStorage(self.location, read_only=False)
+        storage = ZipStorage(self.location, mode="w")
         if not storage.subdir:
             storage.subdir = 'signatures'
 

--- a/src/sourmash/sourmash_args.py
+++ b/src/sourmash/sourmash_args.py
@@ -966,7 +966,7 @@ class SaveSignatures_ZipFile(_BaseSaveSignaturesToLocation):
         if os.path.exists(self.location):
             do_create = False
 
-        storage = ZipStorage(self.location)
+        storage = ZipStorage(self.location, read_only=False)
         if not storage.subdir:
             storage.subdir = 'signatures'
 

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -941,8 +941,7 @@ def test_zipfile_API_signatures_traverse_yield_all(use_manifest):
     assert len(zipidx) == 8
 
     # confirm that there are 12 files in there total, incl build.sh and dirs
-    zf = zipidx.storage.zipfile
-    allfiles = [ zi.filename for zi in zf.infolist() ]
+    allfiles = zipidx.storage._filenames()
     print(allfiles)
     assert len(allfiles) == 13
 

--- a/tests/test_sbt.py
+++ b/tests/test_sbt.py
@@ -367,7 +367,7 @@ def test_sbt_zipstorage(tmpdir):
     old_result = {str(s.signature) for s in tree.find(search_obj, to_search.data)}
     print(*old_result, sep='\n')
 
-    with ZipStorage(str(tmpdir.join("tree.sbt.zip")), read_only=False) as storage:
+    with ZipStorage(str(tmpdir.join("tree.sbt.zip")), mode="w") as storage:
         tree.save(str(tmpdir.join("tree.sbt.json")), storage=storage)
 
     with ZipStorage(str(tmpdir.join("tree.sbt.zip"))) as storage:

--- a/tests/test_sbt.py
+++ b/tests/test_sbt.py
@@ -367,7 +367,7 @@ def test_sbt_zipstorage(tmpdir):
     old_result = {str(s.signature) for s in tree.find(search_obj, to_search.data)}
     print(*old_result, sep='\n')
 
-    with ZipStorage(str(tmpdir.join("tree.sbt.zip"))) as storage:
+    with ZipStorage(str(tmpdir.join("tree.sbt.zip")), read_only=False) as storage:
         tree.save(str(tmpdir.join("tree.sbt.json")), storage=storage)
 
     with ZipStorage(str(tmpdir.join("tree.sbt.zip"))) as storage:

--- a/tox.ini
+++ b/tox.ini
@@ -95,7 +95,7 @@ deps =
 changedir = {toxinidir}
 commands =
   asv machine --yes
-  asv continuous latest HEAD
+  asv continuous latest HEAD {posargs}
 
 [testenv:docs]
 description = invoke sphinx-build to build the HTML docs


### PR DESCRIPTION
Expose the (read-only for now) Rust ZipStorage and use it instead of the regular (read-write) ZipStorage.

if writing is needed, fall back to current ZipStorage (as a stopgap while the Rust one doesn't support writing)

This PR also removes Python 3.7 support (which we actually dropped in https://github.com/sourmash-bio/sourmash/pull/1839), and adds Python 3.9 and Python 3.10 to the setup.cfg classifiers.