### PR TITLE
[MRG] add some tests for Jaccard output ordering

### DIFF
--- a/src/sourmash/lca/lca_db.py
+++ b/src/sourmash/lca/lca_db.py
@@ -510,10 +510,13 @@ class LCA_Database(Index):
             score = search_fn.score_fn(query_size, shared_size, subj_size,
                                        total_size)
 
-            # note to self: even with JaccardSearchBestOnly, this will
+            # CTB note to self: even with JaccardSearchBestOnly, this will
             # still iterate over & score all signatures. We should come
             # up with a protocol by which the JaccardSearch object can
             # signal that it is done, or something.
+            # For example, see test_lca_jaccard_ordering, where
+            # for containment we could be done early, but for Jaccard we
+            # cannot.
             if search_fn.passes(score):
                 if search_fn.collect(score, subj):
                     if passes_all_picklists(subj, self.picklists):

--- a/tests/test_lca.py
+++ b/tests/test_lca.py
@@ -2670,3 +2670,47 @@ def test_lca_index_with_picklist_exclude(runtmp):
     assert len(siglist) == 9
     for ss in siglist:
         assert 'Thermotoga' not in ss.name
+
+
+def test_lca_jaccard_ordering():
+    # this tests a tricky situation where for three sketches A, B, C,
+    # |A intersect B| is greater than |A intersect C|
+    # _but_
+    # |A jaccard B| is less than |A intersect B|
+    a = sourmash.MinHash(ksize=31, n=0, scaled=2)
+    b = a.copy_and_clear()
+    c = a.copy_and_clear()
+
+    a.add_many([1, 2, 3, 4])
+    b.add_many([1, 2, 3] + list(range(10, 30)))
+    c.add_many([1, 5])
+
+    def _intersect(x, y):
+        return x.intersection_and_union_size(y)[0]
+
+    print('a intersect b:', _intersect(a, b))
+    print('a intersect c:', _intersect(a, c))
+    print('a jaccard b:', a.jaccard(b))
+    print('a jaccard c:', a.jaccard(c))
+    assert _intersect(a, b) > _intersect(a, c)
+    assert a.jaccard(b) < a.jaccard(c)
+
+    # thresholds to use:
+    assert a.jaccard(b) < 0.15
+    assert a.jaccard(c) > 0.15
+
+    # now - make signatures, try out :)
+    ss_a = sourmash.SourmashSignature(a, name='A')
+    ss_b = sourmash.SourmashSignature(b, name='B')
+    ss_c = sourmash.SourmashSignature(c, name='C')
+
+    db = sourmash.lca.LCA_Database(ksize=31, scaled=2)
+    db.insert(ss_a)
+    db.insert(ss_b)
+    db.insert(ss_c)
+
+    sr = db.search(ss_a, threshold=0.15)
+    print(sr)
+    assert len(sr) == 2
+    assert sr[0].signature == ss_a
+    assert sr[1].signature == ss_c


### PR DESCRIPTION
This PR adds tests for optimized search `Index` classes (`SBT` and `LCA_Database`, currently) that ensure that we do not erroneously truncate searches. See https://github.com/sourmash-bio/sourmash/issues/1925 for details.

tl;dr more tests good.
