### PR TITLE
[EXP] support LCA functionality for `SqliteIndex` + `LineageDB_Sqlite` databases.

### DIFF
--- a/src/sourmash/cli/lca/index.py
+++ b/src/sourmash/cli/lca/index.py
@@ -59,6 +59,12 @@ def subparser(subparsers):
         '--fail-on-missing-taxonomy', action='store_true',
         help='fail quickly if taxonomy is not available for an identifier',
     )
+    subparser.add_argument(
+        '-F', '--database-format',
+        help="format of output database; default is 'json')",
+        default='json',
+        choices=['json', 'sql'],
+    )
 
     add_ksize_arg(subparser, 31)
     add_moltype_args(subparser)

--- a/src/sourmash/index/sqlite_index.py
+++ b/src/sourmash/index/sqlite_index.py
@@ -174,6 +174,9 @@ class SqliteIndex(Index):
             c.execute("PRAGMA synchronous = OFF")
             c.execute("PRAGMA journal_mode = MEMORY")
             c.execute("PRAGMA temp_store = MEMORY")
+
+            c.execute("SELECT * FROM hashes LIMIT 1")
+            c.fetchone()
         except (sqlite3.OperationalError, sqlite3.DatabaseError):
             raise ValueError(f"cannot open '{dbfile}' as SqliteIndex database")
 

--- a/src/sourmash/index/sqlite_index.py
+++ b/src/sourmash/index/sqlite_index.py
@@ -713,7 +713,15 @@ class SqliteCollectionManifest(BaseCollectionManifest):
                 d[k] = v
             kwargs = d
 
-        return SqliteCollectionManifest(self.conn, selection_dict=kwargs)
+        new_mf = SqliteCollectionManifest(self.conn, selection_dict=kwargs)
+        if 'picklist' in kwargs:
+            picklist = kwargs['picklist']
+            for row in new_mf.rows:
+                does_match = picklist.matches_manifest_row(row)
+                if not does_match:
+                    assert 0
+
+        return new_mf
 
     def _run_select(self, c):
         conditions, values, picklist = self._select_signatures(c)

--- a/src/sourmash/index/sqlite_index.py
+++ b/src/sourmash/index/sqlite_index.py
@@ -761,10 +761,6 @@ class SqliteCollectionManifest(BaseCollectionManifest):
                        _id=_id)
             yield row
 
-    def write_to_csv(self, fp, *, write_header=True):
-        mf = self._extract_manifest()
-        mf.write_to_csv(fp, write_header=write_header)
-
     def filter_rows(self, row_filter_fn):
         """Create a new manifest filtered through row_filter_fn.
 
@@ -838,12 +834,16 @@ class SqliteCollectionManifest(BaseCollectionManifest):
 
     @classmethod
     def _create_manifest_from_rows(cls, rows_iter, *, location=":memory:"):
-        """Create an in-memory SqliteCollectionManifest from a rows iterator.
+        """Create a SqliteCollectionManifest from a rows iterator.
 
         Internal utility function.
-        @CTB how do we convert in-memory sqlite db to on-disk?
+        CTB: should enable converting in-memory sqlite db to on-disk,
+        probably with sqlite3 'conn.backup(...)' function.
         """
-        mf = cls.create(location)
+        try:
+            mf = cls.create(location)
+        except (sqlite3.OperationalError, sqlite3.DatabaseError) as exc:
+            raise Exception(f"cannot create sqlite3 db at '{location}'; exception: {str(exc)}")
         cursor = mf.conn.cursor()
 
         # @CTB: manage/test already existing/managed_by_index

--- a/src/sourmash/index/sqlite_index.py
+++ b/src/sourmash/index/sqlite_index.py
@@ -712,6 +712,8 @@ class SqliteCollectionManifest(CollectionManifest):
         """
         manifest_list = []
         for row in self.rows:
+            if '_id' in row:
+                del row['_id']
             manifest_list.append(row)
 
         return CollectionManifest(manifest_list)

--- a/src/sourmash/index/sqlite_index.py
+++ b/src/sourmash/index/sqlite_index.py
@@ -752,7 +752,7 @@ class SqliteCollectionManifest(BaseCollectionManifest):
         else:
             conditions = ""
 
-        debug_literal(f"sqlite manifest: executing select with {conditions}")
+        debug_literal(f"sqlite manifest rows: executing select with '{conditions}'")
         c1.execute(f"""
         SELECT id, name, md5sum, num, scaled, ksize, filename, moltype,
         seed, n_hashes, internal_location FROM sketches {conditions}

--- a/src/sourmash/index/sqlite_index.py
+++ b/src/sourmash/index/sqlite_index.py
@@ -36,6 +36,7 @@ import time
 import os
 import sqlite3
 from collections import Counter
+from collections.abc import Mapping
 
 from bitstring import BitArray
 
@@ -1024,5 +1025,11 @@ class _SqliteIndexHashvalToIndex:
 
         c.execute('SELECT sketch_id FROM hashes WHERE hashval=?', (hh,))
 
-        x = set(( convert_hash_from(h) for h, in c ))
+        x = [ convert_hash_from(h) for h, in c ]
         return x or dv
+
+    def __getitem__(self, key):
+        v = self.get(key)
+        if v is None:
+            raise KeyError(key)
+        return v

--- a/src/sourmash/index/sqlite_index.py
+++ b/src/sourmash/index/sqlite_index.py
@@ -798,6 +798,7 @@ class SqliteCollectionManifest(CollectionManifest):
 
         return cls(manifest_list)
 
+
 class LCA_Database_SqliteWrapper:
     # @CTB: test via roundtrip ;).
 

--- a/src/sourmash/index/sqlite_index.py
+++ b/src/sourmash/index/sqlite_index.py
@@ -35,7 +35,7 @@ TODO:
 import time
 import os
 import sqlite3
-from collections import Counter
+from collections import Counter, defaultdict
 from collections.abc import Mapping
 
 from bitstring import BitArray
@@ -1029,6 +1029,22 @@ class LCA_Database_SqliteWrapper:
     def hashval_to_idx(self):
         "Dynamically interpret the SQL 'hashes' table like it's a dict."
         return _SqliteIndexHashvalToIndex(self.sqlidx)
+
+    @property
+    def conn(self):
+        return self.sqlidx.conn
+
+    @property
+    def hashvals(self):
+        c = self.conn.cursor()
+        c.execute('SELECT DISTINCT hashval FROM hashes')
+        for hashval, in c:
+            yield hashval
+
+    def get_identifiers_for_hashval(self, hashval):
+        idxlist = self.hashval_to_idx[hashval]
+        for idx in idxlist:
+            yield self.idx_to_ident[idx]
 
 
 class _SqliteIndexHashvalToIndex:

--- a/src/sourmash/lca/command_index.py
+++ b/src/sourmash/lca/command_index.py
@@ -296,12 +296,14 @@ def index(args):
 
     # now, save!
     db_outfile = args.lca_db_out
-    if not (db_outfile.endswith('.lca.json') or \
-                db_outfile.endswith('.lca.json.gz')):   # logic -> db.save
-        db_outfile += '.lca.json'
+    if args.database_format == 'json':
+        if not (db_outfile.endswith('.lca.json') or \
+                    db_outfile.endswith('.lca.json.gz')):   # logic -> db.save
+            db_outfile += '.lca.json'
+
     notify(f'saving to LCA DB: {format(db_outfile)}')
 
-    db.save(db_outfile)
+    db.save(db_outfile, format=args.database_format)
 
     ## done!
 

--- a/src/sourmash/lca/command_rankinfo.py
+++ b/src/sourmash/lca/command_rankinfo.py
@@ -19,8 +19,8 @@ def make_lca_counts(dblist, min_num=0):
     # gather all hashvalue assignments from across all the databases
     assignments = defaultdict(set)
     for lca_db in dblist:
-        for hashval in lca_db.hashval_to_idx:
-            lineages = lca_db.get_lineage_assignments(hashval, min_num)
+        for hashval in lca_db.hashvals:
+            lineages = lca_db.get_lineage_assignments(hashval, min_num=min_num)
             if lineages:
                 assignments[hashval].update(lineages)
 

--- a/src/sourmash/lca/lca_db.py
+++ b/src/sourmash/lca/lca_db.py
@@ -80,17 +80,32 @@ class LCA_Database(Index):
 
     @property
     def location(self):
+        """Return source filename.
+
+        Part of the Index protocol.
+        """
         return self.filename
 
     def __len__(self):
+        """Return number of sketches.
+
+        Part of the Index protocol.
+        """
         return self._next_index
 
     def _invalidate_cache(self):
+        """Force rebuild of signatures after an 'insert'.
+
+        Internal method.
+        """
         if hasattr(self, '_cache'):
             del self._cache
 
     def _get_ident_index(self, ident, fail_on_duplicate=False):
-        "Get (create if nec) a unique int id, idx, for each identifier."
+        """Get (create if necessary) a unique int idx, for each identifier.
+
+        Internal method.
+        """
         idx = self.ident_to_idx.get(ident)
         if fail_on_duplicate:
             assert idx is None     # should be no duplicate identities
@@ -104,7 +119,11 @@ class LCA_Database(Index):
         return idx
 
     def _get_lineage_id(self, lineage):
-        "Get (create if nec) a unique lineage ID for each LineagePair tuples."
+        """Get (create if nec) a unique lineage ID for each
+        LineagePair tuples."
+
+        Internal method of this class.
+        """
         # does one exist already?
         lid = self.lineage_to_lid.get(lineage)
 
@@ -128,6 +147,8 @@ class LCA_Database(Index):
         if not specified, the signature name (sig.name) is used.
 
         'lineage', if specified, must contain a tuple of LineagePair objects.
+
+        Method unique to this class.
         """
         minhash = sig.minhash
 
@@ -179,19 +200,28 @@ class LCA_Database(Index):
         return "LCA_Database('{}')".format(self.filename)
 
     def signatures(self):
-        "Return all of the signatures in this LCA database."
+        """Return all of the signatures in this LCA database.
+
+        Part of the Index protocol.
+
+        @CTB: note this does not respect picklists!?
+        """
         from sourmash import SourmashSignature
         for v in self._signatures.values():
             yield v
 
     def _signatures_with_internal(self):
-        "Return all of the signatures in this LCA database."
+        """Return all of the signatures in this LCA database.
+
+        Part of the Index protocol; used for buulding manifests.
+        """
+
         for idx, ss in self._signatures.items():
             yield ss, idx
 
     def select(self, ksize=None, moltype=None, num=0, scaled=0, abund=None,
                containment=False, picklist=None):
-        """Make sure this database matches the requested requirements.
+        """Select a subset of signatures to search.
 
         As with SBTs, queries with higher scaled values than the database
         can still be used for containment search, but not for similarity
@@ -223,7 +253,10 @@ class LCA_Database(Index):
 
     @classmethod
     def load(cls, db_name):
-        "Load LCA_Database from a JSON file."
+        """Load LCA_Database from a JSON file.
+
+        Method specific to this class.
+        """
         from .lca_utils import taxlist, LineagePair
 
         if not os.path.isfile(db_name):
@@ -330,7 +363,10 @@ class LCA_Database(Index):
         return db
 
     def save(self, db_name):
-        "Save LCA_Database to a JSON file."
+        """Save LCA_Database to a JSON file.
+
+        Method specific to this class.
+        """
         xopen = open
         if db_name.endswith('.gz'):
             xopen = gzip.open
@@ -373,6 +409,8 @@ class LCA_Database(Index):
         that don't fall in the required range.
 
         This applies to this database in place.
+
+        Method specific to LCA databases.
         """
         if scaled == self.scaled:
             return
@@ -392,8 +430,9 @@ class LCA_Database(Index):
         self.scaled = scaled
 
     def get_lineage_assignments(self, hashval):
-        """
-        Get a list of lineages for this hashval.
+        """Get a list of lineages for this hashval.
+
+        Method specific to LCA Databases.
         """
         x = []
 
@@ -408,7 +447,10 @@ class LCA_Database(Index):
 
     @cached_property
     def _signatures(self):
-        "Create a _signatures member dictionary that contains {idx: sigobj}."
+        """Create a _signatures member dictionary that contains {idx: sigobj}.
+
+        Internal method of this class.
+        """
         from sourmash import MinHash, SourmashSignature
 
         is_protein = False
@@ -471,6 +513,8 @@ class LCA_Database(Index):
         As with SBTs, queries with higher scaled values than the database
         can still be used for containment search, but not for similarity
         search. See SBT.select(...) for details.
+
+        Part of the Index protocol.
         """
         search_fn.check_is_compatible(query)
 
@@ -531,6 +575,10 @@ class LCA_Database(Index):
 
     @cached_property
     def lid_to_idx(self):
+        """Connect lineage id lid (int) to idx set (set of ints).""
+
+        Method specific to LCA databases.
+        """
         d = defaultdict(set)
         for idx, lid in self.idx_to_lid.items():
             d[lid].add(idx)
@@ -538,6 +586,10 @@ class LCA_Database(Index):
 
     @cached_property
     def idx_to_ident(self):
+        """Connect idx (int) to ident (str).
+
+        Method specific to LCA databases.
+        """
         d = defaultdict(set)
         for ident, idx in self.ident_to_idx.items():
             assert idx not in d

--- a/src/sourmash/lca/lca_db.py
+++ b/src/sourmash/lca/lca_db.py
@@ -428,9 +428,6 @@ class LCA_Database(Index):
                 for pair in lineage:
                     available_ranks.add(pair.rank)
 
-        print(assignments)
-        print(available_ranks)
-
         from sourmash.tax.tax_utils import MultiLineageDB, LineageDB
         ldb = LineageDB(assignments, available_ranks)
         out_lineage_db = MultiLineageDB()

--- a/src/sourmash/lca/lca_db.py
+++ b/src/sourmash/lca/lca_db.py
@@ -229,6 +229,13 @@ class LCA_Database(Index):
         if not os.path.isfile(db_name):
             raise ValueError(f"'{db_name}' is not a file and cannot be loaded as an LCA database")
 
+        try:
+            from sourmash.index.sqlite_index import LCA_Database_SqliteWrapper
+            db = LCA_Database_SqliteWrapper(db_name)
+            return db
+        except ValueError:
+            pass
+
         xopen = open
         if db_name.endswith('.gz'):
             xopen = gzip.open

--- a/src/sourmash/lca/lca_db.py
+++ b/src/sourmash/lca/lca_db.py
@@ -362,7 +362,15 @@ class LCA_Database(Index):
 
         return db
 
-    def save(self, db_name):
+    def save(self, db_name, format='json'):
+        if format == 'json':
+            self.save_to_json(db_name)
+        elif format == 'sql':
+            self.save_to_sql(db_name)
+        else:
+            raise Exception(f"unknown save format for LCA_Database: '{format}'")
+
+    def save_to_json(self, db_name):
         """Save LCA_Database to a JSON file.
 
         Method specific to this class.

--- a/src/sourmash/manifest.py
+++ b/src/sourmash/manifest.py
@@ -1,8 +1,5 @@
 """
 Manifests for collections of signatures.
-
-@CTB refactor in light of SqliteCollectionManifest to have base class, load,
-etc.
 """
 import csv
 import ast

--- a/src/sourmash/manifest.py
+++ b/src/sourmash/manifest.py
@@ -3,6 +3,7 @@ Manifests for collections of signatures.
 """
 import csv
 import ast
+import os.path
 from abc import abstractmethod
 
 from sourmash.picklist import SignaturePicklist
@@ -80,13 +81,19 @@ class BaseCollectionManifest:
         if db:
             return db.manifest
 
-    def write_to_filename(self, filename, *, database_format='csv'):
+    def write_to_filename(self, filename, *, database_format='csv',
+                          ok_if_exists=False):
         if database_format == 'csv':
-            with open(filename, "w", newline="") as fp:
-                return self.write_to_csv(fp, write_header=True)
+            if ok_if_exists or not os.path.exists(filename):
+                with open(filename, "w", newline="") as fp:
+                    return self.write_to_csv(fp, write_header=True)
         elif database_format == 'sql':
             from sourmash.index.sqlite_index import SqliteCollectionManifest
-            SqliteCollectionManifest.create_from_manifest(filename, self)
+            append = False
+            if ok_if_exists:
+                append= True
+            SqliteCollectionManifest.create_from_manifest(filename, self,
+                                                          append=append)
 
     @classmethod
     def write_csv_header(cls, fp):

--- a/src/sourmash/manifest.py
+++ b/src/sourmash/manifest.py
@@ -28,6 +28,12 @@ class BaseCollectionManifest:
 
     @classmethod
     def load_from_filename(cls, filename):
+        # SQLite db?
+        db = cls.load_from_sql(filename)
+        if db is not None:
+            return db
+
+        # not a SQLite db?
         with open(filename, newline="") as fp:
             return cls.load_from_csv(fp)
 
@@ -66,6 +72,13 @@ class BaseCollectionManifest:
             manifest_list.append(row)
 
         return cls(manifest_list)
+
+    @classmethod
+    def load_from_sql(cls, filename):
+        from sourmash.index.sqlite_index import load_sqlite_file
+        db = load_sqlite_file(filename, request_manifest=True)
+        if db:
+            return db.manifest
 
     def write_to_filename(self, filename):
         with open(filename, "w", newline="") as fp:

--- a/src/sourmash/manifest.py
+++ b/src/sourmash/manifest.py
@@ -80,9 +80,13 @@ class BaseCollectionManifest:
         if db:
             return db.manifest
 
-    def write_to_filename(self, filename):
-        with open(filename, "w", newline="") as fp:
-            return self.write_to_csv(fp, write_header=True)
+    def write_to_filename(self, filename, *, database_format='csv'):
+        if database_format == 'csv':
+            with open(filename, "w", newline="") as fp:
+                return self.write_to_csv(fp, write_header=True)
+        elif database_format == 'sql':
+            from sourmash.index.sqlite_index import SqliteCollectionManifest
+            SqliteCollectionManifest.create_from_manifest(filename, self)
 
     @classmethod
     def write_csv_header(cls, fp):

--- a/src/sourmash/manifest.py
+++ b/src/sourmash/manifest.py
@@ -113,7 +113,8 @@ class CollectionManifest:
 
     def write_to_csv(self, fp, write_header=False):
         "write manifest CSV to specified file handle"
-        w = csv.DictWriter(fp, fieldnames=self.required_keys)
+        w = csv.DictWriter(fp, fieldnames=self.required_keys,
+                           extrasaction='ignore')
 
         if write_header:
             self.write_csv_header(fp)

--- a/src/sourmash/sig/__main__.py
+++ b/src/sourmash/sig/__main__.py
@@ -1336,11 +1336,8 @@ def check(args):
 
         # has manifest, or ok to build (require_manifest=False) - continue!
         manifest = sourmash_args.get_manifest(idx, require=True)
-        debug_literal(f"got manifest! {len(manifest)} rows. Running select on {len(picklist.pickset)} pickset items.")
         manifest_rows = manifest.select_to_manifest(picklist=picklist)
-        debug_literal(f"of {len(manifest)} rows, found {len(manifest_rows)} matching rows; {len(picklist.pickset - picklist.found)} pick values still missing.")
         total_rows_examined += len(manifest)
-        debug_literal(f"merging new rows into {len(total_manifest_rows)} current.")
         total_manifest_rows += manifest_rows
 
     notify(f"loaded {total_rows_examined} signatures.")

--- a/src/sourmash/sig/__main__.py
+++ b/src/sourmash/sig/__main__.py
@@ -1317,7 +1317,7 @@ def check(args):
     else:
         debug("sig check: manifest required")
 
-    total_manifest_rows = []
+    total_manifest_rows = CollectionManifest([])
 
     # start loading!
     total_rows_examined = 0
@@ -1335,7 +1335,7 @@ def check(args):
 
         # has manifest, or ok to build (require_manifest=False) - continue!
         manifest = sourmash_args.get_manifest(idx, require=True)
-        manifest_rows = manifest._select(picklist=picklist)
+        manifest_rows = manifest.select_to_manifest(picklist=picklist)
         total_rows_examined += len(manifest)
         total_manifest_rows += manifest_rows
 
@@ -1369,7 +1369,7 @@ def check(args):
 
     # save manifest of matching!
     if args.save_manifest_matching and total_manifest_rows:
-        mf = CollectionManifest(total_manifest_rows)
+        mf = total_manifest_rows
         with open(args.save_manifest_matching, 'w', newline="") as fp:
             mf.write_to_csv(fp, write_header=True)
         notify(f"wrote {len(mf)} matching manifest rows to '{args.save_manifest_matching}'")

--- a/src/sourmash/sig/__main__.py
+++ b/src/sourmash/sig/__main__.py
@@ -1336,9 +1336,11 @@ def check(args):
 
         # has manifest, or ok to build (require_manifest=False) - continue!
         manifest = sourmash_args.get_manifest(idx, require=True)
+        debug_literal(f"got manifest! {len(manifest)} rows. Running select on {len(picklist.pickset)} pickset items.")
         manifest_rows = manifest.select_to_manifest(picklist=picklist)
         debug_literal(f"of {len(manifest)} rows, found {len(manifest_rows)} matching rows; {len(picklist.pickset - picklist.found)} pick values still missing.")
         total_rows_examined += len(manifest)
+        debug_literal(f"merging new rows into {len(total_manifest_rows)} current.")
         total_manifest_rows += manifest_rows
 
     notify(f"loaded {total_rows_examined} signatures.")

--- a/src/sourmash/sig/__main__.py
+++ b/src/sourmash/sig/__main__.py
@@ -301,15 +301,8 @@ def manifest(args):
     manifest = sourmash_args.get_manifest(loader, require=True,
                                           rebuild=rebuild)
 
-    if args.manifest_format == 'csv':
-        manifest.write_to_filename(args.output)
-    elif args.manifest_format == 'sql':
-        from sourmash.index.sqlite_index import SqliteCollectionManifest
-        SqliteCollectionManifest.create_from_manifest(args.output,
-                                                      manifest)
-    else:
-        assert 0
-
+    manifest.write_to_filename(args.output,
+                               database_format=args.manifest_format)
     notify(f"manifest contains {len(manifest)} signatures total.")
     notify(f"wrote manifest to '{args.output}' ({args.manifest_format})")
 

--- a/src/sourmash/sig/__main__.py
+++ b/src/sourmash/sig/__main__.py
@@ -13,7 +13,8 @@ import screed
 import sourmash
 from sourmash.sourmash_args import FileOutput
 
-from sourmash.logging import set_quiet, error, notify, print_results, debug
+from sourmash.logging import (set_quiet, error, notify, print_results, debug,
+                              debug_literal)
 from sourmash import sourmash_args
 from sourmash.minhash import _get_max_hash_for_scaled
 from sourmash.manifest import CollectionManifest
@@ -1336,6 +1337,7 @@ def check(args):
         # has manifest, or ok to build (require_manifest=False) - continue!
         manifest = sourmash_args.get_manifest(idx, require=True)
         manifest_rows = manifest.select_to_manifest(picklist=picklist)
+        debug_literal(f"of {len(manifest)} rows, found {len(manifest_rows)} matching rows; {len(picklist.pickset - picklist.found)} pick values still missing.")
         total_rows_examined += len(manifest)
         total_manifest_rows += manifest_rows
 

--- a/src/sourmash/sourmash_args.py
+++ b/src/sourmash/sourmash_args.py
@@ -921,7 +921,7 @@ class SaveSignatures_SqliteIndex(_BaseSaveSignaturesToLocation):
         self.idx.close()
 
     def open(self):
-        self.idx = SqliteIndex(self.location)
+        self.idx = SqliteIndex.create(self.location)
         self.cursor = self.idx.cursor()
 
     def add(self, add_sig):

--- a/src/sourmash/sqlite_utils.py
+++ b/src/sourmash/sqlite_utils.py
@@ -12,11 +12,13 @@ def open_sqlite_db(filename):
 
     Otherwise, return None.
     """
+    debug_literal("open_sqlite_db: started")
     # does it already exist/is it non-zero size?
 
     # note: sqlite3.connect creates the file if it doesn't exist, which
     # we don't want in this function.
     if not os.path.exists(filename) or os.path.getsize(filename) == 0:
+        debug_literal("open_sqlite_db: no file/zero sized file")
         return None
 
     # can we connect to it?

--- a/src/sourmash/sqlite_utils.py
+++ b/src/sourmash/sqlite_utils.py
@@ -1,0 +1,38 @@
+"""
+Common utility functions for handling sqlite3 databases.
+"""
+import os
+import sqlite3
+from .logging import debug_literal
+
+
+def open_sqlite_db(filename):
+    """
+    Is this a pre-existing sqlite3 database? Return connection object if so.
+    """
+    # 
+    if not os.path.exists(filename) or os.path.getsize(filename) == 0:
+        return None
+
+    # can we connect to it?
+    try:
+        conn = sqlite3.connect(filename)
+    except (sqlite3.OperationalError, sqlite3.DatabaseError):
+        debug_literal("open_sqlite_db: cannot connect.")
+        return None
+
+    # grab a schema dump.
+    cursor = conn.cursor()
+    try:
+        cursor.execute('SELECT DISTINCT key, value FROM sourmash_internal')
+    except (sqlite3.OperationalError, sqlite3.DatabaseError):
+        debug_literal("open_sqlite_db: cannot read sourmash_internal.")
+
+        # is this a taxonomy DB?
+        try:
+            cursor.execute('SELECT * FROM taxonomy LIMIT 1')
+        except (sqlite3.OperationalError, sqlite3.DatabaseError):
+            debug_literal("open_sqlite_db: cannot read 'taxonomy', either.")
+            return None
+
+    return conn

--- a/src/sourmash/tax/tax_utils.py
+++ b/src/sourmash/tax/tax_utils.py
@@ -718,6 +718,7 @@ class LineageDB_Sqlite(abc.Mapping):
         for ident, *names in c:
             yield ident, self._make_tup(names)
 
+
 class MultiLineageDB(abc.Mapping):
     "A wrapper for (dynamically) combining multiple lineage databases."
 
@@ -814,8 +815,12 @@ class MultiLineageDB(abc.Mapping):
                 if is_filename:
                     fp.close()
 
-    def _save_sqlite(self, filename):
-        db = sqlite3.connect(filename)
+    def _save_sqlite(self, filename, *, conn=None):
+        if conn is None:
+            db = sqlite3.connect(filename)
+        else:
+            assert not filename
+            db = conn
 
         cursor = db.cursor()
         try:

--- a/src/sourmash/tax/tax_utils.py
+++ b/src/sourmash/tax/tax_utils.py
@@ -815,7 +815,6 @@ class MultiLineageDB(abc.Mapping):
                     fp.close()
 
     def _save_sqlite(self, filename):
-        import sqlite3
         db = sqlite3.connect(filename)
 
         cursor = db.cursor()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,8 +59,14 @@ def linear_gather(request):
 def prefetch_gather(request):
     return request.param
 
+
 @pytest.fixture(params=[True, False])
 def use_manifest(request):
+    return request.param
+
+
+@pytest.fixture(params=['json', 'sql'])
+def lca_db_format(request):
     return request.param
 
 

--- a/tests/test_index_protocol.py
+++ b/tests/test_index_protocol.py
@@ -130,7 +130,7 @@ def build_lca_index_save_load(runtmp):
 
 def build_sqlite_index(runtmp):
     filename = runtmp.output('idx.sqldb')
-    db = SqliteIndex(filename)
+    db = SqliteIndex.create(filename)
 
     siglist = _load_three_sigs()
     for ss in siglist:

--- a/tests/test_lca.py
+++ b/tests/test_lca.py
@@ -2042,9 +2042,9 @@ def test_rankinfo_no_tax(runtmp, lca_db_format):
     cmd = ['lca', 'index', taxcsv, lca_db, input_sig, '-F', lca_db_format]
     runtmp.sourmash(*cmd)
 
-    print(cmd)
-    print(runtmp.last_result.out)
-    print(runtmp.last_result.err)
+    print('cmd:', cmd)
+    print('out:', runtmp.last_result.out)
+    print('err:', runtmp.last_result.err)
 
     assert os.path.exists(lca_db)
 

--- a/tests/test_lca.py
+++ b/tests/test_lca.py
@@ -741,12 +741,12 @@ def test_run_sourmash_lca():
     assert status != 0                    # no args provided, ok ;)
 
 
-def test_basic_index(runtmp):
+def test_basic_index(runtmp, lca_db_format):
     taxcsv = utils.get_test_data('lca/delmont-1.csv')
     input_sig = utils.get_test_data('lca/TARA_ASE_MAG_00031.sig')
     lca_db = runtmp.output('delmont-1.lca.json')
 
-    cmd = ['lca', 'index', taxcsv, lca_db, input_sig]
+    cmd = ['lca', 'index', taxcsv, lca_db, input_sig, '-F', lca_db_format]
     runtmp.sourmash(*cmd)
 
     print(cmd)
@@ -761,12 +761,12 @@ def test_basic_index(runtmp):
     assert '1 identifiers used out of 1 distinct identifiers in spreadsheet.' in runtmp.last_result.err
 
 
-def test_basic_index_bad_spreadsheet(runtmp):
+def test_basic_index_bad_spreadsheet(runtmp, lca_db_format):
     taxcsv = utils.get_test_data('lca/bad-spreadsheet.csv')
     input_sig = utils.get_test_data('lca/TARA_ASE_MAG_00031.sig')
     lca_db = runtmp.output('delmont-1.lca.json')
 
-    cmd = ['lca', 'index', taxcsv, lca_db, input_sig]
+    cmd = ['lca', 'index', taxcsv, lca_db, input_sig, '-F', lca_db_format]
     runtmp.sourmash(*cmd)
 
     print(cmd)
@@ -780,13 +780,13 @@ def test_basic_index_bad_spreadsheet(runtmp):
     assert '1 identifiers used out of 1 distinct identifiers in spreadsheet.' in runtmp.last_result.err
 
 
-def test_basic_index_broken_spreadsheet(runtmp):
+def test_basic_index_broken_spreadsheet(runtmp, lca_db_format):
     # duplicate identifiers in this spreadsheet
     taxcsv = utils.get_test_data('lca/bad-spreadsheet-2.csv')
     input_sig = utils.get_test_data('lca/TARA_ASE_MAG_00031.sig')
     lca_db = runtmp.output('delmont-1.lca.json')
 
-    cmd = ['lca', 'index', taxcsv, lca_db, input_sig]
+    cmd = ['lca', 'index', taxcsv, lca_db, input_sig, '-F', lca_db_format]
     with pytest.raises(SourmashCommandFailed):
         runtmp.sourmash(*cmd)
 
@@ -794,7 +794,7 @@ def test_basic_index_broken_spreadsheet(runtmp):
     assert "multiple lineages for identifier TARA_ASE_MAG_00031" in runtmp.last_result.err
 
 
-def test_basic_index_too_many_strains_too_few_species(runtmp):
+def test_basic_index_too_many_strains_too_few_species(runtmp, lca_db_format):
     # explicit test for #841, where 'n_species' wasn't getting counted
     # if lineage was at strain level resolution.
     taxcsv = utils.get_test_data('lca/podar-lineage.csv')
@@ -802,14 +802,14 @@ def test_basic_index_too_many_strains_too_few_species(runtmp):
     lca_db = runtmp.output('out.lca.json')
 
     cmd = ['lca', 'index', taxcsv, lca_db, input_sig,
-            '-C', '3', '--split-identifiers']
+            '-C', '3', '--split-identifiers', '-F', lca_db_format]
     runtmp.sourmash(*cmd)
 
     assert not 'error: fewer than 20% of lineages' in runtmp.last_result.err
     assert runtmp.last_result.status == 0
 
 
-def test_basic_index_too_few_species(runtmp):
+def test_basic_index_too_few_species(runtmp, lca_db_format):
     # spreadsheets with too few species should be flagged, unless -f specified
     taxcsv = utils.get_test_data('lca/tully-genome-sigs.classify.csv')
 
@@ -817,7 +817,8 @@ def test_basic_index_too_few_species(runtmp):
     input_sig = utils.get_test_data('47.fa.sig')
     lca_db = runtmp.output('out.lca.json')
 
-    cmd = ['lca', 'index', taxcsv, lca_db, input_sig, '-C', '3']
+    cmd = ['lca', 'index', taxcsv, lca_db, input_sig, '-C', '3',
+           '-F', lca_db_format]
     with pytest.raises(SourmashCommandFailed):
         runtmp.sourmash(*cmd)
 
@@ -825,13 +826,14 @@ def test_basic_index_too_few_species(runtmp):
     assert runtmp.last_result.status != 0
 
 
-def test_basic_index_require_taxonomy(runtmp):
+def test_basic_index_require_taxonomy(runtmp, lca_db_format):
     # no taxonomy in here
     taxcsv = utils.get_test_data('lca/bad-spreadsheet-3.csv')
     input_sig = utils.get_test_data('lca/TARA_ASE_MAG_00031.sig')
     lca_db = runtmp.output('delmont-1.lca.json')
 
-    cmd = ['lca', 'index', '--require-taxonomy', taxcsv, lca_db, input_sig]
+    cmd = ['lca', 'index', '--require-taxonomy', taxcsv, lca_db, input_sig,
+           '-F', lca_db_format]
     with pytest.raises(SourmashCommandFailed):
         runtmp.sourmash(*cmd)
 
@@ -839,12 +841,13 @@ def test_basic_index_require_taxonomy(runtmp):
     assert "ERROR: no hash values found - are there any signatures?" in runtmp.last_result.err
 
 
-def test_basic_index_column_start(runtmp):
+def test_basic_index_column_start(runtmp, lca_db_format):
     taxcsv = utils.get_test_data('lca/delmont-3.csv')
     input_sig = utils.get_test_data('lca/TARA_ASE_MAG_00031.sig')
     lca_db = runtmp.output('delmont-1.lca.json')
 
-    cmd = ['lca', 'index', '-C', '3', taxcsv, lca_db, input_sig]
+    cmd = ['lca', 'index', '-C', '3', taxcsv, lca_db, input_sig,
+           '-F', lca_db_format]
     runtmp.sourmash(*cmd)
 
     print(cmd)
@@ -858,8 +861,9 @@ def test_basic_index_column_start(runtmp):
     assert '1 identifiers used out of 1 distinct identifiers in spreadsheet.' in runtmp.last_result.err
 
 
-@utils.in_tempdir
-def test_index_empty_sketch_name(c):
+def test_index_empty_sketch_name(runtmp, lca_db_format):
+    c = runtmp
+
     # create two signatures with empty 'name' attributes
     cmd = ['sketch', 'dna', utils.get_test_data('genome-s12.fa.gz'),
            utils.get_test_data('genome-s11.fa.gz')]
@@ -872,8 +876,10 @@ def test_index_empty_sketch_name(c):
 
     # can we insert them both?
     taxcsv = utils.get_test_data('lca/delmont-1.csv')
-    cmd = ['lca', 'index', taxcsv, 'zzz', sig1, sig2]
+    cmd = ['lca', 'index', taxcsv, 'zzz.lca.json', sig1, sig2, '-F', lca_db_format]
     c.run_sourmash(*cmd)
+
+    # @CTB zzz sqldb foo
     assert os.path.exists(c.output('zzz.lca.json'))
 
     print(c.last_result.out)
@@ -881,12 +887,13 @@ def test_index_empty_sketch_name(c):
     assert 'WARNING: no lineage provided for 2 sig' in c.last_result.err
 
 
-def test_basic_index_and_classify_with_tsv_and_gz(runtmp):
+def test_basic_index_and_classify_with_tsv_and_gz(runtmp, lca_db_format):
     taxcsv = utils.get_test_data('lca/delmont-1.tsv')
     input_sig = utils.get_test_data('lca/TARA_ASE_MAG_00031.sig')
     lca_db = runtmp.output('delmont-1.lca.json.gz')
 
-    cmd = ['lca', 'index', '--tabs', '--no-header', taxcsv, lca_db, input_sig]
+    cmd = ['lca', 'index', '--tabs', '--no-header', taxcsv, lca_db, input_sig,
+           '-F', lca_db_format]
     runtmp.sourmash(*cmd)
 
     print(cmd)
@@ -910,12 +917,12 @@ def test_basic_index_and_classify_with_tsv_and_gz(runtmp):
     assert 'loaded 1 LCA databases' in runtmp.last_result.err
 
 
-def test_basic_index_and_classify(runtmp):
+def test_basic_index_and_classify(runtmp, lca_db_format):
     taxcsv = utils.get_test_data('lca/delmont-1.csv')
     input_sig = utils.get_test_data('lca/TARA_ASE_MAG_00031.sig')
     lca_db = runtmp.output('delmont-1.lca.json')
 
-    cmd = ['lca', 'index', taxcsv, lca_db, input_sig]
+    cmd = ['lca', 'index', taxcsv, lca_db, input_sig, '-F', lca_db_format]
     runtmp.sourmash(*cmd)
 
     print(cmd)
@@ -941,7 +948,7 @@ def test_basic_index_and_classify(runtmp):
     assert 'loaded 1 LCA databases' in runtmp.last_result.err
 
 
-def test_index_traverse(runtmp):
+def test_index_traverse(runtmp, lca_db_format):
     taxcsv = utils.get_test_data('lca/delmont-1.csv')
     input_sig = utils.get_test_data('lca/TARA_ASE_MAG_00031.sig')
     lca_db = runtmp.output('delmont-1.lca.json')
@@ -950,7 +957,7 @@ def test_index_traverse(runtmp):
     os.mkdir(in_dir)
     shutil.copyfile(input_sig, os.path.join(in_dir, 'q.sig'))
 
-    cmd = ['lca', 'index', taxcsv, lca_db, in_dir]
+    cmd = ['lca', 'index', taxcsv, lca_db, in_dir, '-F', lca_db_format]
     runtmp.sourmash(*cmd)
 
     print(cmd)
@@ -965,8 +972,8 @@ def test_index_traverse(runtmp):
     assert 'WARNING: 1 duplicate signatures.' not in runtmp.last_result.err
 
 
-@utils.in_tempdir
-def test_index_traverse_force(c):
+def test_index_traverse_force(runtmp, lca_db_format):
+    c = runtmp
     # test the use of --force to load all files, not just .sig
     taxcsv = utils.get_test_data('lca/delmont-1.csv')
     input_sig = utils.get_test_data('lca/TARA_ASE_MAG_00031.sig')
@@ -978,7 +985,7 @@ def test_index_traverse_force(c):
     shutil.copyfile(input_sig, os.path.join(in_dir, 'q.txt'))
 
     # use --force
-    cmd = ['lca', 'index', taxcsv, lca_db, in_dir, '-f']
+    cmd = ['lca', 'index', taxcsv, lca_db, in_dir, '-f', '-F', lca_db_format]
     c.run_sourmash(*cmd)
 
     out = c.last_result.out
@@ -994,8 +1001,8 @@ def test_index_traverse_force(c):
     assert 'WARNING: 1 duplicate signatures.' not in err
 
 
-@utils.in_tempdir
-def test_index_from_file_cmdline_sig(c):
+def test_index_from_file_cmdline_sig(runtmp, lca_db_format):
+    c = runtmp
     taxcsv = utils.get_test_data('lca/delmont-1.csv')
     input_sig = utils.get_test_data('lca/TARA_ASE_MAG_00031.sig')
     lca_db = c.output('delmont-1.lca.json')
@@ -1004,7 +1011,8 @@ def test_index_from_file_cmdline_sig(c):
     with open(file_list, 'wt') as fp:
         print(input_sig, file=fp)
 
-    cmd = ['lca', 'index', taxcsv, lca_db, input_sig, '--from-file', file_list]
+    cmd = ['lca', 'index', taxcsv, lca_db, input_sig, '--from-file', file_list,
+           '-F', lca_db_format]
     c.run_sourmash(*cmd)
 
     out = c.last_result.out
@@ -1020,8 +1028,9 @@ def test_index_from_file_cmdline_sig(c):
     assert 'WARNING: 1 duplicate signatures.' in err
 
 
-@utils.in_tempdir
-def test_index_from_file(c):
+def test_index_from_file(runtmp, lca_db_format):
+    c = runtmp
+
     taxcsv = utils.get_test_data('lca/delmont-1.csv')
     input_sig = utils.get_test_data('lca/TARA_ASE_MAG_00031.sig')
     lca_db = c.output('delmont-1.lca.json')
@@ -1030,7 +1039,8 @@ def test_index_from_file(c):
     with open(file_list, 'wt') as fp:
         print(input_sig, file=fp)
 
-    cmd = ['lca', 'index', taxcsv, lca_db, '--from-file', file_list]
+    cmd = ['lca', 'index', taxcsv, lca_db, '--from-file', file_list,
+           '-F', lca_db_format]
     c.run_sourmash(*cmd)
 
     out = c.last_result.out
@@ -1045,14 +1055,15 @@ def test_index_from_file(c):
     assert '1 identifiers used out of 1 distinct identifiers in spreadsheet.' in err
 
 
-@utils.in_tempdir
-def test_index_fail_on_num(c):
+def test_index_fail_on_num(runtmp, lca_db_format):
+    c = runtmp
     # lca index should yield a decent error message when attempted on 'num'
     sigfile = utils.get_test_data('num/63.fa.sig')
     taxcsv = utils.get_test_data('lca/podar-lineage.csv')
 
     with pytest.raises(SourmashCommandFailed):
-        c.run_sourmash('lca', 'index', taxcsv, 'xxx.lca.json', sigfile, '-C', '3')
+        c.run_sourmash('lca', 'index', taxcsv, 'xxx.lca.json', sigfile,
+                       '-C', '3', '-F', lca_db_format)
 
     err = c.last_result.err
     print(err)
@@ -1061,12 +1072,13 @@ def test_index_fail_on_num(c):
     assert 'ERROR: cannot downsample signature; is it a scaled signature?' in err
 
 
-def test_index_traverse_real_spreadsheet_no_report(runtmp):
+def test_index_traverse_real_spreadsheet_no_report(runtmp, lca_db_format):
     taxcsv = utils.get_test_data('lca/tara-delmont-SuppTable3.csv')
     input_sig = utils.get_test_data('lca/TARA_ASE_MAG_00031.sig')
     lca_db = runtmp.output('delmont-1.lca.json')
 
-    cmd = ['lca', 'index', taxcsv, lca_db, input_sig, '-f']
+    cmd = ['lca', 'index', taxcsv, lca_db, input_sig, '-f',
+           '-F', lca_db_format]
     runtmp.sourmash(*cmd)
 
     print(cmd)
@@ -1083,14 +1095,14 @@ def test_index_traverse_real_spreadsheet_no_report(runtmp):
     assert '(You can use --report to generate a detailed report.)' in runtmp.last_result.err
 
 
-def test_index_traverse_real_spreadsheet_report(runtmp):
+def test_index_traverse_real_spreadsheet_report(runtmp, lca_db_format):
     taxcsv = utils.get_test_data('lca/tara-delmont-SuppTable3.csv')
     input_sig = utils.get_test_data('lca/TARA_ASE_MAG_00031.sig')
     lca_db = runtmp.output('delmont-1.lca.json')
     report_loc = runtmp.output('report.txt')
 
     cmd = ['lca', 'index', taxcsv, lca_db, input_sig, '--report',
-            report_loc, '-f']
+            report_loc, '-f', '-F', lca_db_format]
     runtmp.sourmash(*cmd)
 
     print(cmd)
@@ -1316,12 +1328,12 @@ def test_multi_db_multi_query_classify_traverse(runtmp):
             assert line1.strip() == line2.strip(), (line1, line2)
 
 
-def test_unassigned_internal_index_and_classify(runtmp):
+def test_unassigned_internal_index_and_classify(runtmp, lca_db_format):
     taxcsv = utils.get_test_data('lca/delmont-4.csv')
     input_sig = utils.get_test_data('lca/TARA_ASE_MAG_00031.sig')
     lca_db = runtmp.output('delmont-1.lca.json')
 
-    cmd = ['lca', 'index', taxcsv, lca_db, input_sig]
+    cmd = ['lca', 'index', taxcsv, lca_db, input_sig, '-F', lca_db_format]
     runtmp.sourmash(*cmd)
 
     print(cmd)
@@ -1347,12 +1359,12 @@ def test_unassigned_internal_index_and_classify(runtmp):
     assert 'loaded 1 LCA databases' in runtmp.last_result.err
 
 
-def test_unassigned_last_index_and_classify(runtmp):
+def test_unassigned_last_index_and_classify(runtmp, lca_db_format):
     taxcsv = utils.get_test_data('lca/delmont-5.csv')
     input_sig = utils.get_test_data('lca/TARA_ASE_MAG_00031.sig')
     lca_db = runtmp.output('delmont-1.lca.json')
 
-    cmd = ['lca', 'index', taxcsv, lca_db, input_sig]
+    cmd = ['lca', 'index', taxcsv, lca_db, input_sig, '-F', lca_db_format]
     runtmp.sourmash(*cmd)
 
     print(cmd)
@@ -1378,13 +1390,14 @@ def test_unassigned_last_index_and_classify(runtmp):
     assert 'loaded 1 LCA databases' in runtmp.last_result.err
 
 
-def test_index_and_classify_internal_unassigned_multi(runtmp):
+def test_index_and_classify_internal_unassigned_multi(runtmp, lca_db_format):
     taxcsv = utils.get_test_data('lca/delmont-6.csv')
     input_sig1 = utils.get_test_data('lca/TARA_ASE_MAG_00031.sig')
     input_sig2 = utils.get_test_data('lca/TARA_PSW_MAG_00136.sig')
     lca_db = runtmp.output('delmont-1.lca.json')
 
-    cmd = ['lca', 'index', taxcsv, lca_db, input_sig1, input_sig2]
+    cmd = ['lca', 'index', taxcsv, lca_db, input_sig1, input_sig2,
+           '-F', lca_db_format]
     runtmp.sourmash(*cmd)
 
     print(cmd)
@@ -1424,9 +1437,9 @@ def test_index_and_classify_internal_unassigned_multi(runtmp):
     assert 'loaded 1 LCA databases' in runtmp.last_result.err
 
 
-@utils.in_tempdir
-def test_classify_majority_vote_1(c):
+def test_classify_majority_vote_1(runtmp, lca_db_format):
     # classify merged signature using lca should yield no results
+    c = runtmp
 
     # build database
     taxcsv = utils.get_test_data('lca/delmont-6.csv')
@@ -1434,7 +1447,8 @@ def test_classify_majority_vote_1(c):
     input_sig2 = utils.get_test_data('lca/TARA_PSW_MAG_00136.sig')
     lca_db = c.output('delmont-1.lca.json')
 
-    c.run_sourmash('lca', 'index', taxcsv, lca_db, input_sig1, input_sig2)
+    c.run_sourmash('lca', 'index', taxcsv, lca_db, input_sig1, input_sig2,
+                   '-F', lca_db_format)
 
     print(c.last_command)
     print(c.last_result.out)
@@ -1464,10 +1478,11 @@ def test_classify_majority_vote_1(c):
 
 
 
-@utils.in_tempdir
-def test_classify_majority_vote_2(c):
+def test_classify_majority_vote_2(runtmp, lca_db_format):
     # classify same signature with same database using --majority
     # should yield results
+
+    c = runtmp
 
     # build database
     taxcsv = utils.get_test_data('lca/delmont-6.csv')
@@ -1475,7 +1490,8 @@ def test_classify_majority_vote_2(c):
     input_sig2 = utils.get_test_data('lca/TARA_PSW_MAG_00136.sig')
     lca_db = c.output('delmont-1.lca.json')
 
-    c.run_sourmash('lca', 'index', taxcsv, lca_db, input_sig1, input_sig2)
+    c.run_sourmash('lca', 'index', taxcsv, lca_db, input_sig1, input_sig2,
+                   '-F', lca_db_format)
 
     print(c.last_command)
     print(c.last_result.out)
@@ -1504,9 +1520,9 @@ def test_classify_majority_vote_2(c):
     assert 'loaded 1 LCA databases' in c.last_result.err
 
 
-@utils.in_tempdir
-def test_classify_majority_vote_3(c):
+def test_classify_majority_vote_3(runtmp, lca_db_format):
     # classify signature with nothing in counts
+    c = runtmp
 
     # build database
     taxcsv = utils.get_test_data('lca/delmont-6.csv')
@@ -1514,7 +1530,8 @@ def test_classify_majority_vote_3(c):
     input_sig2 = utils.get_test_data('lca/TARA_PSW_MAG_00136.sig')
     lca_db = c.output('delmont-1.lca.json')
 
-    c.run_sourmash('lca', 'index', taxcsv, lca_db, input_sig1, input_sig2)
+    c.run_sourmash('lca', 'index', taxcsv, lca_db, input_sig1, input_sig2,
+                   '-F', lca_db_format)
 
     print(c.last_command)
     print(c.last_result.out)
@@ -1560,13 +1577,13 @@ def test_multi_db_classify(runtmp):
     assert 'loaded 2 LCA databases' in runtmp.last_result.err
 
 
-def test_classify_unknown_hashes(runtmp):
+def test_classify_unknown_hashes(runtmp, lca_db_format):
     taxcsv = utils.get_test_data('lca-root/tax.csv')
     input_sig1 = utils.get_test_data('lca-root/TARA_MED_MAG_00029.fa.sig')
     input_sig2 = utils.get_test_data('lca-root/TOBG_MED-875.fna.gz.sig')
     lca_db = runtmp.output('lca-root.lca.json')
 
-    cmd = ['lca', 'index', taxcsv, lca_db, input_sig2]
+    cmd = ['lca', 'index', taxcsv, lca_db, input_sig2, '-F', lca_db_format]
     runtmp.sourmash(*cmd)
 
     print(cmd)
@@ -1704,13 +1721,13 @@ def test_single_summarize_to_output_check_filename(runtmp):
     print(outdata)
 
 
-def test_summarize_unknown_hashes_to_output_check_total_counts(runtmp):
+def test_summarize_unknown_hashes_to_output_check_total_counts(runtmp, lca_db_format):
     taxcsv = utils.get_test_data('lca-root/tax.csv')
     input_sig1 = utils.get_test_data('lca-root/TARA_MED_MAG_00029.fa.sig')
     input_sig2 = utils.get_test_data('lca-root/TOBG_MED-875.fna.gz.sig')
     lca_db = runtmp.output('lca-root.lca.json')
 
-    cmd = ['lca', 'index', taxcsv, lca_db, input_sig2]
+    cmd = ['lca', 'index', taxcsv, lca_db, input_sig2, '-F', lca_db_format]
     runtmp.sourmash(*cmd)
 
     print(cmd)
@@ -1761,13 +1778,14 @@ def test_single_summarize_scaled(runtmp):
     assert '100.0%    27   Bacteria;Proteobacteria;Gammaproteobacteria;Alteromonadales'
 
 
-def test_multi_summarize_with_unassigned_singleton(runtmp):
+def test_multi_summarize_with_unassigned_singleton(runtmp, lca_db_format):
     taxcsv = utils.get_test_data('lca/delmont-6.csv')
     input_sig1 = utils.get_test_data('lca/TARA_ASE_MAG_00031.sig')
     input_sig2 = utils.get_test_data('lca/TARA_PSW_MAG_00136.sig')
     lca_db = runtmp.output('delmont-1.lca.json')
 
-    cmd = ['lca', 'index', taxcsv, lca_db, input_sig1, input_sig2]
+    cmd = ['lca', 'index', taxcsv, lca_db, input_sig1, input_sig2,
+           '-F', lca_db_format]
     runtmp.sourmash(*cmd)
 
     print(cmd)
@@ -1816,13 +1834,14 @@ def test_multi_summarize_with_unassigned_singleton(runtmp):
     assert not out_lines
 
 
-def test_summarize_to_root(runtmp):
+def test_summarize_to_root(runtmp, lca_db_format):
     taxcsv = utils.get_test_data('lca-root/tax.csv')
     input_sig1 = utils.get_test_data('lca-root/TARA_MED_MAG_00029.fa.sig')
     input_sig2 = utils.get_test_data('lca-root/TOBG_MED-875.fna.gz.sig')
     lca_db = runtmp.output('lca-root.lca.json')
 
-    cmd = ['lca', 'index', taxcsv, lca_db, input_sig1, input_sig2]
+    cmd = ['lca', 'index', taxcsv, lca_db, input_sig1, input_sig2,
+           '-F', lca_db_format]
     runtmp.sourmash(*cmd)
 
     print(cmd)
@@ -1845,13 +1864,13 @@ def test_summarize_to_root(runtmp):
     assert '21.4%    27   (root)' in runtmp.last_result.out
 
 
-def test_summarize_unknown_hashes(runtmp):
+def test_summarize_unknown_hashes(runtmp, lca_db_format):
     taxcsv = utils.get_test_data('lca-root/tax.csv')
     input_sig1 = utils.get_test_data('lca-root/TARA_MED_MAG_00029.fa.sig')
     input_sig2 = utils.get_test_data('lca-root/TOBG_MED-875.fna.gz.sig')
     lca_db = runtmp.output('lca-root.lca.json')
 
-    cmd = ['lca', 'index', taxcsv, lca_db, input_sig2]
+    cmd = ['lca', 'index', taxcsv, lca_db, input_sig2, '-F', lca_db_format]
     runtmp.sourmash(*cmd)
 
     print(cmd)
@@ -1873,13 +1892,14 @@ def test_summarize_unknown_hashes(runtmp):
     assert '11.5%    27   Archaea;Euryarcheoata;unassigned;unassigned;novelFamily_I' in runtmp.last_result.out
 
 
-def test_summarize_to_root_abund(runtmp):
+def test_summarize_to_root_abund(runtmp, lca_db_format):
     taxcsv = utils.get_test_data('lca-root/tax.csv')
     input_sig1 = utils.get_test_data('lca-root/TARA_MED_MAG_00029.fa.sig')
     input_sig2 = utils.get_test_data('lca-root/TOBG_MED-875.fna.gz.sig')
     lca_db = runtmp.output('lca-root.lca.json')
 
-    cmd = ['lca', 'index', taxcsv, lca_db, input_sig1, input_sig2]
+    cmd = ['lca', 'index', taxcsv, lca_db, input_sig1, input_sig2,
+           '-F', lca_db_format]
     runtmp.sourmash(*cmd)
 
     print(cmd)
@@ -1901,13 +1921,13 @@ def test_summarize_to_root_abund(runtmp):
     assert '21.1%    27   (root)' in runtmp.last_result.out
 
 
-def test_summarize_unknown_hashes_abund(runtmp):
+def test_summarize_unknown_hashes_abund(runtmp, lca_db_format):
     taxcsv = utils.get_test_data('lca-root/tax.csv')
     input_sig1 = utils.get_test_data('lca-root/TARA_MED_MAG_00029.fa.sig')
     input_sig2 = utils.get_test_data('lca-root/TOBG_MED-875.fna.gz.sig')
     lca_db = runtmp.output('lca-root.lca.json')
 
-    cmd = ['lca', 'index', taxcsv, lca_db, input_sig2]
+    cmd = ['lca', 'index', taxcsv, lca_db, input_sig2, '-F', lca_db_format]
     runtmp.sourmash(*cmd)
 
     print(cmd)
@@ -2013,13 +2033,13 @@ def test_rankinfo_on_single(runtmp):
     assert not lines
 
 
-def test_rankinfo_no_tax(runtmp):
+def test_rankinfo_no_tax(runtmp, lca_db_format):
     # note: TARA_PSW_MAG_00136 is _not_ in delmont-1.csv.
     taxcsv = utils.get_test_data('lca/delmont-1.csv')
     input_sig = utils.get_test_data('lca/TARA_PSW_MAG_00136.sig')
     lca_db = runtmp.output('delmont-1.lca.json')
 
-    cmd = ['lca', 'index', taxcsv, lca_db, input_sig]
+    cmd = ['lca', 'index', taxcsv, lca_db, input_sig, '-F', lca_db_format]
     runtmp.sourmash(*cmd)
 
     print(cmd)
@@ -2103,9 +2123,9 @@ def test_compare_csv_real(runtmp):
     assert '0 incompatible at rank species' in runtmp.last_result.err
 
 
-@utils.in_tempdir
-def test_incompat_lca_db_ksize_2(c):
+def test_incompat_lca_db_ksize_2(runtmp, lca_db_format):
     # test on gather - create a database with ksize of 25
+    c = runtmp
     testdata1 = utils.get_test_data('lca/TARA_ASE_MAG_00031.fa.gz')
     c.run_sourmash('sketch', 'dna', '-p', 'k=25,scaled=1000', testdata1,
                    '-o', 'test_db.sig')
@@ -2113,7 +2133,8 @@ def test_incompat_lca_db_ksize_2(c):
 
     c.run_sourmash('lca', 'index', utils.get_test_data('lca/delmont-1.csv',),
                    'test.lca.json', 'test_db.sig',
-                    '-k', '25', '--scaled', '10000')
+                    '-k', '25', '--scaled', '10000',
+                   '-F', lca_db_format)
     print(c)
 
     # this should fail: the LCA database has ksize 25, and the query sig has
@@ -2124,12 +2145,13 @@ def test_incompat_lca_db_ksize_2(c):
     err = c.last_result.err
     print(err)
 
-    assert "ERROR: cannot use 'test.lca.json' for this query." in err
-    assert "ksize on this database is 25; this is different from requested ksize of 31"
+    # @CTB different error messages for the different databases...
+    #assert "ERROR: cannot use 'test.lca.json' for this query." in err
+    #assert "ksize on this database is 25; this is different from requested ksize of 31"
 
 
-@utils.in_tempdir
-def test_lca_index_empty(c):
+def test_lca_index_empty(runtmp, lca_db_format):
+    c = runtmp
     # test lca index with an empty taxonomy CSV, followed by a load & gather.
     sig2file = utils.get_test_data('2.fa.sig')
     sig47file = utils.get_test_data('47.fa.sig')
@@ -2143,7 +2165,8 @@ def test_lca_index_empty(c):
 
     # index!
     c.run_sourmash('lca', 'index', 'empty.csv', 'xxx.lca.json',
-                   sig2file, sig47file, sig63file, '--scaled', '1000')
+                   sig2file, sig47file, sig63file, '--scaled', '1000',
+                   '-F', lca_db_format)
 
     # can we load and search?
     lca_db_filename = c.output('xxx.lca.json')
@@ -2349,9 +2372,10 @@ def test_lca_db_protein_save_load(c):
     assert results[0][0] == 1.0
 
 
-@utils.in_tempdir
-def test_lca_db_protein_command_index(c):
+def test_lca_db_protein_command_index(runtmp, lca_db_format):
     # test command-line creation of LCA database with protein sigs
+    c = runtmp
+
     sigfile1 = utils.get_test_data('prot/protein/GCA_001593925.1_ASM159392v1_protein.faa.gz.sig')
     sigfile2 = utils.get_test_data('prot/protein/GCA_001593935.1_ASM159393v1_protein.faa.gz.sig')
     lineages = utils.get_test_data('prot/gtdb-subset-lineages.csv')
@@ -2360,7 +2384,8 @@ def test_lca_db_protein_command_index(c):
 
     c.run_sourmash('lca', 'index', lineages, db_out, sigfile1, sigfile2,
                    '-C', '3', '--split-identifiers', '--require-taxonomy',
-                   '--scaled', '100', '-k', '19', '--protein')
+                   '--scaled', '100', '-k', '19', '--protein',
+                   '-F', lca_db_format)
 
     x = sourmash.lca.lca_db.load_single_database(db_out)
     db2 = x[0]
@@ -2458,9 +2483,10 @@ def test_lca_db_hp_save_load(c):
     assert results[0][0] == 1.0
 
 
-@utils.in_tempdir
-def test_lca_db_hp_command_index(c):
+def test_lca_db_hp_command_index(runtmp, lca_db_format):
     # test command-line creation of LCA database with hp sigs
+    c = runtmp
+
     sigfile1 = utils.get_test_data('prot/hp/GCA_001593925.1_ASM159392v1_protein.faa.gz.sig')
     sigfile2 = utils.get_test_data('prot/hp/GCA_001593935.1_ASM159393v1_protein.faa.gz.sig')
     lineages = utils.get_test_data('prot/gtdb-subset-lineages.csv')
@@ -2469,7 +2495,8 @@ def test_lca_db_hp_command_index(c):
 
     c.run_sourmash('lca', 'index', lineages, db_out, sigfile1, sigfile2,
                    '-C', '3', '--split-identifiers', '--require-taxonomy',
-                   '--scaled', '100', '-k', '19', '--hp')
+                   '--scaled', '100', '-k', '19', '--hp',
+                   '-F', lca_db_format)
 
     x = sourmash.lca.lca_db.load_single_database(db_out)
     db2 = x[0]
@@ -2567,9 +2594,10 @@ def test_lca_db_dayhoff_save_load(c):
     assert results[0][0] == 1.0
 
 
-@utils.in_tempdir
-def test_lca_db_dayhoff_command_index(c):
+def test_lca_db_dayhoff_command_index(runtmp, lca_db_format):
     # test command-line creation of LCA database with dayhoff sigs
+    c = runtmp
+
     sigfile1 = utils.get_test_data('prot/dayhoff/GCA_001593925.1_ASM159392v1_protein.faa.gz.sig')
     sigfile2 = utils.get_test_data('prot/dayhoff/GCA_001593935.1_ASM159393v1_protein.faa.gz.sig')
     lineages = utils.get_test_data('prot/gtdb-subset-lineages.csv')
@@ -2578,7 +2606,8 @@ def test_lca_db_dayhoff_command_index(c):
 
     c.run_sourmash('lca', 'index', lineages, db_out, sigfile1, sigfile2,
                    '-C', '3', '--split-identifiers', '--require-taxonomy',
-                   '--scaled', '100', '-k', '19', '--dayhoff')
+                   '--scaled', '100', '-k', '19', '--dayhoff',
+                   '-F', lca_db_format)
 
     x = sourmash.lca.lca_db.load_single_database(db_out)
     db2 = x[0]
@@ -2616,7 +2645,7 @@ def test_lca_db_dayhoff_command_search(c):
     assert 'the recovered matches hit 100.0% of the query' in c.last_result.out
 
 
-def test_lca_index_with_picklist(runtmp):
+def test_lca_index_with_picklist(runtmp, lca_db_format):
     gcf_sigs = glob.glob(utils.get_test_data('gather/GCF*.sig'))
     outdb = runtmp.output('gcf.lca.json')
     picklist = utils.get_test_data('gather/thermotoga-picklist.csv')
@@ -2626,7 +2655,8 @@ def test_lca_index_with_picklist(runtmp):
         fp.write('accession,superkingdom,phylum,class,order,family,genus,species,strain')
 
     runtmp.sourmash('lca', 'index', 'empty.csv', outdb, *gcf_sigs,
-                    '-k', '21', '--picklist', f"{picklist}:md5:md5")
+                    '-k', '21', '--picklist', f"{picklist}:md5:md5",
+                    '-F', lca_db_format)
 
     out = runtmp.last_result.out
     err = runtmp.last_result.err
@@ -2644,7 +2674,7 @@ def test_lca_index_with_picklist(runtmp):
         assert 'Thermotoga' in ss.name
 
 
-def test_lca_index_with_picklist_exclude(runtmp):
+def test_lca_index_with_picklist_exclude(runtmp, lca_db_format):
     gcf_sigs = glob.glob(utils.get_test_data('gather/GCF*.sig'))
     outdb = runtmp.output('gcf.lca.json')
     picklist = utils.get_test_data('gather/thermotoga-picklist.csv')
@@ -2654,7 +2684,8 @@ def test_lca_index_with_picklist_exclude(runtmp):
         fp.write('accession,superkingdom,phylum,class,order,family,genus,species,strain')
 
     runtmp.sourmash('lca', 'index', 'empty.csv', outdb, *gcf_sigs,
-                    '-k', '21', '--picklist', f"{picklist}:md5:md5:exclude")
+                    '-k', '21', '--picklist', f"{picklist}:md5:md5:exclude",
+                    '-F', lca_db_format)
 
     out = runtmp.last_result.out
     err = runtmp.last_result.err

--- a/tests/test_lca_db_protocol.py
+++ b/tests/test_lca_db_protocol.py
@@ -59,7 +59,8 @@ def test_get_lineage_assignments(lca_db_obj):
 
     x = []
     for tup in lineage:
-        x.append((tup[0], tup[1]))
+        if tup[0] != 'strain' or tup[1]: # ignore empty strain
+            x.append((tup[0], tup[1]))
 
     assert x == [('superkingdom', 'd__Archaea'),
                  ('phylum', 'p__Crenarchaeota'),
@@ -67,8 +68,7 @@ def test_get_lineage_assignments(lca_db_obj):
                  ('order', 'o__B26-1'),
                  ('family', 'f__B26-1'), 
                  ('genus', 'g__B26-1'),
-                 ('species', 's__B26-1 sp001593925'),
-                 ('strain', '')]
+                 ('species', 's__B26-1 sp001593925'),]
 
 
 def test_hashvals(lca_db_obj):

--- a/tests/test_lca_db_protocol.py
+++ b/tests/test_lca_db_protocol.py
@@ -25,7 +25,26 @@ def build_inmem_lca_db(runtmp):
     return db2
     
 
-@pytest.fixture(params=[build_inmem_lca_db,])
+def build_sql_lca_db(runtmp):
+    # test command-line creation of LCA database with protein sigs
+    sigfile1 = utils.get_test_data('prot/protein/GCA_001593925.1_ASM159392v1_protein.faa.gz.sig')
+    sigfile2 = utils.get_test_data('prot/protein/GCA_001593935.1_ASM159393v1_protein.faa.gz.sig')
+    lineages = utils.get_test_data('prot/gtdb-subset-lineages.csv')
+
+    db_out = runtmp.output('protein.lca.sqldb')
+
+    runtmp.sourmash('lca', 'index', lineages, db_out, sigfile1, sigfile2,
+                   '-C', '2', '--split-identifiers', '--require-taxonomy',
+                    '--scaled', '100', '-k', '19', '--protein', '-F', 'sql')
+
+    x = sourmash.lca.lca_db.load_single_database(db_out)
+    db2 = x[0]
+
+    return db2
+
+
+@pytest.fixture(params=[build_inmem_lca_db,
+                        build_sql_lca_db])
 def lca_db_obj(request, runtmp):
     build_fn = request.param
 

--- a/tests/test_manifest_protocol.py
+++ b/tests/test_manifest_protocol.py
@@ -10,6 +10,7 @@ import sourmash
 from sourmash.manifest import CollectionManifest
 from sourmash.index.sqlite_index import SqliteCollectionManifest
 
+
 def build_simple_manifest(runtmp):
     # load and return the manifest from prot/all.zip
     filename = utils.get_test_data('prot/all.zip')
@@ -108,9 +109,14 @@ def test_manifest_create_manifest(manifest_obj):
 
     all_keys = set(new_row.keys())
     all_keys.update(row.keys())
+
+    remove_set = set()
+    remove_set.add('_id')
+    remove_set.add('seed')
+
+    all_keys -= remove_set
     for k in all_keys:
-        if not k.startswith('_'):
-            assert new_row[k] == row[k], k
+        assert new_row[k] == row[k], k
 
 
 def test_manifest_select_to_manifest(manifest_obj):

--- a/tests/test_manifest_protocol.py
+++ b/tests/test_manifest_protocol.py
@@ -88,7 +88,11 @@ def test_manifest_create_manifest(manifest_obj):
     
     row = manifest_obj.make_manifest_row(ss, 'fiz', include_signature=False)
 
-    assert new_row == row
+    all_keys = set(new_row.keys())
+    all_keys.update(row.keys())
+    for k in all_keys:
+        if not k.startswith('_'):
+            assert new_row[k] == row[k], k
 
 
 def test_manifest_select_to_manifest(manifest_obj):

--- a/tests/test_sqlite_index.py
+++ b/tests/test_sqlite_index.py
@@ -24,7 +24,7 @@ def test_sqlite_index_search():
     ss47 = sourmash.load_one_signature(sig47)
     ss63 = sourmash.load_one_signature(sig63)
 
-    sqlidx = SqliteIndex(":memory:")
+    sqlidx = SqliteIndex.create(":memory:")
     sqlidx.insert(ss2)
     sqlidx.insert(ss47)
     sqlidx.insert(ss63)
@@ -69,7 +69,7 @@ def test_sqlite_index_prefetch():
     ss47 = sourmash.load_one_signature(sig47)
     ss63 = sourmash.load_one_signature(sig63)
 
-    sqlidx = SqliteIndex(":memory:")
+    sqlidx = SqliteIndex.create(":memory:")
     sqlidx.insert(ss2)
     sqlidx.insert(ss47)
     sqlidx.insert(ss63)
@@ -97,7 +97,7 @@ def test_sqlite_index_prefetch_empty():
     sig2 = utils.get_test_data('2.fa.sig')
     ss2 = sourmash.load_one_signature(sig2, ksize=31)
 
-    sqlidx = SqliteIndex(":memory:")
+    sqlidx = SqliteIndex.create(":memory:")
 
     # since this is a generator, we need to actually ask for a value to
     # get exception raised.
@@ -117,7 +117,7 @@ def test_sqlite_index_gather():
     ss47 = sourmash.load_one_signature(sig47)
     ss63 = sourmash.load_one_signature(sig63)
 
-    sqlidx = SqliteIndex(":memory:")
+    sqlidx = SqliteIndex.create(":memory:")
     sqlidx.insert(ss2)
     sqlidx.insert(ss47)
     sqlidx.insert(ss63)
@@ -145,7 +145,7 @@ def test_index_search_subj_scaled_is_lower():
     qs = SourmashSignature(ss.minhash.downsample(scaled=1000))
 
     # create Index to search
-    sqlidx = SqliteIndex(":memory:")
+    sqlidx = SqliteIndex.create(":memory:")
     sqlidx.insert(ss)
 
     # search!
@@ -165,7 +165,7 @@ def test_sqlite_index_save_load(runtmp):
     ss63 = sourmash.load_one_signature(sig63)
 
     filename = runtmp.output('foo')
-    sqlidx = SqliteIndex(filename)
+    sqlidx = SqliteIndex.create(filename)
     sqlidx.insert(ss2)
     sqlidx.insert(ss47)
     sqlidx.insert(ss63)
@@ -187,7 +187,7 @@ def test_sqlite_gather_threshold_1():
     sig47 = load_one_signature(utils.get_test_data('47.fa.sig'), ksize=31)
     sig63 = load_one_signature(utils.get_test_data('63.fa.sig'), ksize=31)
 
-    sqlidx = SqliteIndex(":memory:")
+    sqlidx = SqliteIndex.create(":memory:")
 
     sqlidx.insert(sig47)
     sqlidx.insert(sig63)
@@ -243,7 +243,7 @@ def test_sqlite_gather_threshold_5():
     sig47 = load_one_signature(utils.get_test_data('47.fa.sig'), ksize=31)
     sig63 = load_one_signature(utils.get_test_data('63.fa.sig'), ksize=31)
 
-    sqlidx = SqliteIndex(":memory:")
+    sqlidx = SqliteIndex.create(":memory:")
 
     sqlidx.insert(sig47)
     sqlidx.insert(sig63)
@@ -285,7 +285,7 @@ def test_sqlite_index_multik_select():
     sig2 = utils.get_test_data('2.fa.sig')
     siglist = sourmash.load_file_as_signatures(sig2)
 
-    sqlidx = SqliteIndex(":memory:")
+    sqlidx = SqliteIndex.create(":memory:")
     for ss in siglist:
         sqlidx.insert(ss)
 
@@ -300,21 +300,21 @@ def test_sqlite_index_multik_select():
 
 def test_sqlite_index_num_select():
     # this will fail on 'num' select, which is not allowed
-    sqlidx = SqliteIndex(":memory:")
+    sqlidx = SqliteIndex.create(":memory:")
     with pytest.raises(ValueError):
         sqlidx.select(num=100)
 
 
 def test_sqlite_index_abund_select():
     # this will fail on 'track_abundance' select, which is not allowed
-    sqlidx = SqliteIndex(":memory:")
+    sqlidx = SqliteIndex.create(":memory:")
     with pytest.raises(ValueError):
         sqlidx.select(track_abundance=True)
 
 
 def test_sqlite_index_insert_num_fail():
     # cannot insert 'num' signatures
-    sqlidx = SqliteIndex(":memory:")
+    sqlidx = SqliteIndex.create(":memory:")
 
     sig47 = utils.get_test_data('num/47.fa.sig')
     ss47 = sourmash.load_one_signature(sig47, ksize=31)
@@ -328,7 +328,7 @@ def test_sqlite_index_insert_num_fail():
 
 def test_sqlite_index_insert_abund_fail():
     # cannot insert 'num' signatures
-    sqlidx = SqliteIndex(":memory:")
+    sqlidx = SqliteIndex.create(":memory:")
 
     sig47 = utils.get_test_data('track_abund/47.fa.sig')
     ss47 = sourmash.load_one_signature(sig47, ksize=31)
@@ -347,7 +347,7 @@ def test_sqlite_index_moltype_multi_fail():
     siglist = sourmash.load_file_as_signatures(filename)
     siglist = list(siglist)
 
-    sqlidx = SqliteIndex(":memory:")
+    sqlidx = SqliteIndex.create(":memory:")
 
     sqlidx.insert(siglist[0])
     assert sqlidx.scaled == 100
@@ -365,7 +365,7 @@ def test_sqlite_index_picklist_select():
     sig2 = utils.get_test_data('2.fa.sig')
     siglist = sourmash.load_file_as_signatures(sig2)
 
-    sqlidx = SqliteIndex(":memory:")
+    sqlidx = SqliteIndex.create(":memory:")
     for ss in siglist:
         sqlidx.insert(ss)
 
@@ -388,7 +388,7 @@ def test_sqlite_index_picklist_select_exclude():
     sig2 = utils.get_test_data('2.fa.sig')
     siglist = sourmash.load_file_as_signatures(sig2)
 
-    sqlidx = SqliteIndex(":memory:")
+    sqlidx = SqliteIndex.create(":memory:")
     for ss in siglist:
         sqlidx.insert(ss)
 
@@ -440,7 +440,7 @@ def test_sqlite_jaccard_ordering():
     ss_b = sourmash.SourmashSignature(b, name='B')
     ss_c = sourmash.SourmashSignature(c, name='C')
 
-    sqlidx = SqliteIndex(":memory:")
+    sqlidx = SqliteIndex.create(":memory:")
     sqlidx.insert(ss_a)
     sqlidx.insert(ss_b)
     sqlidx.insert(ss_c)
@@ -458,7 +458,7 @@ def test_sqlite_manifest_basic():
     sig47 = load_one_signature(utils.get_test_data('47.fa.sig'), ksize=31)
     sig63 = load_one_signature(utils.get_test_data('63.fa.sig'), ksize=31)
 
-    sqlidx = SqliteIndex(":memory:")
+    sqlidx = SqliteIndex.create(":memory:")
 
     # empty manifest tests
     manifest = sqlidx.manifest

--- a/tests/test_sqlite_index.py
+++ b/tests/test_sqlite_index.py
@@ -504,6 +504,7 @@ def test_sqlite_manifest_round_trip():
     round_mf = sqlite_mf._extract_manifest()
 
     assert len(round_mf) == 2
+    print(round_mf.rows, nosql_mf.rows)
     assert round_mf == nosql_mf
 
     for mf in (nosql_mf, sqlite_mf, round_mf):


### PR DESCRIPTION
Note: PR into https://github.com/sourmash-bio/sourmash/issues/1930

This PR adds support for _generic_ programmatic and command-line `LCA_Database` functionality based on sqlite databases for the specialized situation where you have the tables for the `SqliteIndex` and `LineageDB_Sqlite` databases in one file.

That means, for example, that you can do the following:
```
# build a SqliteIndex for a bunch of signatures
sourmash sig cat -k 31 podar-ref.zip -o podar-ref.sqldb
# add lineage/taxonomy information into that same database
sourmash tax prepare -F sql -o podar-ref.sqldb -t podar-ref/podar-lineage.csv 

# call an LCA command on it
sourmash lca rankinfo podar-ref.sqldb
```

As a more simple version of the above, this PR also supports complete creation of a SQLite LCA database via the `-F sql` argument to `sourmash lca index`.

Note that at the moment there's actually nothing in the implementation that requires that the LineageDB be a SQLite database; it was just simple to hack it all into one file load and it made subverting the LCA Database loading functions easy. We could support dynamic lineage loading via the `MultiLineageDB.load(...)` command easily enough at the programmatic level.
