### PR TITLE
build macos arm64 wheels

### DIFF
--- a/.ci/install_cargo.sh
+++ b/.ci/install_cargo.sh
@@ -2,3 +2,4 @@
 curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable
 export PATH="$HOME/.cargo/bin:$PATH"
 rustc -V
+rustup target add aarch64-apple-darwin

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -20,6 +20,7 @@ jobs:
           linux-ppc64le,
           linux-s390x,
           macos-x86_64,
+          macos-arm64,
         ]
         include:
           - build: linux-x86_64
@@ -41,7 +42,11 @@ jobs:
           - build: macos-x86_64
             os: macos-latest
             arch: x86_64
-            macos_target: 'MACOSX_DEPLOYMENT_TARGET=10.11'
+            macos_target: 'MACOSX_DEPLOYMENT_TARGET=10.11 CARGO_BUILD_TARGET=x86_64-apple-darwin'
+          - build: macos-arm64
+            os: macos-latest
+            arch: arm64
+            macos_target: 'MACOSX_DEPLOYMENT_TARGET=11 CARGO_BUILD_TARGET=aarch64-apple-darwin'
       fail-fast: false
 
     steps:
@@ -63,12 +68,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.2.2
         env:
-          CIBW_BUILD: "cp39-*"
-          CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux_ppc64le *-musllinux_s390x"
-          CIBW_BEFORE_BUILD: 'source .ci/install_cargo.sh'
-          CIBW_ENVIRONMENT: 'PATH="$HOME/.cargo/bin:$PATH"'
           CIBW_ENVIRONMENT_MACOS: ${{ matrix.macos_target }}
-          CIBW_BUILD_VERBOSITY: 3
           CIBW_ARCHS_LINUX: ${{ matrix.arch }}
           CIBW_ARCHS_MACOS: ${{ matrix.arch }}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,3 +19,10 @@ include_trailing_comma = true
 force_grid_wrap = 0
 line_length = 88
 known_first_party = ["sourmash"]
+
+[tool.cibuildwheel]
+build = "cp39-*"
+skip = "*-win32 *-manylinux_i686 *-musllinux_ppc64le *-musllinux_s390x"
+before-build = "source .ci/install_cargo.sh"
+environment = { PATH="$HOME/.cargo/bin:$PATH" }
+build-verbosity = 3

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ DEBUG_BUILD = os.environ.get("SOURMASH_DEBUG") == "1"
 NO_BUILD = os.environ.get("NO_BUILD") == "1"
 
 
-def find_dylib(name, paths):
+def find_dylib_no_build(name, paths):
     to_find = None
     if sys.platform == 'darwin':
         to_find = f'lib{name}.dylib'
@@ -23,6 +23,15 @@ def find_dylib(name, paths):
                 return os.path.join(path, filename)
 
         raise LookupError('dylib %r not found' % name)
+
+
+def find_dylib(build, target):
+    cargo_target = os.environ.get("CARGO_BUILD_TARGET")
+    if cargo_target:
+        in_path = "target/%s/%s" % (cargo_target, target)
+    else:
+        in_path = "target/%s" % target
+    return build.find_dylib("sourmash", in_path=in_path)
 
 
 def build_native(spec):
@@ -41,7 +50,7 @@ def build_native(spec):
         header_filename = lambda: "include/sourmash.h"
     else:
         build = spec.add_external_build(cmd=cmd, path=".")
-        dylib=lambda: build.find_dylib("sourmash", in_path="target/%s" % target)
+        dylib = lambda: find_dylib(build, target)
         header_filename=lambda: build.find_header("sourmash.h", in_path="include")
 
     rtld_flags = ["NOW"]


### PR DESCRIPTION
Previous try (in #1334) tried to build `universal2` wheels on mac, but that's complicated. This PR builds two separated wheels, one for `arm64`, another for `x86_64`, and let `pip` choose the correct one during installation.

I also updated `cibuildwheel` to list configuration in `pyproject.toml`, this way it can also be tested locally.

(In preparation for fixing the currently broken `sourmash-minimal` package on `conda-forge`, which is not doing the cross-compilation properly).