### PR TITLE
[MRG] Speed-up `SeqToHashes()`

### DIFF
--- a/src/core/src/signature.rs
+++ b/src/core/src/signature.rs
@@ -2,12 +2,12 @@
 //!
 //! A signature is a collection of sketches for a genomic dataset.
 
+use std::collections::VecDeque;
 use std::fs::File;
 use std::io;
 use std::iter::Iterator;
 use std::path::Path;
 use std::str;
-use std::collections::VecDeque;
 
 use cfg_if::cfg_if;
 #[cfg(feature = "parallel")]


### PR DESCRIPTION
* In this PR, I am changing the kmers_buffer data structure from Vec into VecDeque for faster deletion time complexity. This should speed up the `seqToHashes()` function and not only limited to `translate`.
* This change fixes #1746 