### PR TITLE
Benchmarks for seq_to_hashes in protein mode

### DIFF
--- a/asv.conf.json
+++ b/asv.conf.json
@@ -6,7 +6,6 @@
     "branches": ["latest"],
     "dvcs": "git",
     "environment_type": "virtualenv",
-    "pythons": ["3.10"],
     "env_dir": ".asv/env",
     "results_dir": ".asv/results",
     "html_dir": ".asv/html",

--- a/src/sourmash/command_compute.py
+++ b/src/sourmash/command_compute.py
@@ -326,7 +326,16 @@ def save_sigs_to_location(siglist, save_sig):
 class ComputeParameters(RustObject):
     __dealloc_func__ = lib.computeparams_free
 
-    def __init__(self, ksizes, seed, protein, dayhoff, hp, dna, num_hashes, track_abundance, scaled):
+    def __init__(self,
+                 ksizes=(21, 31, 51),
+                 seed=42,
+                 protein=False,
+                 dayhoff=False,
+                 hp=False,
+                 dna=True,
+                 num_hashes=500,
+                 track_abundance=False,
+                 scaled=0):
         self._objptr = lib.computeparams_new()
 
         self.seed = seed
@@ -405,7 +414,7 @@ class ComputeParameters(RustObject):
         return ",".join(pi)
 
     def __repr__(self):
-        return f"ComputeParameters({self.ksizes}, {self.seed}, {self.protein}, {self.dayhoff}, {self.hp}, {self.dna}, {self.num_hashes}, {self.track_abundance}, {self.scaled})"
+        return f"ComputeParameters(ksizes={self.ksizes}, seed={self.seed}, protein={self.protein}, dayhoff={self.dayhoff}, hp={self.hp}, dna={self.dna}, num_hashes={self.num_hashes}, track_abundance={self.track_abundance}, scaled={self.scaled})"
 
     def __eq__(self, other):
         return (self.ksizes == other.ksizes and

--- a/src/sourmash/command_compute.py
+++ b/src/sourmash/command_compute.py
@@ -137,10 +137,15 @@ class _signatures_for_compute_factory(object):
 
     def __call__(self):
         args = self.args
-        params = ComputeParameters(args.ksizes, args.seed, args.protein,
-                                   args.dayhoff, args.hp, args.dna,
-                                   args.num_hashes,
-                                   args.track_abundance, args.scaled)
+        params = ComputeParameters(ksizes=args.ksizes,
+                                   seed=args.seed,
+                                   protein=args.protein,
+                                   dayhoff=args.dayhoff,
+                                   hp=args.hp,
+                                   dna=args.dna,
+                                   num_hashes=args.num_hashes,
+                                   track_abundance=args.track_abundance,
+                                   scaled=args.scaled)
         sig = SourmashSignature.from_params(params)
         return [sig]
 
@@ -327,6 +332,7 @@ class ComputeParameters(RustObject):
     __dealloc_func__ = lib.computeparams_free
 
     def __init__(self,
+                 *,
                  ksizes=(21, 31, 51),
                  seed=42,
                  protein=False,
@@ -368,8 +374,15 @@ class ComputeParameters(RustObject):
         else:
             ksize = row['ksize'] * 3
 
-        p = cls([ksize], DEFAULT_MMHASH_SEED, is_protein, is_dayhoff, is_hp, is_dna,
-                row['num'], row['with_abundance'], row['scaled'])
+        p = cls(ksizes=[ksize],
+                seed=DEFAULT_MMHASH_SEED,
+                protein=is_protein,
+                dayhoff=is_dayhoff,
+                hp=is_hp,
+                dna=is_dna,
+                num_hashes=row['num'],
+                track_abundance=row['with_abundance'],
+                scaled=row['scaled'])
 
         return p
 

--- a/src/sourmash/command_sketch.py
+++ b/src/sourmash/command_sketch.py
@@ -146,16 +146,17 @@ class _signatures_for_sketch_factory(object):
             if self.mult_ksize_by_3 and not def_dna:
                 ksizes = [ k*3 for k in ksizes ]
 
-            make_param = lambda ksizes: ComputeParameters(ksizes,
-                                            params_d.get('seed', def_seed),
-                                            def_protein,
-                                            def_dayhoff,
-                                            def_hp,
-                                            def_dna,
-                                            params_d.get('num', def_num),
-                                            params_d.get('track_abundance',
-                                                         def_abund),
-                                            params_d.get('scaled', def_scaled))
+            make_param = lambda ksizes: ComputeParameters(
+                                            ksizes=ksizes,
+                                            seed=params_d.get('seed', def_seed),
+                                            protein=def_protein,
+                                            dayhoff=def_dayhoff,
+                                            hp=def_hp,
+                                            dna=def_dna,
+                                            num_hashes=params_d.get('num', def_num),
+                                            track_abundance=params_d.get('track_abundance',
+                                                                         def_abund),
+                                            scaled=params_d.get('scaled', def_scaled))
 
             if split_ksizes:
                 for ksize in ksizes:

--- a/tests/test_sourmash_sketch.py
+++ b/tests/test_sourmash_sketch.py
@@ -511,7 +511,8 @@ def test_manifest_row_to_compute_parameters_4():
 
 
 def test_bad_compute_parameters():
-    p = ComputeParameters([31], 42, 0, 0, 0, 0, 0, True, 1000)
+    p = ComputeParameters(ksizes=[31], seed=42, dna=0, protein=0, dayhoff=0,
+                          hp=0, num_hashes=0, track_abundance=True, scaled=1000)
     with pytest.raises(AssertionError):
         p.moltype
 


### PR DESCRIPTION
Add some rust benchmarks for seq_to_hashes in protein mode, so we don't regress after the awesome progress in #1938 

Other fixes:
- Default python in `asv` to the one where `asv` is running (fixes https://github.com/sourmash-bio/sourmash/issues/1937)
- Make `ComputeParameters` initliazer use explicit keywords (and fix `__repr__`)