### PR TITLE
[MRG] speed up `SeqToHashes` `translate`

### DIFF
--- a/src/core/src/signature.rs
+++ b/src/core/src/signature.rs
@@ -342,11 +342,10 @@ impl Iterator for SeqToHashes {
                         self.hashes_buffer.clear();
                         self.kmer_index = self.max_index;
                         return Some(Ok(0));
-                    } else {
-                        let curr_idx = self.translate_iter_step;
-                        self.translate_iter_step += 1;
-                        return Some(Ok(self.hashes_buffer[curr_idx]));
                     }
+                    let curr_idx = self.translate_iter_step;
+                    self.translate_iter_step += 1;
+                    Some(Ok(self.hashes_buffer[curr_idx]))
                 }
             } else {
                 // Processing protein

--- a/src/core/src/signature.rs
+++ b/src/core/src/signature.rs
@@ -228,13 +228,21 @@ impl SeqToHashes {
     }
 }
 
+/*
+Iterator that return a kmer hash for all modes except translate.
+In translate mode:
+    - all the frames are processed at once and converted to hashes.
+    - all the hashes are stored in `hashes_buffer`
+    - after processing all the kmers, `translate_iter_step` is incremented
+      per iteration to iterate over all the indeces of the `hashes_buffer`.
+    - the iterator will die once `translate_iter_step` == length(hashes_buffer)
+More info https://github.com/sourmash-bio/sourmash/pull/1946
+*/
+
 impl Iterator for SeqToHashes {
     type Item = Result<u64, Error>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        // TODO: Remove the hashes buffer
-        // Priority for flushing the hashes buffer
-
         if (self.kmer_index < self.max_index) || !self.hashes_buffer.is_empty() {
             // Processing DNA or Translated DNA
             if !self.is_protein {
@@ -294,7 +302,7 @@ impl Iterator for SeqToHashes {
                     Some(Ok(hash))
                 } else if self.hashes_buffer.is_empty() && self.translate_iter_step == 0 {
                     // Processing protein by translating DNA
-                    // TODO: make it a real iterator not a buffer
+                    // TODO: Implement iterator over frames instead of hashes_buffer.
 
                     for frame_number in 0..3 {
                         let substr: Vec<u8> = self


### PR DESCRIPTION
Vectors are very good in insertions, not in deletion. In #1938 I replaced `Vec` with `VecDeque` because I was popping out a hash per iteration. This deletion is very slow in `Vec` because it shifts all the elements in memory, while it's very fast in `VecDeque`. 

In this PR I am reverting back to `Vec` and replacing all the parts that require deletion or popping by smoother code. Now there's no need for using `VecDeque`.

Resolves #1945 