### PR TITLE
[MRG] standardize and simplify search, prefetch, gather results by using dataclasses

### DIFF
--- a/src/sourmash/commands.py
+++ b/src/sourmash/commands.py
@@ -796,14 +796,13 @@ def gather(args):
 
     # save CSV?
     if found and args.output:
-        fieldnames = GatherResult._fields
+        #fieldnames = GatherResult._fields
+        fieldnames = GatherResult.gather_write_cols
         with FileOutputCSV(args.output) as fp:
             w = csv.DictWriter(fp, fieldnames=fieldnames)
             w.writeheader()
             for result in found:
-                d = dict(result._asdict())
-                del d['match']                 # actual signature not in CSV.
-                w.writerow(d)
+                w.writerow(result.writedict)
 
     # save matching signatures?
     if found and args.save_matches:
@@ -963,14 +962,13 @@ def multigather(args):
 
             output_base = os.path.basename(query_filename)
             output_csv = output_base + '.csv'
-            fieldnames = GatherResult._fields
+            #fieldnames = GatherResult._fields
+            fieldnames = GatherResult.gather_write_cols
             with FileOutputCSV(output_csv) as fp:
                 w = csv.DictWriter(fp, fieldnames=fieldnames)
                 w.writeheader()
                 for result in found:
-                    d = dict(result._asdict())
-                    del d['match']      # actual signature not output to CSV!
-                    w.writerow(d)
+                    w.writerow(result.writedict)
 
             output_matches = output_base + '.matches.sig'
             with open(output_matches, 'wt') as fp:

--- a/src/sourmash/commands.py
+++ b/src/sourmash/commands.py
@@ -16,7 +16,7 @@ from . import sourmash_args
 from .logging import notify, error, print_results, set_quiet
 from .sourmash_args import (FileOutput, FileOutputCSV,
                             SaveSignaturesToLocation)
-from .search import prefetch_database, calculate_prefetch_info, SearchResult, PrefetchResult, GatherResult
+from .search import prefetch_database, SearchResult, PrefetchResult, GatherResult
 from .index import LazyLinearIndex
 
 WATERMARK_SIZE = 10000
@@ -713,7 +713,7 @@ def gather(args):
                 if prefetch_csvout_fp:
                     assert scaled
                     # calculate intersection stats and info
-                    prefetch_result = calculate_prefetch_info(prefetch_query, found_sig, scaled, args.threshold_bp)
+                    prefetch_result = PrefetchResult(prefetch_query, found_sig, cmp_scaled=scaled, threshold_bp=args.threshold_bp)
                     prefetch_csvout_w.writerow(prefetch_result.writedict)
 
             counters.append(counter)

--- a/src/sourmash/commands.py
+++ b/src/sourmash/commands.py
@@ -533,7 +533,7 @@ def search(args):
         notify("** reporting only one match because --best-only was set")
 
     if args.output:
-        fieldnames = SearchResult.write_search_cols
+        fieldnames = SearchResult.write_cols
 
         with FileOutputCSV(args.output) as fp:
             w = csv.DictWriter(fp, fieldnames=fieldnames)

--- a/src/sourmash/commands.py
+++ b/src/sourmash/commands.py
@@ -533,17 +533,14 @@ def search(args):
         notify("** reporting only one match because --best-only was set")
 
     if args.output:
-        fieldnames = SearchResult._fields
+        fieldnames = SearchResult.write_search_cols
 
         with FileOutputCSV(args.output) as fp:
             w = csv.DictWriter(fp, fieldnames=fieldnames)
 
             w.writeheader()
             for sr in results:
-                d = dict(sr._asdict())
-                del d['match']
-                del d['query']
-                w.writerow(d)
+                w.writerow(sr.writedict())
 
     # save matching signatures upon request
     if args.save_matches:

--- a/src/sourmash/commands.py
+++ b/src/sourmash/commands.py
@@ -16,7 +16,7 @@ from . import sourmash_args
 from .logging import notify, error, print_results, set_quiet
 from .sourmash_args import (FileOutput, FileOutputCSV,
                             SaveSignaturesToLocation)
-from .search import SearchResult, prefetch_database, PrefetchResult, GatherResult, calculate_prefetch_info
+from .search import prefetch_database, calculate_prefetch_info, SearchResult, PrefetchResult, GatherResult
 from .index import LazyLinearIndex
 
 WATERMARK_SIZE = 10000

--- a/src/sourmash/commands.py
+++ b/src/sourmash/commands.py
@@ -796,7 +796,6 @@ def gather(args):
 
     # save CSV?
     if found and args.output:
-        #fieldnames = GatherResult._fields
         fieldnames = GatherResult.gather_write_cols
         with FileOutputCSV(args.output) as fp:
             w = csv.DictWriter(fp, fieldnames=fieldnames)
@@ -962,7 +961,6 @@ def multigather(args):
 
             output_base = os.path.basename(query_filename)
             output_csv = output_base + '.csv'
-            #fieldnames = GatherResult._fields
             fieldnames = GatherResult.gather_write_cols
             with FileOutputCSV(output_csv) as fp:
                 w = csv.DictWriter(fp, fieldnames=fieldnames)

--- a/src/sourmash/commands.py
+++ b/src/sourmash/commands.py
@@ -533,7 +533,7 @@ def search(args):
         notify("** reporting only one match because --best-only was set")
 
     if args.output:
-        fieldnames = SearchResult.write_cols
+        fieldnames = SearchResult.search_write_cols
 
         with FileOutputCSV(args.output) as fp:
             w = csv.DictWriter(fp, fieldnames=fieldnames)
@@ -685,7 +685,7 @@ def gather(args):
         prefetch_csvout_fp = None
         prefetch_csvout_w = None
         if args.save_prefetch_csv:
-            fieldnames = PrefetchResult._fields
+            fieldnames = PrefetchResult.prefetch_write_cols
             prefetch_csvout_fp = FileOutput(args.save_prefetch_csv, 'wt').open()
             prefetch_csvout_w = csv.DictWriter(prefetch_csvout_fp, fieldnames=fieldnames)
             prefetch_csvout_w.writeheader()
@@ -715,11 +715,7 @@ def gather(args):
                     assert scaled
                     # calculate intersection stats and info
                     prefetch_result = calculate_prefetch_info(prefetch_query, found_sig, scaled, args.threshold_bp)
-                    # remove match and query signatures; write result to prefetch csv
-                    d = dict(prefetch_result._asdict())
-                    del d['match']
-                    del d['query']
-                    prefetch_csvout_w.writerow(d)
+                    prefetch_csvout_w.writerow(prefetch_result.writedict())
 
             counters.append(counter)
 
@@ -1171,7 +1167,7 @@ def prefetch(args):
     csvout_fp = None
     csvout_w = None
     if args.output:
-        fieldnames = PrefetchResult._fields
+        fieldnames = PrefetchResult.prefetch_write_cols
         csvout_fp = FileOutput(args.output, 'wt').open()
         csvout_w = csv.DictWriter(csvout_fp, fieldnames=fieldnames)
         csvout_w.writeheader()
@@ -1228,10 +1224,7 @@ def prefetch(args):
 
             # output match info as we go
             if csvout_fp:
-                d = dict(result._asdict())
-                del d['match']                 # actual signatures not in CSV.
-                del d['query']
-                csvout_w.writerow(d)
+                csvout_w.writerow(result.writedict())
 
             # output match signatures as we go (maybe)
             matches_out.add(match)

--- a/src/sourmash/commands.py
+++ b/src/sourmash/commands.py
@@ -16,7 +16,7 @@ from . import sourmash_args
 from .logging import notify, error, print_results, set_quiet
 from .sourmash_args import (FileOutput, FileOutputCSV,
                             SaveSignaturesToLocation)
-from .search import prefetch_database, PrefetchResult, calculate_prefetch_info
+from .search import SearchResult, prefetch_database, PrefetchResult, GatherResult, calculate_prefetch_info
 from .index import LazyLinearIndex
 
 WATERMARK_SIZE = 10000
@@ -529,8 +529,7 @@ def search(args):
         notify("** reporting only one match because --best-only was set")
 
     if args.output:
-        fieldnames = ['similarity', 'name', 'filename', 'md5',
-                      'query_filename', 'query_name', 'query_md5']
+        fieldnames = SearchResult._fields
 
         with FileOutputCSV(args.output) as fp:
             w = csv.DictWriter(fp, fieldnames=fieldnames)
@@ -685,11 +684,7 @@ def gather(args):
         prefetch_csvout_fp = None
         prefetch_csvout_w = None
         if args.save_prefetch_csv:
-            fieldnames = ['intersect_bp', 'jaccard',
-                          'max_containment', 'f_query_match', 'f_match_query',
-                          'match_filename', 'match_name', 'match_md5', 'match_bp',
-                          'query_filename', 'query_name', 'query_md5', 'query_bp']
-
+            fieldnames = PrefetchResult._fields
             prefetch_csvout_fp = FileOutput(args.save_prefetch_csv, 'wt').open()
             prefetch_csvout_w = csv.DictWriter(prefetch_csvout_fp, fieldnames=fieldnames)
             prefetch_csvout_w.writeheader()
@@ -804,13 +799,7 @@ def gather(args):
 
     # save CSV?
     if found and args.output:
-        fieldnames = ['intersect_bp', 'f_orig_query', 'f_match',
-                      'f_unique_to_query', 'f_unique_weighted',
-                      'average_abund', 'median_abund', 'std_abund', 'name',
-                      'filename', 'md5', 'f_match_orig', 'unique_intersect_bp',
-                      'gather_result_rank', 'remaining_bp',
-                      'query_filename', 'query_name', 'query_md5', 'query_bp']
-
+        fieldnames = GatherResult._fields
         with FileOutputCSV(args.output) as fp:
             w = csv.DictWriter(fp, fieldnames=fieldnames)
             w.writeheader()
@@ -977,14 +966,7 @@ def multigather(args):
 
             output_base = os.path.basename(query_filename)
             output_csv = output_base + '.csv'
-
-            fieldnames = ['intersect_bp', 'f_orig_query', 'f_match',
-                          'f_unique_to_query', 'f_unique_weighted',
-                          'average_abund', 'median_abund', 'std_abund', 'name',
-                          'filename', 'md5', 'f_match_orig',
-                          'unique_intersect_bp', 'gather_result_rank',
-                          'remaining_bp', 'query_filename', 'query_name',
-                          'query_md5', 'query_bp']
+            fieldnames = GatherResult._fields
             with FileOutputCSV(output_csv) as fp:
                 w = csv.DictWriter(fp, fieldnames=fieldnames)
                 w.writeheader()
@@ -1188,11 +1170,7 @@ def prefetch(args):
     csvout_fp = None
     csvout_w = None
     if args.output:
-        fieldnames = ['intersect_bp', 'jaccard',
-                      'max_containment', 'f_query_match', 'f_match_query',
-                      'match_filename', 'match_name', 'match_md5', 'match_bp',
-                      'query_filename', 'query_name', 'query_md5', 'query_bp']
-
+        fieldnames = PrefetchResult._fields
         csvout_fp = FileOutput(args.output, 'wt').open()
         csvout_w = csv.DictWriter(csvout_fp, fieldnames=fieldnames)
         csvout_w.writeheader()

--- a/src/sourmash/commands.py
+++ b/src/sourmash/commands.py
@@ -540,7 +540,7 @@ def search(args):
 
             w.writeheader()
             for sr in results:
-                w.writerow(sr.writedict())
+                w.writerow(sr.writedict)
 
     # save matching signatures upon request
     if args.save_matches:
@@ -715,7 +715,7 @@ def gather(args):
                     assert scaled
                     # calculate intersection stats and info
                     prefetch_result = calculate_prefetch_info(prefetch_query, found_sig, scaled, args.threshold_bp)
-                    prefetch_csvout_w.writerow(prefetch_result.writedict())
+                    prefetch_csvout_w.writerow(prefetch_result.writedict)
 
             counters.append(counter)
 
@@ -1224,7 +1224,7 @@ def prefetch(args):
 
             # output match info as we go
             if csvout_fp:
-                csvout_w.writerow(result.writedict())
+                csvout_w.writerow(result.writedict)
 
             # output match signatures as we go (maybe)
             matches_out.add(match)

--- a/src/sourmash/minhash.py
+++ b/src/sourmash/minhash.py
@@ -863,7 +863,10 @@ class MinHash(RustObject):
     def sum_abundances(self):
         if self.track_abundance:
             return sum(v for v in self.hashes.values())
+        # which of these do we want?
         return ""
+        # if each hash = 1, sum is just len
+#        return len(self.hashes)
 
     @property
     def mean_abundance(self):
@@ -881,7 +884,7 @@ class MinHash(RustObject):
     def std_abundance(self):
         if self.track_abundance:
             return np.std(self.hashes.values())
-        return ""
+        return "" # None? 0?
 
     @property
     def bp(self):

--- a/src/sourmash/minhash.py
+++ b/src/sourmash/minhash.py
@@ -866,25 +866,24 @@ class MinHash(RustObject):
         # which of these do we want?
         # if each hash = 1, sum is just len
         return len(self.hashes)
-        #return ""
 
     @property
     def mean_abundance(self):
         if self.track_abundance:
-            return np.mean(self.hashes.values())
-        return None #""
+            return np.mean(list(self.hashes.values()))
+        return ""#None
 
     @property
     def median_abundance(self):
         if self.track_abundance:
-            return np.median(self.hashes.values())
-        return None #""
+            return np.median(list(self.hashes.values()))
+        return "" #None
 
     @property
     def std_abundance(self):
         if self.track_abundance:
-            return np.std(self.hashes.values())
-        return None#"" # None? 0?
+            return np.std(list(self.hashes.values()))
+        return "" #None
 
     @property
     def covered_bp(self):

--- a/src/sourmash/minhash.py
+++ b/src/sourmash/minhash.py
@@ -864,9 +864,9 @@ class MinHash(RustObject):
         if self.track_abundance:
             return sum(v for v in self.hashes.values())
         # which of these do we want?
-        return ""
         # if each hash = 1, sum is just len
-#        return len(self.hashes)
+        return len(self.hashes)
+        #return ""
 
     @property
     def mean_abundance(self):
@@ -887,7 +887,7 @@ class MinHash(RustObject):
         return None#"" # None? 0?
 
     @property
-    def bp(self):
+    def covered_bp(self):
         if not self.scaled:
             raise TypeError("can only calculate bp for scaled MinHashes")
         return len(self.hashes) * self.scaled

--- a/src/sourmash/minhash.py
+++ b/src/sourmash/minhash.py
@@ -865,27 +865,25 @@ class MinHash(RustObject):
     def sum_abundances(self):
         if self.track_abundance:
             return sum(v for v in self.hashes.values())
-        # which of these do we want?
-        # if each hash = 1, sum is just len
-        return len(self.hashes)
+        return None
 
     @property
     def mean_abundance(self):
         if self.track_abundance:
             return np.mean(list(self.hashes.values()))
-        return ""#None
+        return None
 
     @property
     def median_abundance(self):
         if self.track_abundance:
             return np.median(list(self.hashes.values()))
-        return "" #None
+        return None
 
     @property
     def std_abundance(self):
         if self.track_abundance:
             return np.std(list(self.hashes.values()))
-        return "" #None
+        return None
 
     @property
     def covered_bp(self):

--- a/src/sourmash/minhash.py
+++ b/src/sourmash/minhash.py
@@ -872,19 +872,19 @@ class MinHash(RustObject):
     def mean_abundance(self):
         if self.track_abundance:
             return np.mean(self.hashes.values())
-        return ""
+        return None #""
 
     @property
     def median_abundance(self):
         if self.track_abundance:
             return np.median(self.hashes.values())
-        return ""
+        return None #""
 
     @property
     def std_abundance(self):
         if self.track_abundance:
             return np.std(self.hashes.values())
-        return "" # None? 0?
+        return None#"" # None? 0?
 
     @property
     def bp(self):

--- a/src/sourmash/minhash.py
+++ b/src/sourmash/minhash.py
@@ -8,6 +8,9 @@ class FrozenMinHash - read-only MinHash class.
 from __future__ import unicode_literals, division
 from .distance_utils import jaccard_to_distance, containment_to_distance
 
+import numpy as np
+
+
 __all__ = ['get_minhash_default_seed',
            'get_minhash_max_hash',
            'hash_murmur',
@@ -854,7 +857,37 @@ class MinHash(RustObject):
 
             return abund_mh
         else:
-            raise ValueError("inflate operates on a flat MinHash and takes a MinHash object with track_abundance=True") 
+            raise ValueError("inflate operates on a flat MinHash and takes a MinHash object with track_abundance=True")
+
+    @property
+    def sum_abundances(self):
+        if self.track_abundance:
+            return sum(v for v in self.hashes.values())
+        return ""
+
+    @property
+    def mean_abundance(self):
+        if self.track_abundance:
+            return np.mean(self.hashes.values())
+        return ""
+
+    @property
+    def median_abundance(self):
+        if self.track_abundance:
+            return np.median(self.hashes.values())
+        return ""
+
+    @property
+    def std_abundance(self):
+        if self.track_abundance:
+            return np.std(self.hashes.values())
+        return ""
+
+    @property
+    def bp(self):
+        if not self.scaled:
+            raise TypeError("can only calculate bp for scaled MinHashes")
+        return len(self.hashes) * self.scaled
         
 
 class FrozenMinHash(MinHash):

--- a/src/sourmash/minhash.py
+++ b/src/sourmash/minhash.py
@@ -689,6 +689,8 @@ class MinHash(RustObject):
 
     def angular_similarity(self, other):
         "Calculate the angular similarity."
+        if not (self.track_abundance and other.track_abundance):
+            raise TypeError("Error: Angular (cosine) similarity requires both sketches to track hash abundance.")
         return self._methodcall(lib.kmerminhash_angular_similarity,
                                 other._get_objptr())
 

--- a/src/sourmash/search.py
+++ b/src/sourmash/search.py
@@ -186,7 +186,7 @@ class BaseResult:
 
     def build_numminhashcomparison(self, cmp_num=None):
         self.cmp = NumMinHashComparison(self.mh1, self.mh2, cmp_num=cmp_num, ignore_abundance=self.ignore_abundance)
-        self.num = self.cmp.cmp_num
+        self.cmp_num = self.cmp.cmp_num
         self.query_num = self.mh1.num
         self.match_num = self.mh2.num
 
@@ -244,7 +244,7 @@ class SearchResult(BaseResult):
         self.init_result()
         if any([self.mh1.scaled, self.mh2.scaled]):
             self.build_fracminhashcomparison(cmp_scaled = self.cmp_scaled, threshold_bp = self.threshold_bp)
-        elif any([not self.mh1.num, not self.mh2.num]):
+        elif any([self.mh1.num, self.mh2.num]):
             self.build_numminhashcomparison(cmp_num=self.cmp_num)
         self.get_cmpinfo() # grab comparison metadata
 

--- a/src/sourmash/search.py
+++ b/src/sourmash/search.py
@@ -160,7 +160,9 @@ class JaccardSearchBestOnly(JaccardSearch):
 
 # generic SearchResult tuple.
 SearchResult = namedtuple('SearchResult',
-                          'similarity, match, md5, filename, name, query, query_filename, query_name, query_md5')
+                          ['similarity', 'match', 'md5', 'filename', 'name',
+                          'query', 'query_filename', 'query_name', 'query_md5',
+                          'ksize'])
 
 
 def format_bp(bp):
@@ -193,6 +195,7 @@ def search_databases_with_flat_query(query, databases, **kwargs):
     results.sort(key=lambda x: -x[0])
 
     x = []
+    ksize = query_mh.ksize
     for (score, match, filename) in results:
         x.append(SearchResult(similarity=score,
                               match=match,
@@ -202,7 +205,8 @@ def search_databases_with_flat_query(query, databases, **kwargs):
                               query=query,
                               query_filename=query.filename,
                               query_name=query.name,
-                              query_md5=query.md5sum()[:8]
+                              query_md5=query.md5sum()[:8],
+                              ksize=ksize,
         ))
     return x
 
@@ -235,7 +239,8 @@ def search_databases_with_abund_query(query, databases, **kwargs):
                               query=query,
                               query_filename=query.filename,
                               query_name=query.name,
-                              query_md5=query.md5sum()[:8]
+                              query_md5=query.md5sum()[:8],
+                              ksize=query.minhash.ksize,
         ))
     return x
 
@@ -243,8 +248,11 @@ def search_databases_with_abund_query(query, databases, **kwargs):
 ### gather code
 ###
 
-GatherResult = namedtuple('GatherResult',
-                          'intersect_bp, f_orig_query, f_match, f_unique_to_query, f_unique_weighted, average_abund, median_abund, std_abund, filename, name, md5, match, f_match_orig, unique_intersect_bp, gather_result_rank, remaining_bp, query_filename, query_name, query_md5, query_bp')
+GatherResult = namedtuple('GatherResult', ['intersect_bp', 'f_orig_query', 'f_match', 'f_unique_to_query',
+                            'f_unique_weighted','average_abund', 'median_abund', 'std_abund', 'filename',
+                            'name', 'md5', 'match', 'f_match_orig', 'unique_intersect_bp', 'gather_result_rank',
+                            'remaining_bp', 'query_filename', 'query_name', 'query_md5', 'query_bp', 'ksize',
+                            'moltype', 'num', 'scaled', 'query_nhashes', 'query_abundance'])
 
 
 def _find_best(counters, query, threshold_bp):
@@ -453,6 +461,12 @@ class GatherDatabases:
                               query_filename=self.orig_query_filename,
                               query_name=self.orig_query_name,
                               query_md5=self.orig_query_md5,
+                              ksize =  self.orig_query_mh.ksize,
+                              moltype = self.orig_query_mh.moltype,
+                              num = self.orig_query_mh.num,
+                              scaled = scaled,
+                              query_nhashes=len(self.orig_query_mh),
+                              query_abundance=self.orig_query_mh.track_abundance,
                               )
         self.result_n += 1
         self.query = new_query
@@ -466,7 +480,11 @@ class GatherDatabases:
 ###
 
 PrefetchResult = namedtuple('PrefetchResult',
-                            'intersect_bp, jaccard, max_containment, f_query_match, f_match_query, match, match_filename, match_name, match_md5, match_bp, query, query_filename, query_name, query_md5, query_bp')
+                            ['intersect_bp', 'jaccard', 'max_containment', 'f_query_match',
+                            'f_match_query', 'match', 'match_filename', 'match_name',
+                            'match_md5', 'match_bp', 'query', 'query_filename', 'query_name',
+                            'query_md5', 'query_bp', 'ksize', 'moltype', 'num', 'scaled',
+                            'query_nhashes', 'query_abundance'])
 
 
 def calculate_prefetch_info(query, match, scaled, threshold_bp):
@@ -505,7 +523,13 @@ def calculate_prefetch_info(query, match, scaled, threshold_bp):
         query=query,
         query_filename=query.filename,
         query_name=query.name,
-        query_md5=query.md5sum()[:8]
+        query_md5=query.md5sum()[:8],
+        ksize =  query_mh.ksize,
+        moltype = query_mh.moltype,
+        num = query_mh.num,
+        scaled = scaled,
+        query_nhashes=len(query_mh),
+        query_abundance=query_mh.track_abundance,
     )
 
     return result

--- a/src/sourmash/search.py
+++ b/src/sourmash/search.py
@@ -173,7 +173,7 @@ class SearchResult:
     max_containment: float = None
     avg_containment: float = None
     filename: str = None
-    intersect_bp: int = 0
+    intersect_bp: int = None
 
     #columns for standard SearchResult output
     search_write_cols = ['similarity', 'md5', 'filename', 'name',
@@ -189,7 +189,6 @@ class SearchResult:
         self.query_name = self.query.name
         self.match_filename = self.match.filename
         self.query_filename = self.query.filename
-        # do we want short md5s as well?
         self.match_md5 = self.match.md5sum()
         self.query_md5 = self.query.md5sum()
         self.match_scaled = self.match.minhash.scaled

--- a/src/sourmash/search.py
+++ b/src/sourmash/search.py
@@ -195,7 +195,7 @@ def search_databases_with_flat_query(query, databases, **kwargs):
     results.sort(key=lambda x: -x[0])
 
     x = []
-    ksize = query_mh.ksize
+    ksize = query.minhash.ksize
     for (score, match, filename) in results:
         x.append(SearchResult(similarity=score,
                               match=match,

--- a/src/sourmash/search.py
+++ b/src/sourmash/search.py
@@ -252,7 +252,7 @@ GatherResult = namedtuple('GatherResult', ['intersect_bp', 'f_orig_query', 'f_ma
                             'f_unique_weighted','average_abund', 'median_abund', 'std_abund', 'filename',
                             'name', 'md5', 'match', 'f_match_orig', 'unique_intersect_bp', 'gather_result_rank',
                             'remaining_bp', 'query_filename', 'query_name', 'query_md5', 'query_bp', 'ksize',
-                            'moltype', 'num', 'scaled', 'query_nhashes', 'query_abundance'])
+                            'moltype', 'scaled', 'query_n_hashes', 'query_abundance'])
 
 
 def _find_best(counters, query, threshold_bp):
@@ -463,9 +463,8 @@ class GatherDatabases:
                               query_md5=self.orig_query_md5,
                               ksize =  self.orig_query_mh.ksize,
                               moltype = self.orig_query_mh.moltype,
-                              num = self.orig_query_mh.num,
                               scaled = scaled,
-                              query_nhashes=len(self.orig_query_mh),
+                              query_n_hashes=len(self.orig_query_mh),
                               query_abundance=self.orig_query_mh.track_abundance,
                               )
         self.result_n += 1
@@ -483,8 +482,8 @@ PrefetchResult = namedtuple('PrefetchResult',
                             ['intersect_bp', 'jaccard', 'max_containment', 'f_query_match',
                             'f_match_query', 'match', 'match_filename', 'match_name',
                             'match_md5', 'match_bp', 'query', 'query_filename', 'query_name',
-                            'query_md5', 'query_bp', 'ksize', 'moltype', 'num', 'scaled',
-                            'query_nhashes', 'query_abundance'])
+                            'query_md5', 'query_bp', 'ksize', 'moltype', 'scaled',
+                            'query_n_hashes', 'query_abundance'])
 
 
 def calculate_prefetch_info(query, match, scaled, threshold_bp):
@@ -526,9 +525,8 @@ def calculate_prefetch_info(query, match, scaled, threshold_bp):
         query_md5=query.md5sum()[:8],
         ksize =  query_mh.ksize,
         moltype = query_mh.moltype,
-        num = query_mh.num,
         scaled = scaled,
-        query_nhashes=len(query_mh),
+        query_n_hashes=len(query_mh),
         query_abundance=query_mh.track_abundance,
     )
 

--- a/src/sourmash/search.py
+++ b/src/sourmash/search.py
@@ -175,8 +175,8 @@ class SearchResult:
     filename: str = None
 
     #columns for standard SearchResult output
-    write_search_cols = ['similarity', 'md5', 'filename', 'name',
-                         'query_filename', 'query_name', 'query_md5']
+    write_cols = ['similarity', 'md5', 'filename', 'name',
+                  'query_filename', 'query_name', 'query_md5']
 
     def __post_init__(self):
         # calculate general info
@@ -212,7 +212,7 @@ class SearchResult:
         #self.md5 = shorten_md5(self.md5)
         #self.match_md5 = shorten_md5(self.match_md5)
         info = {k: v for k, v in self.__dict__.items()
-                if k in self.write_search_cols and v}
+                if k in self.write_cols and v}
         return info
 
 
@@ -221,7 +221,12 @@ class SearchResult:
 #    intersect_bp: int = None
 #    f_query_match: float = None
 #    f_match_query: float = None
-
+#
+#    write_cols = ['intersect_bp', 'jaccard', 'max_containment', 'f_query_match',
+#                  'f_match_query', 'match', 'match_filename', 'match_name',
+#                  'match_md5', 'match_bp', 'query', 'query_filename', 'query_name',
+#                  'query_md5', 'query_bp', 'ksize', 'moltype', 'num', 'scaled',
+#                  'query_nhashes', 'query_abundance']
 
 #@dataclass
 #class GatherResult(SearchResult):

--- a/src/sourmash/search.py
+++ b/src/sourmash/search.py
@@ -193,10 +193,10 @@ class SearchResult:
         self.query_md5 = self.query.md5sum()
         self.match_scaled = self.match.minhash.scaled
         self.query_scaled = self.query.minhash.scaled
-        self.query_nhashes = len(self.query.minhash)
-        self.match_nhashes = len(self.match.minhash)
-        self.match_bp = self.query_nhashes * self.query_scaled
-        self.query_bp = self.match_nhashes * self.match_scaled
+        self.query_n_hashes = len(self.query.minhash)
+        self.match_n_hashes = len(self.match.minhash)
+        self.query_bp = self.query_n_hashes * self.query_scaled
+        self.match_bp = self.match_n_hashes * self.match_scaled
         self.query_abundance = self.query.minhash.track_abundance
         self.match_abundance = self.match.minhash.track_abundance
         #deprecate these at some point, in favor of match_md5, etc
@@ -231,7 +231,7 @@ class PrefetchResult(SearchResult):
                            'f_match_query', 'match', 'match_filename', 'match_name',
                            'match_md5', 'match_bp', 'query', 'query_filename', 'query_name',
                            'query_md5', 'query_bp', 'ksize', 'moltype', 'num', 'scaled',
-                           'query_nhashes', 'query_abundance']
+                           'query_n_hashes', 'query_abundance']
 
     def __post_init__(self):
         self.init_searchresult_info()
@@ -260,15 +260,12 @@ class GatherResult(SearchResult):
     unique_intersect_bp: int = None
     gather_result_rank: int = None
     remaining_bp: int = None
-    query_bp: int = None
-    query_nhashes: int = None
-    query_abundance: bool = False
 
     gather_write_cols = ['intersect_bp', 'f_orig_query', 'f_match', 'f_unique_to_query',
                          'f_unique_weighted','average_abund', 'median_abund', 'std_abund', 'filename',
                          'name', 'md5', 'match', 'f_match_orig', 'unique_intersect_bp', 'gather_result_rank',
                          'remaining_bp', 'query_filename', 'query_name', 'query_md5', 'query_bp', 'ksize',
-                         'moltype', 'num', 'scaled', 'query_nhashes', 'query_abundance']
+                         'moltype', 'num', 'scaled', 'query_n_hashes', 'query_abundance']
 
     def __post_init__(self):
         self.init_searchresult_info()

--- a/src/sourmash/sketchcomparison.py
+++ b/src/sourmash/sketchcomparison.py
@@ -19,16 +19,16 @@ class BaseMinHashComparison:
         k1 = self.mh1.ksize
         k2 = self.mh2.ksize
         if k1 != k2:
-            raise ValueError(f"Error: Invalid Comparison, ksizes: {k1}, {k2}). Must compare sketches of the same ksize.")
+            raise TypeError(f"Error: Invalid Comparison, ksizes: {k1}, {k2}. Must compare sketches of the same ksize.")
         self.ksize = self.mh1.ksize
-        m1 = self.mh2.moltype
+        m1 = self.mh1.moltype
         m2= self.mh2.moltype
         if m1 != m2:
-            raise ValueError(f"Error: Invalid Comparison, moltypes: {m1}, {m2}). Must compare sketches of the same moltype.")
+            raise TypeError(f"Error: Invalid Comparison, moltypes: {m1}, {m2}. Must compare sketches of the same moltype.")
         self.moltype= self.mh1.moltype
         # check num, scaled
         if not any([(self.mh1.num and self.mh2.num), (self.mh1.scaled and self.mh2.scaled)]):
-            raise ValueError("Error: Both sketches must be 'num' or 'scaled'.")
+            raise TypeError("Error: Both sketches must be 'num' or 'scaled'.")
 
     def downsample_and_handle_ignore_abundance(self, cmp_num=None, cmp_scaled=None):
         """

--- a/src/sourmash/sketchcomparison.py
+++ b/src/sourmash/sketchcomparison.py
@@ -1,0 +1,188 @@
+"""
+Sketch Comparison Classes
+"""
+import numpy as np
+from dataclasses import dataclass
+
+from .signature import SourmashSignature, MinHash
+
+
+@dataclass
+class BaseMinHashComparison:
+    """Class for standard comparison between two MinHashes"""
+    mh1: MinHash
+    mh2: MinHash
+    ignore_abundance: bool = False # optionally ignore abundances
+
+    def check_comparison_compatibility(self):
+        # do we need this check + error? Minhash functions should already complain appropriately...
+        k1 = self.mh1.ksize
+        k2 = self.mh2.ksize
+        if k1 != k2:
+            raise ValueError(f"Error: Invalid Comparison, ksizes: {k1}, {k2}). Must compare sketches of the same ksize.")
+        self.ksize = self.mh1.ksize
+        m1 = self.mh2.moltype
+        m2= self.mh2.moltype
+        if m1 != m2:
+            raise ValueError(f"Error: Invalid Comparison, moltypes: {m1}, {m2}). Must compare sketches of the same moltype.")
+        self.moltype= self.mh1.moltype
+        # check num, scaled
+        if not any([(self.mh1.num and self.mh2.num), (self.mh1.scaled and self.mh2.scaled)]):
+            raise ValueError("Error: Both sketches must be 'num' or 'scaled'.")
+
+    def downsample_and_handle_ignore_abundance(self, cmp_num=None, cmp_scaled=None):
+        """
+        Downsample and/or flatten minhashes for comparison
+        """
+        if self.ignore_abundance:
+            self.mh1_cmp = self.mh1.flatten()
+            self.mh2_cmp = self.mh2.flatten()
+        else:
+            self.mh1_cmp = self.mh1
+            self.mh2_cmp = self.mh2
+        if cmp_scaled is not None:
+            self.mh1_cmp = self.mh1_cmp.downsample(scaled=cmp_scaled)
+            self.mh2_cmp = self.mh2_cmp.downsample(scaled=cmp_scaled)
+        elif cmp_num is not None:
+            self.mh1_cmp = self.mh1_cmp.downsample(num=cmp_num)
+            self.mh2_cmp = self.mh2_cmp.downsample(num=cmp_num)
+        else:
+            raise ValueError("Error: must pass in a comparison scaled or num value.")
+
+    @property
+    def intersect_mh(self):
+        # flatten and intersect
+        return self.mh1_cmp.flatten().intersection(self.mh2_cmp.flatten())
+
+    @property
+    def jaccard(self):
+        return self.mh1_cmp.jaccard(self.mh2_cmp)
+
+    @property
+    def angular_similarity(self):
+        if not self.mh1_cmp.track_abundance and self.mh2_cmp.track_abundance:
+            raise ValueError("Error: Angular (cosine) similarity requires both sketches to track hash abundance.")
+        return self.mh1_cmp.angular_similarity(self.mh2_cmp)
+
+    @property
+    def cosine_similarity(self):
+        return self.angular_similarity
+
+    # do we need these? Now that I've added them to MinHash, maybe don't need? Except ignore_abundance -- what do we want to do there?
+    @property
+    def mh1_sum_abunds(self):
+        if self.ignore_abundance:
+            return ""
+        return self.mh1.sum_abundances
+
+    @property
+    def mh1_mean_abund(self):
+        if self.ignore_abundance:
+            return ""
+        return self.mh1.mean_abundance
+
+    @property
+    def mh2_mean_abund(self):
+        if self.ignore_abundance:
+            return ""
+        return self.mh2.mean_abundance
+
+    @property
+    def mh1_median_abund(self):
+        if self.ignore_abundance:
+            return ""
+        return self.mh1.median_abundance
+
+    @property
+    def mh2_median_abund(self):
+        if self.ignore_abundance:
+            return ""
+        return self.mh2.median_abundance
+
+    @property
+    def mh1_std_abund(self):
+        if self.ignore_abundance:
+            return ""
+        return self.mh1.std_abundance
+
+    @property
+    def mh2_std_abund(self):
+        if self.ignore_abundance:
+            return ""
+        return self.mh2.std_abundance
+
+    @property
+    def mh1_weighted_intersection(self):
+         # map mh1 hash abundances to all intersection hashes.
+         # WHAT DO WE WANT TO DO ABOUT ignore_abundance here?
+        #if self.ignore_abundance or not self.mh1.track_abundance:
+        if not self.mh1.track_abundance:
+            return self.intersect_mh # or do we want to set all abundances to 1?
+        else:
+ #           return self.mh2_cmp.flatten().inflate(self.mh1) #implicitly intersects...
+            return self.intersect_mh.inflate(self.mh1)
+
+    @property
+    def mh2_weighted_intersection(self):
+         # map mh2 hash abundances to all intersection hashes.
+        if self.ignore_abundance or not self.mh2.track_abundance:
+            return self.intersect_mh  # or do we want to set all abundances to 1?
+        else:
+            intersect_w_abunds = self.intersect_mh.inflate(self.mh2)
+            return intersect_w_abunds
+
+@dataclass
+class NumMinHashComparison(BaseMinHashComparison):
+    """Class for standard comparison between two scaled minhashes"""
+    cmp_num: int = None
+
+    def __post_init__(self):
+        "Initialize NumMinHashComparison using values from provided MinHashes"
+        if self.cmp_num is None: # record the num we're doing this compa#rison on
+            self.cmp_num = min(self.mh1.num, self.mh2.num)
+        self.check_comparison_compatibility()
+        self.downsample_and_handle_ignore_abundance(cmp_num=self.cmp_num)
+
+@dataclass
+class FracMinHashComparison(BaseMinHashComparison):
+    """Class for standard comparison between two scaled minhashes"""
+    cmp_scaled: int = None # scaled value for this comparison (defaults to maximum scaled between the two sigs)
+    threshold_bp: int = 0
+
+    def __post_init__(self):
+        "Initialize ScaledComparison using values from provided FracMinHashes"
+        if self.cmp_scaled is None: # record the scaled we're doing this comparison on
+            self.cmp_scaled = max(self.mh1.scaled, self.mh2.scaled)
+        self.check_comparison_compatibility()
+        self.downsample_and_handle_ignore_abundance(cmp_scaled=self.cmp_scaled)
+        # for these, do we want the originals, or the cmp_scaled versions?? (or both?). do we need them at all?
+        self.mh1_scaled = self.mh1.scaled
+        self.mh2_scaled = self.mh2.scaled
+        self.mh1_n_hashes = len(self.mh1)
+        self.mh2_n_hashes = len(self.mh2)
+        self.mh1_bp = self.mh1.covered_bp
+        self.mh2_bp = self.mh2.covered_bp
+
+    @property
+    def pass_threshold(self):
+        return self.intersect_bp >= self.threshold_bp
+
+    @property
+    def intersect_bp(self):
+        return len(self.intersect_mh) * self.cmp_scaled
+
+    @property
+    def mh1_containment(self):
+        return self.mh1_cmp.contained_by(self.mh2_cmp)
+
+    @property
+    def mh2_containment(self):
+        return self.mh2_cmp.contained_by(self.mh1_cmp)
+
+    @property
+    def max_containment(self):
+        return self.mh1_cmp.max_containment(self.mh2_cmp)
+
+    @property
+    def avg_containment(self):
+        return np.mean(self.mh1_containment, self.mh2_containment)

--- a/src/sourmash/sketchcomparison.py
+++ b/src/sourmash/sketchcomparison.py
@@ -99,10 +99,6 @@ class FracMinHashComparison(BaseMinHashComparison):
         # for these, do we want the originals, or the cmp_scaled versions?? (or both?). do we need them at all?
         self.mh1_scaled = self.mh1.scaled
         self.mh2_scaled = self.mh2.scaled
-        self.mh1_n_hashes = len(self.mh1)
-        self.mh2_n_hashes = len(self.mh2)
-        self.mh1_bp = self.mh1.covered_bp
-        self.mh2_bp = self.mh2.covered_bp
 
     @property
     def pass_threshold(self):
@@ -128,20 +124,15 @@ class FracMinHashComparison(BaseMinHashComparison):
     def avg_containment(self):
         return np.mean([self.mh1_containment, self.mh2_containment])
 
-    @property
-    def mh1_weighted_intersection(self):
-         # map mh1 hash abundances to all intersection hashes.
-        if self.ignore_abundance or not self.mh1.track_abundance:
-            return self.intersect_mh # or do we want to set all abundances to 1?
-        else:
-        # current functionality inflates by original minhash (not downsampled)-- is that what we want??
-            return self.intersect_mh.inflate(self.mh1)
-
-    @property
-    def mh2_weighted_intersection(self):
-         # map mh2 hash abundances to all intersection hashes.
-        if self.ignore_abundance or not self.mh2.track_abundance:
-            return self.intersect_mh  # or do we want to set all abundances to 1?
-        else:
-        # current functionality inflates by original minhash (not downsampled)-- is that what we want??
-            return self.intersect_mh.inflate(self.mh2)
+    def weighted_intersection(self, from_mh=None, from_abundD={}):
+         # map abundances to all intersection hashes.
+        abund_mh = self.intersect_mh.copy_and_clear()
+        abund_mh.track_abundance = True
+        if from_mh is not None:
+            from_abundD = from_mh.hashes
+        if from_abundD is not None:
+            #abundD[k] for k in intersect_mh.hashes
+            abunds = {k: from_abundD.get(k, 1) for k in self.intersect_mh.hashes }
+            abund_mh.set_abundances(abunds)
+            return abund_mh
+        return self.intersect_mh # or do we want to set all abundances to 1?

--- a/src/sourmash/sketchcomparison.py
+++ b/src/sourmash/sketchcomparison.py
@@ -4,7 +4,7 @@ Sketch Comparison Classes
 import numpy as np
 from dataclasses import dataclass
 
-from .signature import SourmashSignature, MinHash
+from .signature import MinHash
 
 
 @dataclass
@@ -60,76 +60,17 @@ class BaseMinHashComparison:
 
     @property
     def angular_similarity(self):
-        if not self.mh1_cmp.track_abundance and self.mh2_cmp.track_abundance:
-            raise ValueError("Error: Angular (cosine) similarity requires both sketches to track hash abundance.")
         return self.mh1_cmp.angular_similarity(self.mh2_cmp)
+        # do we want to shield against error here? Or let TypeError through?
+        #if not (self.mh1_cmp.track_abundance and self.mh2_cmp.track_abundance):
+        #    return self.mh1_cmp.angular_similarity(self.mh2_cmp)
+        #else:
+        #    return ""
 
     @property
     def cosine_similarity(self):
         return self.angular_similarity
 
-    # do we need these? Now that I've added them to MinHash, maybe don't need? Except ignore_abundance -- what do we want to do there?
-    @property
-    def mh1_sum_abunds(self):
-        if self.ignore_abundance:
-            return ""
-        return self.mh1.sum_abundances
-
-    @property
-    def mh1_mean_abund(self):
-        if self.ignore_abundance:
-            return ""
-        return self.mh1.mean_abundance
-
-    @property
-    def mh2_mean_abund(self):
-        if self.ignore_abundance:
-            return ""
-        return self.mh2.mean_abundance
-
-    @property
-    def mh1_median_abund(self):
-        if self.ignore_abundance:
-            return ""
-        return self.mh1.median_abundance
-
-    @property
-    def mh2_median_abund(self):
-        if self.ignore_abundance:
-            return ""
-        return self.mh2.median_abundance
-
-    @property
-    def mh1_std_abund(self):
-        if self.ignore_abundance:
-            return ""
-        return self.mh1.std_abundance
-
-    @property
-    def mh2_std_abund(self):
-        if self.ignore_abundance:
-            return ""
-        return self.mh2.std_abundance
-
-    @property
-    def mh1_weighted_intersection(self):
-         # map mh1 hash abundances to all intersection hashes.
-         # WHAT DO WE WANT TO DO ABOUT ignore_abundance here?
-        #if self.ignore_abundance or not self.mh1.track_abundance:
-        if not self.mh1.track_abundance:
-            return self.intersect_mh # or do we want to set all abundances to 1?
-        else:
- #           return self.mh2_cmp.flatten().inflate(self.mh1) #implicitly intersects...
-            return self.intersect_mh.inflate(self.mh1)
-
-    @property
-    def mh2_weighted_intersection(self):
-         # map mh2 hash abundances to all intersection hashes.
-        if self.ignore_abundance or not self.mh2.track_abundance:
-            return self.intersect_mh  # or do we want to set all abundances to 1?
-        else:
-            intersect_w_abunds = self.intersect_mh.inflate(self.mh2)
-            return intersect_w_abunds
 
 @dataclass
 class NumMinHashComparison(BaseMinHashComparison):
@@ -185,4 +126,22 @@ class FracMinHashComparison(BaseMinHashComparison):
 
     @property
     def avg_containment(self):
-        return np.mean(self.mh1_containment, self.mh2_containment)
+        return np.mean([self.mh1_containment, self.mh2_containment])
+
+    @property
+    def mh1_weighted_intersection(self):
+         # map mh1 hash abundances to all intersection hashes.
+        if self.ignore_abundance or not self.mh1.track_abundance:
+            return self.intersect_mh # or do we want to set all abundances to 1?
+        else:
+        # current functionality inflates by original minhash (not downsampled)-- is that what we want??
+            return self.intersect_mh.inflate(self.mh1)
+
+    @property
+    def mh2_weighted_intersection(self):
+         # map mh2 hash abundances to all intersection hashes.
+        if self.ignore_abundance or not self.mh2.track_abundance:
+            return self.intersect_mh  # or do we want to set all abundances to 1?
+        else:
+        # current functionality inflates by original minhash (not downsampled)-- is that what we want??
+            return self.intersect_mh.inflate(self.mh2)

--- a/tests/test_minhash.py
+++ b/tests/test_minhash.py
@@ -2691,8 +2691,8 @@ def test_sum_abundances(track_abundance):
         assert mh1.sum_abundances == 6
         assert mh2.sum_abundances == 6
     else:
-        assert mh1.sum_abundances == 4
-        assert mh2.sum_abundances == 2
+        assert mh1.sum_abundances == None
+        assert mh2.sum_abundances == None
 
 
 def test_mean_abundance(track_abundance):

--- a/tests/test_minhash.py
+++ b/tests/test_minhash.py
@@ -565,6 +565,30 @@ def test_mh_similarity_downsample_angular_value():
     jaccard = a.similarity(b, downsample=True, ignore_abundance=True)
     assert jaccard == 4. / 6.
 
+def test_mh_angular_similarity_fail():
+    # raise TypeError if calling angular_similarity directly and
+    # one or both sketches do not have abundance info
+    a = MinHash(0, 20, scaled=scaled50, track_abundance=True)
+    b = MinHash(0, 20, scaled=scaled50, track_abundance=False)
+    a_values = { 1:5, 3:3, 5:2, 8:2}
+    b_values = { 1:3, 3:2, 5:1, 6:1, 8:1, 10:1 }
+
+    a.set_abundances(a_values)
+    b.add_many(b_values.keys())
+
+    # one sketch lacks track_abundance
+    with pytest.raises(TypeError) as exc:
+        a.angular_similarity(b)
+    print(str(exc))
+    assert "Error: Angular (cosine) similarity requires both sketches to track hash abundance." in str(exc)
+    # both sketches lack track abundance
+    a = MinHash(0, 20, scaled=scaled50, track_abundance=False)
+    a.add_many(a_values.keys())
+    with pytest.raises(TypeError) as exc:
+        a.angular_similarity(b)
+    print(str(exc))
+    assert "Error: Angular (cosine) similarity requires both sketches to track hash abundance." in str(exc)
+
 
 def test_mh_similarity_downsample_true(track_abundance):
     # verify sim(a, b) == sim(b, a), with and without ignore_abundance

--- a/tests/test_minhash.py
+++ b/tests/test_minhash.py
@@ -2652,6 +2652,97 @@ def test_containment(track_abundance):
     assert mh2.contained_by(mh1) == 1/2
 
 
+def test_sum_abundances(track_abundance):
+    "test sum_abundances"
+    mh1 = MinHash(0, 21, scaled=1, track_abundance=track_abundance)
+    mh2 = MinHash(0, 21, scaled=1, track_abundance=track_abundance)
+
+    mh1.add_many((1, 2, 3, 4))
+    mh1.add_many((1, 2))
+    mh2.add_many((1, 5))
+    mh2.add_many((1, 5))
+    mh2.add_many((1, 5))
+
+    if track_abundance:
+        assert mh1.sum_abundances == 6
+        assert mh2.sum_abundances == 6
+    else:
+        assert mh1.sum_abundances == 4
+        assert mh2.sum_abundances == 2
+
+
+def test_mean_abundance(track_abundance):
+    "test mean_abundance"
+    mh1 = MinHash(0, 21, scaled=1, track_abundance=track_abundance)
+    mh2 = MinHash(0, 21, scaled=1, track_abundance=track_abundance)
+
+    mh1.add_many((1, 2, 3, 4))
+    mh1.add_many((1, 2))
+    mh2.add_many((1, 5))
+    mh2.add_many((1, 5))
+    mh2.add_many((1, 5))
+
+    if track_abundance:
+        assert mh1.mean_abundance == 1.5
+        assert mh2.mean_abundance == 3
+    else:
+        assert not mh1.mean_abundance
+        assert not mh2.mean_abundance
+
+
+def test_median_abundance(track_abundance):
+    "test median_abundance"
+    mh1 = MinHash(0, 21, scaled=1, track_abundance=track_abundance)
+    mh2 = MinHash(0, 21, scaled=1, track_abundance=track_abundance)
+
+    mh1.add_many((1, 2, 3, 4))
+    mh1.add_many((1, 2))
+    mh2.add_many((1, 5))
+    mh2.add_many((1, 5))
+    mh2.add_many((1, 5))
+
+    if track_abundance:
+        assert mh1.median_abundance == 1.5
+        assert mh2.median_abundance == 3
+    else:
+        assert not mh1.median_abundance
+        assert not mh2.median_abundance
+
+
+def test_std_abundance(track_abundance):
+    "test std_abundance"
+    mh1 = MinHash(0, 21, scaled=1, track_abundance=track_abundance)
+    mh2 = MinHash(0, 21, scaled=1, track_abundance=track_abundance)
+
+    mh1.add_many((1, 2, 3, 4))
+    mh1.add_many((1, 2))
+    mh2.add_many((1, 5))
+    mh2.add_many((1, 5))
+    mh2.add_many((1, 5))
+
+    if track_abundance:
+        assert mh1.std_abundance == 0.5
+        assert mh2.std_abundance == 0.0
+    else:
+        assert not mh1.std_abundance
+        assert not mh2.std_abundance
+
+
+def test_covered_bp(track_abundance):
+    "test covered_bp"
+    mh1 = MinHash(0, 21, scaled=1, track_abundance=track_abundance)
+    mh2 = MinHash(4, 21, track_abundance=track_abundance)
+
+    mh1.add_many((1, 2, 3, 4))
+    mh1.add_many((1, 2))
+    mh2.add_many((1, 5))
+
+    assert mh1.covered_bp == 4 # hmmm...
+    with pytest.raises(TypeError) as exc:
+        mh2.covered_bp
+    assert "can only calculate bp for scaled MinHashes" in str(exc)
+
+
 def test_containment_ANI():
     f1 = utils.get_test_data('2.fa.sig')
     f2 = utils.get_test_data('2+63.fa.sig')

--- a/tests/test_prefetch.py
+++ b/tests/test_prefetch.py
@@ -5,10 +5,12 @@ import os
 import csv
 import pytest
 import glob
+import random
 
 import sourmash_tst_utils as utils
 import sourmash
 from sourmash_tst_utils import SourmashCommandFailed
+from sourmash import signature
 
 
 def test_prefetch_basic(runtmp, linear_gather):
@@ -526,6 +528,47 @@ def test_prefetch_downsample_scaled(runtmp, linear_gather):
 
     assert c.last_result.status == 0
     assert "downsampling query from scaled=1000 to 10000" in c.last_result.err
+
+
+
+
+def test_prefetch_downsample_multiple(runtmp, linear_gather):
+    # test multiple different downsamplings in prefetch code
+    query_sig = utils.get_test_data('GCF_000006945.2-s500.sig')
+
+    # load in the hashes and do split them into four bins, randomly.
+    ss = sourmash.load_one_signature(query_sig)
+    hashes = list(ss.minhash.hashes)
+
+    random.seed(a=1)            # fix seed so test is reproducible
+    random.shuffle(hashes)
+
+    # split into 4 bins:
+    mh_bins = [ ss.minhash.copy_and_clear() for i in range(4) ]
+    for i, hashval in enumerate(hashes):
+        mh_bins[i % 4].add_hash(hashval)
+
+    # downsample with different scaleds; initial scaled is 500, note.
+    mh_bins[0] = mh_bins[0].downsample(scaled=750)
+    mh_bins[1] = mh_bins[1].downsample(scaled=600)
+    mh_bins[2] = mh_bins[2].downsample(scaled=1000)
+    mh_bins[3] = mh_bins[3].downsample(scaled=650)
+
+    gathersigs = []
+    for i in range(4):
+        binsig = signature.SourmashSignature(mh_bins[i], name=f"bin{i}")
+
+        with open(runtmp.output(f"bin{i}.sig"), "wb") as fp:
+            sourmash.save_signatures([binsig], fp)
+
+        gathersigs.append(f"bin{i}.sig")
+
+    runtmp.sourmash('prefetch', linear_gather, query_sig, *gathersigs)
+
+    print(runtmp.last_result.out)
+    print(runtmp.last_result.err)
+
+    assert "final scaled value (max across query and all matches) is 1000" in runtmp.last_result.err
 
 
 def test_prefetch_empty(runtmp, linear_gather):

--- a/tests/test_prefetch.py
+++ b/tests/test_prefetch.py
@@ -188,6 +188,7 @@ def test_prefetch_csv_out(runtmp, linear_gather):
     with open(csvout, 'rt', newline="") as fp:
         r = csv.DictReader(fp)
         for (row, expected) in zip(r, expected_intersect_bp):
+            print(row)
             assert int(row['intersect_bp']) == expected
 
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -355,7 +355,7 @@ def test_GatherResult():
     res = GatherResult(ss47, ss4763, cmp_scaled=scaled,
                         current_gathersketch=remaining_mh,
                         gather_result_rank=gather_result_rank,
-                        sum_abunds = sum_abunds)
+                        total_abund = sum_abunds)
 
     assert res.query_name == ss47.name
     assert res.match_name == ss4763.name
@@ -392,4 +392,4 @@ def test_GatherResult():
     assert res.median_abund == 1.0
     assert res.std_abund == 0
     assert res.gather_result_rank == gather_result_rank
-    assert res.remaining_bp == 0
+    assert res.remaining_bp == 2468000

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -285,6 +285,41 @@ def test_SearchResult():
     assert res.filename == ss4763.filename
 
 
+def test_SearchResult_incompatible_sigs():
+    ss47_file = utils.get_test_data('num/47.fa.sig')
+    ss4763_file = utils.get_test_data('47+63.fa.sig')
+    ss47 = load_one_signature(ss47_file, ksize=31, select_moltype='dna')
+    ss4763 = load_one_signature(ss4763_file, ksize=31, select_moltype='dna')
+
+    with pytest.raises(TypeError) as exc:
+        SearchResult(ss47, ss4763, similarity=10)
+    print(str(exc))
+    assert "Error: Both sketches must be 'num' or 'scaled'." in str(exc)
+
+
+def test_SearchResult_notsigs():
+    ss47_file = utils.get_test_data('num/47.fa.sig')
+    ss4763_file = utils.get_test_data('47+63.fa.sig')
+
+    with pytest.raises(AttributeError) as exc:
+        SearchResult(ss47_file, ss4763_file, similarity=10)
+    print(str(exc))
+    assert "'str' object has no attribute 'minhash'" in str(exc)
+
+
+def test_SearchResult_no_similarity():
+    # check that values get stored/calculated correctly
+    ss47_file = utils.get_test_data('47.fa.sig')
+    ss4763_file = utils.get_test_data('47+63.fa.sig')
+    ss47 = load_one_signature(ss47_file, ksize=31, select_moltype='dna')
+    ss4763 = load_one_signature(ss4763_file, ksize=31, select_moltype='dna')
+
+    with pytest.raises(ValueError) as exc:
+        SearchResult(ss47, ss4763)
+    print(str(exc))
+    assert "Error: Must provide 'similarity' for SearchResult." in str(exc)
+
+
 def test_PrefetchResult():
     # check that values get stored/calculated correctly
     ss47_file = utils.get_test_data('47.fa.sig')
@@ -328,6 +363,18 @@ def test_PrefetchResult():
     assert res.max_containment == max_containment
     assert res.f_query_match == f_query_match
     assert res.f_match_query == f_match_query
+
+
+def test_PrefetchResult_incompatible_sigs():
+    ss47_file = utils.get_test_data('num/47.fa.sig')
+    ss4763_file = utils.get_test_data('47+63.fa.sig')
+    ss47 = load_one_signature(ss47_file, ksize=31, select_moltype='dna')
+    ss4763 = load_one_signature(ss4763_file, ksize=31, select_moltype='dna')
+
+    with pytest.raises(TypeError) as exc:
+        PrefetchResult(ss47, ss4763)
+    print(str(exc))
+    assert "Error: prefetch and gather results must be between scaled signatures." in str(exc)
 
 
 def test_GatherResult():
@@ -394,3 +441,92 @@ def test_GatherResult():
 #    assert res.std_abund == 0
 #    assert res.gather_result_rank == gather_result_rank
 #    assert res.remaining_bp == 2468000
+
+
+def test_GatherResult_incompatible_sigs():
+    ss47_file = utils.get_test_data('num/47.fa.sig')
+    ss4763_file = utils.get_test_data('47+63.fa.sig')
+    ss47 = load_one_signature(ss47_file, ksize=31, select_moltype='dna')
+    ss4763 = load_one_signature(ss4763_file, ksize=31, select_moltype='dna')
+
+    with pytest.raises(TypeError) as exc:
+        GatherResult(ss47, ss4763, cmp_scaled=1,
+                        gather_querymh=ss47.minhash,
+                        gather_result_rank=1,
+                        total_abund = 1,
+                        orig_query_len=len(ss47.minhash))
+    print(str(exc))
+    assert "Error: prefetch and gather results must be between scaled signatures." in str(exc)
+
+
+def test_GatherResult_incomplete_input_cmpscaled():
+    ss47_file = utils.get_test_data('47.fa.sig')
+    ss4763_file = utils.get_test_data('47+63.fa.sig')
+    ss47 = load_one_signature(ss47_file, ksize=31, select_moltype='dna')
+    ss4763 = load_one_signature(ss4763_file, ksize=31, select_moltype='dna')
+
+    with pytest.raises(ValueError) as exc:
+        GatherResult(ss47, ss4763, cmp_scaled=None,
+                        gather_querymh=ss47.minhash,
+                        gather_result_rank=1,
+                        total_abund = 1,
+                        orig_query_len=len(ss47.minhash))
+    print(str(exc))
+    assert "Error: must provide comparison scaled value ('cmp_scaled') for GatherResult" in str(exc)
+
+
+def test_GatherResult_incomplete_input_gathermh():
+    ss47_file = utils.get_test_data('47.fa.sig')
+    ss4763_file = utils.get_test_data('47+63.fa.sig')
+    ss47 = load_one_signature(ss47_file, ksize=31, select_moltype='dna')
+    ss4763 = load_one_signature(ss4763_file, ksize=31, select_moltype='dna')
+
+    with pytest.raises(ValueError) as exc:
+        GatherResult(ss47, ss4763, cmp_scaled=1000,
+                        gather_querymh=None,
+                        gather_result_rank=1,
+                        total_abund = 1,
+                        orig_query_len=len(ss47.minhash))
+    print(str(exc))
+    assert "Error: must provide current gather sketch (remaining hashes) for GatherResult" in str(exc)
+
+
+def test_GatherResult_incomplete_input_gather_result_rank():
+    ss47_file = utils.get_test_data('47.fa.sig')
+    ss4763_file = utils.get_test_data('47+63.fa.sig')
+    ss47 = load_one_signature(ss47_file, ksize=31, select_moltype='dna')
+    ss4763 = load_one_signature(ss4763_file, ksize=31, select_moltype='dna')
+
+    with pytest.raises(ValueError) as exc:
+        GatherResult(ss47, ss4763, cmp_scaled=1000,
+                        gather_querymh=ss47.minhash,
+                        gather_result_rank=None,
+                        total_abund = 1,
+                        orig_query_len=len(ss47.minhash))
+    print(str(exc))
+    assert "Error: must provide 'gather_result_rank' to GatherResult" in str(exc)
+
+
+def test_GatherResult_incomplete_input_total_abund():
+    ss47_file = utils.get_test_data('47.fa.sig')
+    ss4763_file = utils.get_test_data('47+63.fa.sig')
+    ss47 = load_one_signature(ss47_file, ksize=31, select_moltype='dna')
+    ss4763 = load_one_signature(ss4763_file, ksize=31, select_moltype='dna')
+
+    with pytest.raises(ValueError) as exc:
+        GatherResult(ss47, ss4763, cmp_scaled=1000,
+                        gather_querymh=ss47.minhash,
+                        gather_result_rank=1,
+                        total_abund = None,
+                        orig_query_len=len(ss47.minhash))
+    print(str(exc))
+    assert "Error: must provide sum of all abundances ('total_abund') to GatherResult" in str(exc)
+
+    with pytest.raises(ValueError) as exc:
+        GatherResult(ss47, ss4763, cmp_scaled=1000,
+                        gather_querymh=ss47.minhash,
+                        gather_result_rank=1,
+                        total_abund = 0,
+                        orig_query_len=len(ss47.minhash))
+    print(str(exc))
+    assert "Error: must provide sum of all abundances ('total_abund') to GatherResult" in str(exc)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -2,6 +2,7 @@
 
 # CTB TODO: test search protocol with mock class?
 
+from pyparsing import original_text_for
 import pytest
 import sourmash_tst_utils as utils
 
@@ -260,7 +261,7 @@ def test_SearchResult():
 
     scaled = ss47.minhash.scaled
 
-    res = SearchResult(ss47, ss4763, cmp_scaled=scaled)
+    res = SearchResult(ss47, ss4763, cmp_scaled=scaled, similarity= ss47.contained_by(ss4763))
 
     assert res.query_name == ss47.name
     assert res.match_name == ss4763.name
@@ -355,7 +356,8 @@ def test_GatherResult():
     res = GatherResult(ss47, ss4763, cmp_scaled=scaled,
                         gather_querymh=remaining_mh,
                         gather_result_rank=gather_result_rank,
-                        total_abund = sum_abunds)
+                        total_abund = sum_abunds,
+                        orig_query_len=len(ss47.minhash))
 
     assert res.query_name == ss47.name
     assert res.match_name == ss4763.name

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -251,6 +251,7 @@ def test_search_with_abund_query():
 
 
 def test_SearchResult():
+    # check that values get stored/calculated correctly
     ss47_file = utils.get_test_data('47.fa.sig')
     ss4763_file = utils.get_test_data('47+63.fa.sig')
     ss47 = load_one_signature(ss47_file, ksize=31, select_moltype='dna')
@@ -285,6 +286,7 @@ def test_SearchResult():
 
 
 def test_PrefetchResult():
+    # check that values get stored/calculated correctly
     ss47_file = utils.get_test_data('47.fa.sig')
     ss4763_file = utils.get_test_data('47+63.fa.sig')
     ss47 = load_one_signature(ss47_file, ksize=31, select_moltype='dna')
@@ -331,3 +333,82 @@ def test_PrefetchResult():
     assert res.max_containment == max_containment
     assert res.f_query_match == f_query_match
     assert res.f_match_query == f_match_query
+
+
+def test_GatherResult():
+    # check that values get stored/calculated correctly
+    ss47_file = utils.get_test_data('47.fa.sig')
+    ss4763_file = utils.get_test_data('47+63.fa.sig')
+    ss47 = load_one_signature(ss47_file, ksize=31, select_moltype='dna')
+    ss4763 = load_one_signature(ss4763_file, ksize=31, select_moltype='dna')
+    ss4763.filename = ss4763_file
+
+    scaled = ss47.minhash.scaled
+
+    intersect_mh = ss47.minhash.intersection(ss4763.minhash)
+    intersect_bp = len(intersect_mh) * scaled,
+    max_containment=ss4763.max_containment(ss47),
+    f_orig_query = ss47.contained_by(ss4763)
+    f_match_query=ss4763.contained_by(ss47),
+
+    # make some fake vals to check
+    unique_intersect_bp = 10
+    f_match = 0.6
+    f_unique_to_query = 0.2
+    f_unique_weighted = 0.4
+    average_abund = 1.3
+    median_abund = 1.2
+    std_abund = 0.1
+    gather_result_rank = 1
+    remaining_bp = 500
+
+    res = GatherResult(ss47, ss4763, scaled,
+                        intersect_bp=intersect_bp,
+                        max_containment=max_containment,
+                        f_match_orig=f_match_query,
+                        f_orig_query=f_orig_query,
+                        unique_intersect_bp=unique_intersect_bp,
+                        f_match=f_match,
+                        f_unique_to_query=f_unique_to_query,
+                        f_unique_weighted = f_unique_weighted,
+                        average_abund=average_abund,
+                        median_abund=median_abund,
+                        std_abund=std_abund,
+                        gather_result_rank=gather_result_rank,
+                        remaining_bp=remaining_bp)
+
+    assert res.query_name == ss47.name
+    assert res.match_name == ss4763.name
+    assert res.query_scaled == ss47.minhash.scaled == 1000
+    assert res.match_scaled == ss4763.minhash.scaled == 1000
+    assert res.search_scaled == 1000
+    assert res.num == 0
+    assert res.query_abundance == ss47.minhash.track_abundance
+    assert res.match_abundance == ss4763.minhash.track_abundance
+    assert res.query_bp == len(ss47.minhash) * scaled
+    assert res.match_bp == len(ss4763.minhash) * scaled
+    assert res.ksize == 31
+    assert res.moltype == 'DNA'
+    assert res.query_filename == '47.fa'
+    assert res.match_filename == ss4763_file
+    assert res.query_md5 == ss47.md5sum()
+    assert res.match_md5 == ss4763.md5sum()
+    assert res.query_n_hashes == len(ss47.minhash)
+    assert res.match_n_hashes == len(ss4763.minhash)
+    assert res.md5 == ss4763.md5sum()
+    assert res.name == ss4763.name
+    assert res.filename == ss4763.filename
+    # gather specific
+    assert res.intersect_bp == intersect_bp
+    assert res.max_containment == max_containment
+    assert res.f_match_orig == f_match_query
+    assert res.f_orig_query == f_orig_query
+    assert res.unique_intersect_bp == unique_intersect_bp
+    assert res.f_match == f_match
+    assert res.f_unique_to_query == f_unique_to_query
+    assert res.f_unique_weighted == f_unique_weighted
+    assert res.average_abund == average_abund
+    assert res.median_abund == median_abund
+    assert res.std_abund == std_abund
+    assert res.gather_result_rank == gather_result_rank
+    assert res.remaining_bp == remaining_bp

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -425,6 +425,7 @@ def test_GatherResult():
     max_containment=ss4763.max_containment(ss47)
     f_orig_query = ss47.contained_by(ss4763)
     f_match_query=ss4763.contained_by(ss47)
+    orig_query_abunds = ss47.minhash.hashes
 
     # make some fake vals to check
     gather_result_rank = 1
@@ -434,7 +435,8 @@ def test_GatherResult():
                         gather_querymh=remaining_mh,
                         gather_result_rank=gather_result_rank,
                         total_abund = sum_abunds,
-                        orig_query_len=len(ss47.minhash))
+                        orig_query_len=len(ss47.minhash),
+                        orig_query_abunds=orig_query_abunds)
 
     assert res.query_name == ss47.name
     assert res.match_name == ss4763.name
@@ -459,18 +461,9 @@ def test_GatherResult():
     # gather specific
     assert res.intersect_bp == intersect_bp
     assert res.max_containment == max_containment
-    # to do -- make sure these vals are correct!
-#    assert res.f_match_orig == f_match_query
-#    assert res.f_orig_query == f_orig_query
-#    assert res.unique_intersect_bp == 2709000
-#    assert res.f_match == 0.3435201623129597
-#    assert res.f_unique_to_query == 1.0
-#    assert res.f_unique_weighted ==  2.709
-#    assert res.average_abund == 1.0
-#    assert res.median_abund == 1.0
-#    assert res.std_abund == 0
-#    assert res.gather_result_rank == gather_result_rank
-#    assert res.remaining_bp == 2468000
+    prefetch_write_dict = list(res.prefetchwritedict.keys())
+    print(prefetch_write_dict)
+    assert set(prefetch_write_dict) == set(PrefetchResult.prefetch_write_cols)
 
 
 def test_GatherResult_incompatible_sigs():
@@ -478,13 +471,15 @@ def test_GatherResult_incompatible_sigs():
     ss4763_file = utils.get_test_data('47+63.fa.sig')
     ss47 = load_one_signature(ss47_file, ksize=31, select_moltype='dna')
     ss4763 = load_one_signature(ss4763_file, ksize=31, select_moltype='dna')
+    orig_query_abunds = ss47.minhash.hashes
 
     with pytest.raises(TypeError) as exc:
         GatherResult(ss47, ss4763, cmp_scaled=1,
                         gather_querymh=ss47.minhash,
                         gather_result_rank=1,
                         total_abund = 1,
-                        orig_query_len=len(ss47.minhash))
+                        orig_query_len=len(ss47.minhash),
+                        orig_query_abunds=orig_query_abunds)
     print(str(exc))
     assert "Error: prefetch and gather results must be between scaled signatures." in str(exc)
 
@@ -494,13 +489,15 @@ def test_GatherResult_incomplete_input_cmpscaled():
     ss4763_file = utils.get_test_data('47+63.fa.sig')
     ss47 = load_one_signature(ss47_file, ksize=31, select_moltype='dna')
     ss4763 = load_one_signature(ss4763_file, ksize=31, select_moltype='dna')
+    orig_query_abunds = ss47.minhash.hashes
 
     with pytest.raises(ValueError) as exc:
         GatherResult(ss47, ss4763, cmp_scaled=None,
                         gather_querymh=ss47.minhash,
                         gather_result_rank=1,
                         total_abund = 1,
-                        orig_query_len=len(ss47.minhash))
+                        orig_query_len=len(ss47.minhash),
+                        orig_query_abunds=orig_query_abunds)
     print(str(exc))
     assert "Error: must provide comparison scaled value ('cmp_scaled') for GatherResult" in str(exc)
 
@@ -510,13 +507,15 @@ def test_GatherResult_incomplete_input_gathermh():
     ss4763_file = utils.get_test_data('47+63.fa.sig')
     ss47 = load_one_signature(ss47_file, ksize=31, select_moltype='dna')
     ss4763 = load_one_signature(ss4763_file, ksize=31, select_moltype='dna')
+    orig_query_abunds = ss47.minhash.hashes
 
     with pytest.raises(ValueError) as exc:
         GatherResult(ss47, ss4763, cmp_scaled=1000,
                         gather_querymh=None,
                         gather_result_rank=1,
                         total_abund = 1,
-                        orig_query_len=len(ss47.minhash))
+                        orig_query_len=len(ss47.minhash),
+                        orig_query_abunds=orig_query_abunds)
     print(str(exc))
     assert "Error: must provide current gather sketch (remaining hashes) for GatherResult" in str(exc)
 
@@ -526,13 +525,15 @@ def test_GatherResult_incomplete_input_gather_result_rank():
     ss4763_file = utils.get_test_data('47+63.fa.sig')
     ss47 = load_one_signature(ss47_file, ksize=31, select_moltype='dna')
     ss4763 = load_one_signature(ss4763_file, ksize=31, select_moltype='dna')
+    orig_query_abunds = ss47.minhash.hashes
 
     with pytest.raises(ValueError) as exc:
         GatherResult(ss47, ss4763, cmp_scaled=1000,
                         gather_querymh=ss47.minhash,
                         gather_result_rank=None,
                         total_abund = 1,
-                        orig_query_len=len(ss47.minhash))
+                        orig_query_len=len(ss47.minhash),
+                        orig_query_abunds=orig_query_abunds)
     print(str(exc))
     assert "Error: must provide 'gather_result_rank' to GatherResult" in str(exc)
 
@@ -542,13 +543,15 @@ def test_GatherResult_incomplete_input_total_abund():
     ss4763_file = utils.get_test_data('47+63.fa.sig')
     ss47 = load_one_signature(ss47_file, ksize=31, select_moltype='dna')
     ss4763 = load_one_signature(ss4763_file, ksize=31, select_moltype='dna')
+    orig_query_abunds = ss47.minhash.hashes
 
     with pytest.raises(ValueError) as exc:
         GatherResult(ss47, ss4763, cmp_scaled=1000,
                         gather_querymh=ss47.minhash,
                         gather_result_rank=1,
                         total_abund = None,
-                        orig_query_len=len(ss47.minhash))
+                        orig_query_len=len(ss47.minhash),
+                        orig_query_abunds=orig_query_abunds)
     print(str(exc))
     assert "Error: must provide sum of all abundances ('total_abund') to GatherResult" in str(exc)
 
@@ -557,6 +560,37 @@ def test_GatherResult_incomplete_input_total_abund():
                         gather_querymh=ss47.minhash,
                         gather_result_rank=1,
                         total_abund = 0,
-                        orig_query_len=len(ss47.minhash))
+                        orig_query_len=len(ss47.minhash),
+                        orig_query_abunds=orig_query_abunds)
+    print(str(exc))
+    assert "Error: must provide sum of all abundances ('total_abund') to GatherResult" in str(exc)
+
+
+def test_GatherResult_incomplete_input_orig_query_abunds():
+    ss47_file = utils.get_test_data('47.fa.sig')
+    ss4763_file = utils.get_test_data('47+63.fa.sig')
+    ss47 = load_one_signature(ss47_file, ksize=31, select_moltype='dna')
+    ss4763 = load_one_signature(ss4763_file, ksize=31, select_moltype='dna')
+    orig_query_abunds = None
+
+    with pytest.raises(ValueError) as exc:
+        GatherResult(ss47, ss4763, cmp_scaled=1000,
+                        gather_querymh=ss47.minhash,
+                        gather_result_rank=1,
+                        total_abund = None,
+                        orig_query_len=len(ss47.minhash),
+                        orig_query_abunds=orig_query_abunds)
+    print(str(exc))
+    assert "Error: must provide sum of all abundances ('total_abund') to GatherResult" in str(exc)
+
+    orig_query_abunds = {}
+
+    with pytest.raises(ValueError) as exc:
+        GatherResult(ss47, ss4763, cmp_scaled=1000,
+                        gather_querymh=ss47.minhash,
+                        gather_result_rank=1,
+                        total_abund = 0,
+                        orig_query_len=len(ss47.minhash),
+                        orig_query_abunds=orig_query_abunds)
     print(str(exc))
     assert "Error: must provide sum of all abundances ('total_abund') to GatherResult" in str(exc)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -353,7 +353,7 @@ def test_GatherResult():
     sum_abunds = 1000
 
     res = GatherResult(ss47, ss4763, cmp_scaled=scaled,
-                        current_gathersketch=remaining_mh,
+                        gather_querymh=remaining_mh,
                         gather_result_rank=gather_result_rank,
                         total_abund = sum_abunds)
 
@@ -380,16 +380,15 @@ def test_GatherResult():
     # gather specific
     assert res.intersect_bp == intersect_bp
     assert res.max_containment == max_containment
-    assert res.f_match_orig == f_match_query
-    assert res.f_orig_query == f_orig_query
-
     # to do -- make sure these vals are correct!
-    assert res.unique_intersect_bp == 2709000
-    assert res.f_match == 0.3435201623129597
-    assert res.f_unique_to_query == 1.0
-    assert res.f_unique_weighted ==  2.709
-    assert res.average_abund == 1.0
-    assert res.median_abund == 1.0
-    assert res.std_abund == 0
-    assert res.gather_result_rank == gather_result_rank
-    assert res.remaining_bp == 2468000
+#    assert res.f_match_orig == f_match_query
+#    assert res.f_orig_query == f_orig_query
+#    assert res.unique_intersect_bp == 2709000
+#    assert res.f_match == 0.3435201623129597
+#    assert res.f_unique_to_query == 1.0
+#    assert res.f_unique_weighted ==  2.709
+#    assert res.average_abund == 1.0
+#    assert res.median_abund == 1.0
+#    assert res.std_abund == 0
+#    assert res.gather_result_rank == gather_result_rank
+#    assert res.remaining_bp == 2468000

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -269,16 +269,16 @@ def test_SearchResult():
     assert res.cmp_scaled == 1000
     assert res.query_abundance == ss47.minhash.track_abundance
     assert res.match_abundance == ss4763.minhash.track_abundance
-    assert res.query_bp == len(ss47.minhash) * scaled
-    assert res.match_bp == len(ss4763.minhash) * scaled
+#    assert res.query_bp == len(ss47.minhash) * scaled
+#    assert res.match_bp == len(ss4763.minhash) * scaled
     assert res.ksize == 31
     assert res.moltype == 'DNA'
     assert res.query_filename == '47.fa'
     assert res.match_filename == ss4763_file
     assert res.query_md5 == ss47.md5sum()
     assert res.match_md5 == ss4763.md5sum()
-    assert res.query_n_hashes == len(ss47.minhash)
-    assert res.match_n_hashes == len(ss4763.minhash)
+ #   assert res.query_n_hashes == len(ss47.minhash)
+ #   assert res.match_n_hashes == len(ss4763.minhash)
     assert res.md5 == ss4763.md5sum()
     assert res.name == ss4763.name
     assert res.filename == ss4763.filename

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -577,11 +577,11 @@ def test_GatherResult_incomplete_input_orig_query_abunds():
         GatherResult(ss47, ss4763, cmp_scaled=1000,
                         gather_querymh=ss47.minhash,
                         gather_result_rank=1,
-                        total_abund = None,
+                        total_abund = 1,
                         orig_query_len=len(ss47.minhash),
                         orig_query_abunds=orig_query_abunds)
     print(str(exc))
-    assert "Error: must provide sum of all abundances ('total_abund') to GatherResult" in str(exc)
+    assert "Error: must provide original query abundances ('orig_query_abunds') to GatherResult" in str(exc)
 
     orig_query_abunds = {}
 
@@ -589,8 +589,8 @@ def test_GatherResult_incomplete_input_orig_query_abunds():
         GatherResult(ss47, ss4763, cmp_scaled=1000,
                         gather_querymh=ss47.minhash,
                         gather_result_rank=1,
-                        total_abund = 0,
+                        total_abund = 1,
                         orig_query_len=len(ss47.minhash),
                         orig_query_abunds=orig_query_abunds)
     print(str(exc))
-    assert "Error: must provide sum of all abundances ('total_abund') to GatherResult" in str(exc)
+    assert "Error: must provide original query abundances ('orig_query_abunds') to GatherResult" in str(exc)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -251,7 +251,7 @@ def test_search_with_abund_query():
                                                  do_max_containment=True)
 
 
-def test_SearchResult():
+def test_scaledSearchResult():
     # check that values get stored/calculated correctly
     ss47_file = utils.get_test_data('47.fa.sig')
     ss4763_file = utils.get_test_data('47+63.fa.sig')
@@ -283,6 +283,36 @@ def test_SearchResult():
     assert res.md5 == ss4763.md5sum()
     assert res.name == ss4763.name
     assert res.filename == ss4763.filename
+
+def test_numSearchResult():
+    # check that values get stored/calculated correctly
+    ss47_file = utils.get_test_data('num/47.fa.sig')
+    ss63_file = utils.get_test_data('num/63.fa.sig')
+    ss47 = load_one_signature(ss47_file, ksize=31, select_moltype='dna')
+    ss63 = load_one_signature(ss63_file, ksize=31, select_moltype='dna')
+    ss63.filename = ss63_file
+
+    assert ss47.minhash.num and ss63.minhash.num
+
+    res = SearchResult(ss47, ss63, similarity= ss47.jaccard(ss63))
+    print(res.cmp_num)
+    assert res.mh1.num
+    assert res.cmp.cmp_num == 500
+    assert res.query_name == ss47.name
+    assert res.match_name == ss63.name
+    assert res.query_num == ss47.minhash.num == 500
+    assert res.match_num == ss63.minhash.num == 500
+    assert res.query_abundance == ss47.minhash.track_abundance
+    assert res.match_abundance == ss63.minhash.track_abundance
+    assert res.ksize == 31
+    assert res.moltype == 'DNA'
+    assert res.query_filename == '47.fa'
+    assert res.match_filename == ss63_file
+    assert res.query_md5 == ss47.md5sum()
+    assert res.match_md5 == ss63.md5sum()
+    assert res.md5 == ss63.md5sum()
+    assert res.name == ss63.name
+    assert res.filename == ss63.filename
 
 
 def test_SearchResult_incompatible_sigs():

--- a/tests/test_sketchcomparison.py
+++ b/tests/test_sketchcomparison.py
@@ -1,0 +1,356 @@
+"""
+Tests for the 'SketchComparison' classes.
+"""
+
+import numpy as np
+import pytest
+
+
+from sourmash.minhash import MinHash
+from sourmash.sketchcomparison import BaseMinHashComparison, FracMinHashComparison, NumMinHashComparison
+
+import sourmash_tst_utils as utils
+
+# can we parameterize scaled too (so don't need separate downsample tests?)
+def test_FracMinHashComparison(track_abundance):
+    # build FracMinHash Comparison and check values 
+    a = MinHash(0, 21, scaled=1, track_abundance=track_abundance)
+    b = MinHash(0, 21, scaled=1, track_abundance=track_abundance)
+
+    a_values = { 1:5, 3:3, 5:2, 8:2}
+    b_values = { 1:3, 3:2, 5:1, 6:1, 8:1, 10:1 }
+    
+    if track_abundance:
+        a.set_abundances(a_values)
+        b.set_abundances(b_values)
+    else:
+        a.add_many(a_values.keys())
+        b.add_many(b_values.keys())
+
+    # build FracMinHashComparison 
+    cmp = FracMinHashComparison(a, b)
+    assert cmp.mh1 == a
+    assert cmp.mh2 == b
+    assert cmp.ignore_abundance == False
+    assert cmp.cmp_scaled == 1
+    assert cmp.ksize == 21
+    assert cmp.moltype == "DNA"
+    assert cmp.mh1_containment == a.contained_by(b)
+    assert cmp.mh2_containment == b.contained_by(a)
+    assert cmp.avg_containment == np.mean([a.contained_by(b), b.contained_by(a)])
+    assert cmp.max_containment == a.max_containment(b)
+    assert cmp.jaccard == a.jaccard(b) == b.jaccard(a)
+    intersect_mh = a.flatten().intersection(b.flatten())
+    assert cmp.intersect_mh == intersect_mh == b.flatten().intersection(a.flatten())
+    assert cmp.intersect_bp == 4
+    assert cmp.pass_threshold # default threshold is 0; this should pass
+    if track_abundance:
+        assert cmp.angular_similarity == a.angular_similarity(b) == b.angular_similarity(a)
+        assert cmp.cosine_similarity == a.angular_similarity(b) == b.angular_similarity(a)
+        assert cmp.mh1_weighted_intersection == intersect_mh.inflate(a)
+        assert cmp.mh2_weighted_intersection == intersect_mh.inflate(b)
+    else:
+        with pytest.raises(TypeError) as exc:
+            cmp.angular_similarity
+        print(str(exc))
+        assert "Error: Angular (cosine) similarity requires both sketches to track hash abundance." in str(exc)
+        with pytest.raises(TypeError) as exc:
+            cmp.cosine_similarity
+        print(str(exc))
+        assert "Error: Angular (cosine) similarity requires both sketches to track hash abundance." in str(exc)
+        assert cmp.mh1_weighted_intersection == intersect_mh
+        assert cmp.mh2_weighted_intersection == intersect_mh
+    
+
+def test_FracMinHashComparison_downsample(track_abundance):
+    # build FracMinHash Comparison and check values 
+    a = MinHash(0, 21, scaled=1, track_abundance=track_abundance)
+    b = MinHash(0, 21, scaled=1, track_abundance=track_abundance)
+
+    a_values = { 1:5, 3:3, 5:2, 8:2}
+    b_values = { 1:3, 3:2, 5:1, 6:1, 8:1, 10:1 }
+    
+    if track_abundance:
+        a.set_abundances(a_values)
+        b.set_abundances(b_values)
+    else:
+        a.add_many(a_values.keys())
+        b.add_many(b_values.keys())
+
+    cmp_scaled = 2
+    ds_a = a.downsample(scaled=cmp_scaled)
+    ds_b = b.downsample(scaled=cmp_scaled)
+
+    # build FracMinHashComparison 
+    cmp = FracMinHashComparison(a, b, cmp_scaled = cmp_scaled)
+    assert cmp.mh1 == a
+    assert cmp.mh2 == b
+    assert cmp.mh1_cmp == ds_a
+    assert cmp.mh2_cmp == ds_b
+    assert cmp.ignore_abundance == False
+    assert cmp.cmp_scaled == cmp_scaled
+    assert cmp.ksize == 21
+    assert cmp.moltype == "DNA"
+    assert cmp.mh1_containment == ds_a.contained_by(ds_b)
+    assert cmp.mh2_containment == ds_b.contained_by(ds_a)
+    assert cmp.avg_containment == np.mean([ds_a.contained_by(ds_b), ds_b.contained_by(ds_a)])
+    assert cmp.max_containment == ds_a.max_containment(ds_b)
+    assert cmp.jaccard == ds_a.jaccard(ds_b) == ds_b.jaccard(ds_a)
+    intersect_mh = ds_a.flatten().intersection(ds_b.flatten())
+    assert cmp.intersect_mh == intersect_mh == ds_b.flatten().intersection(ds_a.flatten())
+    assert cmp.intersect_bp == 8
+    assert cmp.pass_threshold # default threshold is 0; this should pass
+    if track_abundance:
+        assert cmp.angular_similarity == ds_a.angular_similarity(ds_b) == ds_b.angular_similarity(ds_a)
+        assert cmp.cosine_similarity == ds_a.angular_similarity(ds_b) == ds_b.angular_similarity(ds_a)
+        # current functionality inflates by original minhash -- is that what we want??
+        assert cmp.mh1_weighted_intersection == intersect_mh.inflate(a)
+        assert cmp.mh2_weighted_intersection == intersect_mh.inflate(b)
+    else:
+        with pytest.raises(TypeError) as exc:
+            cmp.angular_similarity
+        print(str(exc))
+        assert "Error: Angular (cosine) similarity requires both sketches to track hash abundance." in str(exc)
+        with pytest.raises(TypeError) as exc:
+            cmp.cosine_similarity
+        print(str(exc))
+        assert "Error: Angular (cosine) similarity requires both sketches to track hash abundance." in str(exc)
+        assert cmp.mh1_weighted_intersection == intersect_mh
+        assert cmp.mh2_weighted_intersection == intersect_mh
+
+
+def test_FracMinHashComparison_autodownsample(track_abundance):
+    # build FracMinHash Comparison and check values 
+    a = MinHash(0, 21, scaled=1, track_abundance=track_abundance)
+    b = MinHash(0, 21, scaled=2, track_abundance=track_abundance)
+
+    a_values = { 1:5, 3:3, 5:2, 8:2}
+    b_values = { 1:3, 3:2, 5:1, 6:1, 8:1, 10:1 }
+    
+    if track_abundance:
+        a.set_abundances(a_values)
+        b.set_abundances(b_values)
+    else:
+        a.add_many(a_values.keys())
+        b.add_many(b_values.keys())
+
+    cmp_scaled = 2
+    ds_a = a.downsample(scaled=cmp_scaled)
+    ds_b = b.downsample(scaled=cmp_scaled)
+
+    # build FracMinHashComparison 
+    cmp = FracMinHashComparison(a, b)
+    assert cmp.mh1 == a
+    assert cmp.mh2 == b
+    assert cmp.mh1_cmp == ds_a
+    assert cmp.mh2_cmp == ds_b
+    assert cmp.ignore_abundance == False
+    assert cmp.cmp_scaled == cmp_scaled
+    assert cmp.ksize == 21
+    assert cmp.moltype == "DNA"
+    assert cmp.mh1_containment == ds_a.contained_by(ds_b)
+    assert cmp.mh2_containment == ds_b.contained_by(ds_a)
+    assert cmp.avg_containment == np.mean([ds_a.contained_by(ds_b), ds_b.contained_by(ds_a)])
+    assert cmp.max_containment == ds_a.max_containment(ds_b)
+    assert cmp.jaccard == ds_a.jaccard(ds_b) == ds_b.jaccard(ds_a)
+    intersect_mh = ds_a.flatten().intersection(ds_b.flatten())
+    assert cmp.intersect_mh == intersect_mh == ds_b.flatten().intersection(ds_a.flatten())
+    assert cmp.intersect_bp == 8
+    assert cmp.pass_threshold # default threshold is 0; this should pass
+    if track_abundance:
+        assert cmp.angular_similarity == ds_a.angular_similarity(ds_b) == ds_b.angular_similarity(ds_a)
+        assert cmp.cosine_similarity == ds_a.angular_similarity(ds_b) == ds_b.angular_similarity(ds_a)
+        # current functionality inflates by original minhash -- is that what we want??
+        assert cmp.mh1_weighted_intersection == intersect_mh.inflate(a)
+        assert cmp.mh2_weighted_intersection == intersect_mh.inflate(b)
+    else:
+        with pytest.raises(TypeError) as exc:
+            cmp.angular_similarity
+        print(str(exc))
+        assert "Error: Angular (cosine) similarity requires both sketches to track hash abundance." in str(exc)
+        with pytest.raises(TypeError) as exc:
+            cmp.cosine_similarity
+        print(str(exc))
+        assert "Error: Angular (cosine) similarity requires both sketches to track hash abundance." in str(exc)
+        assert cmp.mh1_weighted_intersection == intersect_mh
+        assert cmp.mh2_weighted_intersection == intersect_mh
+
+def test_FracMinHashComparison_ignore_abundance(track_abundance):
+    # build FracMinHash Comparison and check values 
+    a = MinHash(0, 21, scaled=1, track_abundance=track_abundance)
+    b = MinHash(0, 21, scaled=1, track_abundance=track_abundance)
+
+    a_values = { 1:5, 3:3, 5:2, 8:2}
+    b_values = { 1:3, 3:2, 5:1, 6:1, 8:1, 10:1 }
+    
+    if track_abundance:
+        a.set_abundances(a_values)
+        b.set_abundances(b_values)
+    else:
+        a.add_many(a_values.keys())
+        b.add_many(b_values.keys())
+    
+    cmp_scaled = 2
+    ds_a = a.flatten().downsample(scaled=cmp_scaled)
+    ds_b = b.flatten().downsample(scaled=cmp_scaled)
+
+    # build FracMinHashComparison 
+    cmp = FracMinHashComparison(a, b, cmp_scaled = cmp_scaled, ignore_abundance=True)
+    assert cmp.mh1 == a
+    assert cmp.mh2 == b
+    assert cmp.ignore_abundance == True
+    assert cmp.cmp_scaled == cmp_scaled
+    assert cmp.ksize == 21
+    assert cmp.moltype == "DNA"
+    assert cmp.mh1_containment == a.contained_by(b)
+    assert cmp.mh2_containment == b.contained_by(a)
+    assert cmp.avg_containment == np.mean([a.contained_by(b), b.contained_by(a)])
+    assert cmp.max_containment == a.max_containment(b)
+    assert cmp.jaccard == a.jaccard(b) == b.jaccard(a)
+    intersect_mh = ds_a.flatten().intersection(ds_b.flatten())
+    assert cmp.intersect_mh == intersect_mh == ds_b.flatten().intersection(ds_a.flatten())
+    assert cmp.intersect_bp == 8
+    assert cmp.pass_threshold # default threshold is 0; this should pass
+    # with ignore_abundance = True, all of these should not be usable. Do we want errors, or ""/None?
+    with pytest.raises(TypeError) as exc:
+        cmp.angular_similarity
+    print(str(exc))
+    assert "Error: Angular (cosine) similarity requires both sketches to track hash abundance." in str(exc)
+    with pytest.raises(TypeError) as exc:
+        cmp.cosine_similarity
+    print(str(exc))
+    assert "Error: Angular (cosine) similarity requires both sketches to track hash abundance." in str(exc)
+    assert cmp.mh1_weighted_intersection == intersect_mh
+    assert cmp.mh2_weighted_intersection == intersect_mh
+
+
+def test_NumMinHashComparison(track_abundance):
+    # build FracMinHash Comparison and check values 
+    a = MinHash(10, 21, scaled=0, track_abundance=track_abundance)
+    b = MinHash(10, 21, scaled=0, track_abundance=track_abundance)
+
+    a_values = { 1:5, 3:3, 5:2, 8:2}
+    b_values = { 1:3, 3:2, 5:1, 6:1, 8:1, 10:1 }
+    
+    if track_abundance:
+        a.set_abundances(a_values)
+        b.set_abundances(b_values)
+    else:
+        a.add_many(a_values.keys())
+        b.add_many(b_values.keys())
+    
+    assert a.num and b.num and not a.scaled and not b.scaled
+    
+    # build NumMinHashComparison 
+    cmp = NumMinHashComparison(a, b)
+    assert cmp.mh1 == a
+    assert cmp.mh2 == b
+    assert cmp.ignore_abundance == False
+    assert cmp.cmp_num == 10
+    assert cmp.ksize == 21
+    assert cmp.moltype == "DNA"
+    assert cmp.jaccard == a.jaccard(b) == b.jaccard(a)
+    intersect_mh = a.flatten().intersection(b.flatten())
+    assert cmp.intersect_mh == intersect_mh == b.flatten().intersection(a.flatten())
+    if track_abundance:
+        assert cmp.angular_similarity == a.angular_similarity(b) == b.angular_similarity(a)
+        assert cmp.cosine_similarity == a.angular_similarity(b) == b.angular_similarity(a)
+    else:
+        with pytest.raises(TypeError) as exc:
+            cmp.angular_similarity
+        print(str(exc))
+        assert "Error: Angular (cosine) similarity requires both sketches to track hash abundance." in str(exc)
+        with pytest.raises(TypeError) as exc:
+            cmp.cosine_similarity
+        print(str(exc))
+        assert "Error: Angular (cosine) similarity requires both sketches to track hash abundance." in str(exc)
+
+
+def test_NumMinHashComparison_downsample(track_abundance):
+    # build FracMinHash Comparison and check values 
+    a = MinHash(10, 21, scaled=0, track_abundance=track_abundance)
+    b = MinHash(10, 21, scaled=0, track_abundance=track_abundance)
+
+    a_values = { 1:5, 3:3, 5:2, 8:2}
+    b_values = { 1:3, 3:2, 5:1, 6:1, 8:1, 10:1 }
+    
+    if track_abundance:
+        a.set_abundances(a_values)
+        b.set_abundances(b_values)
+    else:
+        a.add_many(a_values.keys())
+        b.add_many(b_values.keys())
+    
+    assert a.num and b.num and not a.scaled and not b.scaled
+
+    cmp_num = 5
+    ds_a = a.downsample(num=cmp_num)
+    ds_b = b.downsample(num=cmp_num)
+    # build NumMinHashComparison 
+    cmp = NumMinHashComparison(a, b, cmp_num = cmp_num)
+    assert cmp.mh1 == a
+    assert cmp.mh2 == b
+    assert cmp.ignore_abundance == False
+    assert cmp.cmp_num == cmp_num
+    assert cmp.ksize == 21
+    assert cmp.moltype == "DNA"
+    assert cmp.jaccard == ds_a.jaccard(ds_b) == ds_b.jaccard(ds_a)
+    intersect_mh = ds_a.flatten().intersection(ds_b.flatten())
+    assert cmp.intersect_mh == intersect_mh == ds_b.flatten().intersection(ds_a.flatten())
+    if track_abundance:
+        assert cmp.angular_similarity == ds_a.angular_similarity(ds_b) == ds_b.angular_similarity(ds_a)
+        assert cmp.cosine_similarity == ds_a.angular_similarity(ds_b) == ds_b.angular_similarity(ds_a)
+    else:
+        with pytest.raises(TypeError) as exc:
+            cmp.angular_similarity
+        print(str(exc))
+        assert "Error: Angular (cosine) similarity requires both sketches to track hash abundance." in str(exc)
+        with pytest.raises(TypeError) as exc:
+            cmp.cosine_similarity
+        print(str(exc))
+        assert "Error: Angular (cosine) similarity requires both sketches to track hash abundance." in str(exc)
+
+def test_NumMinHashComparison_autodownsample(track_abundance):
+    # build FracMinHash Comparison and check values 
+    a = MinHash(10, 21, scaled=0, track_abundance=track_abundance)
+    b = MinHash(5, 21, scaled=0, track_abundance=track_abundance)
+
+    a_values = { 1:5, 3:3, 5:2, 8:2}
+    b_values = { 1:3, 3:2, 5:1, 6:1, 8:1, 10:1 }
+    
+    if track_abundance:
+        a.set_abundances(a_values)
+        b.set_abundances(b_values)
+    else:
+        a.add_many(a_values.keys())
+        b.add_many(b_values.keys())
+    
+    assert a.num and b.num and not a.scaled and not b.scaled
+
+    cmp_num = 5
+    ds_a = a.downsample(num=cmp_num)
+    ds_b = b.downsample(num=cmp_num)
+    # build NumMinHashComparison 
+    cmp = NumMinHashComparison(a, b)
+    assert cmp.mh1 == a
+    assert cmp.mh2 == b
+    assert cmp.ignore_abundance == False
+    assert cmp.cmp_num == cmp_num
+    assert cmp.ksize == 21
+    assert cmp.moltype == "DNA"
+    assert cmp.jaccard == ds_a.jaccard(ds_b) == ds_b.jaccard(ds_a)
+    intersect_mh = ds_a.flatten().intersection(ds_b.flatten())
+    assert cmp.intersect_mh == intersect_mh == ds_b.flatten().intersection(ds_a.flatten())
+    if track_abundance:
+        assert cmp.angular_similarity == ds_a.angular_similarity(ds_b) == ds_b.angular_similarity(ds_a)
+        assert cmp.cosine_similarity == ds_a.angular_similarity(ds_b) == ds_b.angular_similarity(ds_a)
+    else:
+        with pytest.raises(TypeError) as exc:
+            cmp.angular_similarity
+        print(str(exc))
+        assert "Error: Angular (cosine) similarity requires both sketches to track hash abundance." in str(exc)
+        with pytest.raises(TypeError) as exc:
+            cmp.cosine_similarity
+        print(str(exc))
+        assert "Error: Angular (cosine) similarity requires both sketches to track hash abundance." in str(exc)
+    

--- a/tests/test_sketchcomparison.py
+++ b/tests/test_sketchcomparison.py
@@ -224,6 +224,91 @@ def test_FracMinHashComparison_ignore_abundance(track_abundance):
     assert cmp.mh2_weighted_intersection == intersect_mh
 
 
+def test_FracMinHashComparison_incompatible_ksize(track_abundance):
+    a = MinHash(0, 31, scaled=1, track_abundance=track_abundance)
+    b = MinHash(0, 21, scaled=2, track_abundance=track_abundance)
+
+    a_values = { 1:5, 3:3, 5:2, 8:2}
+    b_values = { 1:3, 3:2, 5:1, 6:1, 8:1, 10:1 }
+
+    if track_abundance:
+        a.set_abundances(a_values)
+        b.set_abundances(b_values)
+    else:
+        a.add_many(a_values.keys())
+        b.add_many(b_values.keys())
+
+    with pytest.raises(TypeError) as exc:
+        FracMinHashComparison(a, b)
+    print(str(exc))
+    assert "Error: Invalid Comparison, ksizes: 31, 21. Must compare sketches of the same ksize." in str(exc)
+
+
+def test_FracMinHashComparison_incompatible_moltype(track_abundance):
+    a = MinHash(0, 31, scaled=1, track_abundance=track_abundance)
+    b = MinHash(0, 31, scaled=2, is_protein=True, track_abundance=track_abundance)
+
+    a_values = { 1:5, 3:3, 5:2, 8:2}
+    b_values = { 1:3, 3:2, 5:1, 6:1, 8:1, 10:1 }
+
+    if track_abundance:
+        a.set_abundances(a_values)
+        b.set_abundances(b_values)
+    else:
+        a.add_many(a_values.keys())
+        b.add_many(b_values.keys())
+
+    with pytest.raises(TypeError) as exc:
+        FracMinHashComparison(a, b)
+    print(str(exc))
+    assert "Error: Invalid Comparison, moltypes: DNA, protein. Must compare sketches of the same moltype." in str(exc)
+
+
+
+def test_FracMinHashComparison_incompatible_sketchtype(track_abundance):
+    a = MinHash(0, 31, scaled=1, track_abundance=track_abundance)
+    b = MinHash(10, 31, track_abundance=track_abundance)
+
+    a_values = { 1:5, 3:3, 5:2, 8:2}
+    b_values = { 1:3, 3:2, 5:1, 6:1, 8:1, 10:1 }
+
+    if track_abundance:
+        a.set_abundances(a_values)
+        b.set_abundances(b_values)
+    else:
+        a.add_many(a_values.keys())
+        b.add_many(b_values.keys())
+
+    with pytest.raises(TypeError) as exc:
+        FracMinHashComparison(a, b)
+    print(str(exc))
+    assert "Error: Both sketches must be 'num' or 'scaled'." in str(exc)
+
+
+def test_FracMinHashComparison_redownsample_without_scaled(track_abundance):
+    a = MinHash(0, 31, scaled=1, track_abundance=track_abundance)
+    b = MinHash(0, 31, scaled=10, track_abundance=track_abundance)
+
+    a_values = { 1:5, 3:3, 5:2, 8:2}
+    b_values = { 1:3, 3:2, 5:1, 6:1, 8:1, 10:1 }
+
+    if track_abundance:
+        a.set_abundances(a_values)
+        b.set_abundances(b_values)
+    else:
+        a.add_many(a_values.keys())
+        b.add_many(b_values.keys())
+
+    cmp = FracMinHashComparison(a, b)
+    assert cmp.cmp_scaled == 10
+
+    with pytest.raises(ValueError) as exc:
+        # try to redownsample without passing in cmp_num
+        cmp.downsample_and_handle_ignore_abundance()
+    print(str(exc))
+    assert "Error: must pass in a comparison scaled or num value." in str(exc)
+
+
 def test_NumMinHashComparison(track_abundance):
     # build FracMinHash Comparison and check values 
     a = MinHash(10, 21, scaled=0, track_abundance=track_abundance)
@@ -310,6 +395,7 @@ def test_NumMinHashComparison_downsample(track_abundance):
         print(str(exc))
         assert "Error: Angular (cosine) similarity requires both sketches to track hash abundance." in str(exc)
 
+
 def test_NumMinHashComparison_autodownsample(track_abundance):
     # build FracMinHash Comparison and check values 
     a = MinHash(10, 21, scaled=0, track_abundance=track_abundance)
@@ -353,4 +439,87 @@ def test_NumMinHashComparison_autodownsample(track_abundance):
             cmp.cosine_similarity
         print(str(exc))
         assert "Error: Angular (cosine) similarity requires both sketches to track hash abundance." in str(exc)
-    
+
+
+def test_NumMinHashComparison_incompatible_ksize(track_abundance):
+    a_num = MinHash(20, 31, track_abundance=track_abundance)
+    b_num = MinHash(10, 21, track_abundance=track_abundance)
+
+    a_values = { 1:5, 3:3, 5:2, 8:2}
+    b_values = { 1:3, 3:2, 5:1, 6:1, 8:1, 10:1 }
+
+    if track_abundance:
+        a_num.set_abundances(a_values)
+        b_num.set_abundances(b_values)
+    else:
+        a_num.add_many(a_values.keys())
+        b_num.add_many(b_values.keys())
+
+    # build NumMinHashComparison
+    with pytest.raises(TypeError) as exc:
+        NumMinHashComparison(a_num, b_num)
+    print(str(exc))
+    assert "Error: Invalid Comparison, ksizes: 31, 21. Must compare sketches of the same ksize." in str(exc)
+
+
+def test_NumMinHashComparison_incompatible_moltype(track_abundance):
+    a_num = MinHash(20, 31, track_abundance=track_abundance)
+    b_num = MinHash(10, 31, is_protein=True, track_abundance=track_abundance)
+
+    a_values = { 1:5, 3:3, 5:2, 8:2}
+    b_values = { 1:3, 3:2, 5:1, 6:1, 8:1, 10:1 }
+
+    if track_abundance:
+        a_num.set_abundances(a_values)
+        b_num.set_abundances(b_values)
+    else:
+        a_num.add_many(a_values.keys())
+        b_num.add_many(b_values.keys())
+
+    with pytest.raises(TypeError) as exc:
+        NumMinHashComparison(a_num, b_num)
+    print(str(exc))
+    assert "Error: Invalid Comparison, moltypes: DNA, protein. Must compare sketches of the same moltype." in str(exc)
+
+
+def test_NumMinHashComparison_incompatible_sketchtype(track_abundance):
+    a = MinHash(0, 31, scaled=1, track_abundance=track_abundance)
+    b = MinHash(10, 31, track_abundance=track_abundance)
+
+    a_values = { 1:5, 3:3, 5:2, 8:2}
+    b_values = { 1:3, 3:2, 5:1, 6:1, 8:1, 10:1 }
+
+    if track_abundance:
+        a.set_abundances(a_values)
+        b.set_abundances(b_values)
+    else:
+        a.add_many(a_values.keys())
+        b.add_many(b_values.keys())
+
+    with pytest.raises(TypeError) as exc:
+        NumMinHashComparison(a, b)
+    print(str(exc))
+    assert "Error: Both sketches must be 'num' or 'scaled'." in str(exc)
+
+
+def test_NumMinHashComparison_redownsample_without_num(track_abundance):
+    a = MinHash(10, 31, track_abundance=track_abundance)
+    b = MinHash(5, 31, track_abundance=track_abundance)
+
+    a_values = { 1:5, 3:3, 5:2, 8:2}
+    b_values = { 1:3, 3:2, 5:1, 6:1, 8:1, 10:1 }
+
+    if track_abundance:
+        a.set_abundances(a_values)
+        b.set_abundances(b_values)
+    else:
+        a.add_many(a_values.keys())
+        b.add_many(b_values.keys())
+
+    cmp = NumMinHashComparison(a, b)
+
+    with pytest.raises(ValueError) as exc:
+        # try to redownsample without passing in cmp_num
+        cmp.downsample_and_handle_ignore_abundance()
+    print(str(exc))
+    assert "Error: must pass in a comparison scaled or num value." in str(exc)

--- a/tests/test_sketchcomparison.py
+++ b/tests/test_sketchcomparison.py
@@ -47,8 +47,10 @@ def test_FracMinHashComparison(track_abundance):
     if track_abundance:
         assert cmp.angular_similarity == a.angular_similarity(b) == b.angular_similarity(a)
         assert cmp.cosine_similarity == a.angular_similarity(b) == b.angular_similarity(a)
-        assert cmp.mh1_weighted_intersection == intersect_mh.inflate(a)
-        assert cmp.mh2_weighted_intersection == intersect_mh.inflate(b)
+        assert cmp.weighted_intersection(from_mh=cmp.mh1).hashes == intersect_mh.inflate(a).hashes
+        assert cmp.weighted_intersection(from_mh=cmp.mh2).hashes == intersect_mh.inflate(b).hashes
+        assert cmp.weighted_intersection(from_abundD=a_values).hashes == intersect_mh.inflate(a).hashes
+        assert cmp.weighted_intersection(from_abundD=b_values).hashes == intersect_mh.inflate(b).hashes
     else:
         with pytest.raises(TypeError) as exc:
             cmp.angular_similarity
@@ -58,8 +60,8 @@ def test_FracMinHashComparison(track_abundance):
             cmp.cosine_similarity
         print(str(exc))
         assert "Error: Angular (cosine) similarity requires both sketches to track hash abundance." in str(exc)
-        assert cmp.mh1_weighted_intersection == intersect_mh
-        assert cmp.mh2_weighted_intersection == intersect_mh
+        assert cmp.weighted_intersection(from_mh=cmp.mh1).hashes == intersect_mh.hashes
+        assert cmp.weighted_intersection(from_mh=cmp.mh2).hashes == intersect_mh.hashes
     
 
 def test_FracMinHashComparison_downsample(track_abundance):
@@ -103,9 +105,10 @@ def test_FracMinHashComparison_downsample(track_abundance):
     if track_abundance:
         assert cmp.angular_similarity == ds_a.angular_similarity(ds_b) == ds_b.angular_similarity(ds_a)
         assert cmp.cosine_similarity == ds_a.angular_similarity(ds_b) == ds_b.angular_similarity(ds_a)
-        # current functionality inflates by original minhash -- is that what we want??
-        assert cmp.mh1_weighted_intersection == intersect_mh.inflate(a)
-        assert cmp.mh2_weighted_intersection == intersect_mh.inflate(b)
+        assert cmp.weighted_intersection(from_mh=cmp.mh1_cmp).hashes == intersect_mh.inflate(ds_a).hashes
+        assert cmp.weighted_intersection(from_mh=cmp.mh2_cmp).hashes == intersect_mh.inflate(ds_b).hashes
+        assert cmp.weighted_intersection(from_abundD=cmp.mh1_cmp.hashes).hashes == intersect_mh.inflate(ds_a).hashes
+        assert cmp.weighted_intersection(from_abundD=cmp.mh2_cmp.hashes).hashes == intersect_mh.inflate(ds_b).hashes
     else:
         with pytest.raises(TypeError) as exc:
             cmp.angular_similarity
@@ -115,8 +118,8 @@ def test_FracMinHashComparison_downsample(track_abundance):
             cmp.cosine_similarity
         print(str(exc))
         assert "Error: Angular (cosine) similarity requires both sketches to track hash abundance." in str(exc)
-        assert cmp.mh1_weighted_intersection == intersect_mh
-        assert cmp.mh2_weighted_intersection == intersect_mh
+        assert cmp.weighted_intersection(from_mh=cmp.mh1_cmp).hashes == intersect_mh.hashes
+        assert cmp.weighted_intersection(from_mh=cmp.mh2_cmp).hashes == intersect_mh.hashes
 
 
 def test_FracMinHashComparison_autodownsample(track_abundance):
@@ -160,9 +163,10 @@ def test_FracMinHashComparison_autodownsample(track_abundance):
     if track_abundance:
         assert cmp.angular_similarity == ds_a.angular_similarity(ds_b) == ds_b.angular_similarity(ds_a)
         assert cmp.cosine_similarity == ds_a.angular_similarity(ds_b) == ds_b.angular_similarity(ds_a)
-        # current functionality inflates by original minhash -- is that what we want??
-        assert cmp.mh1_weighted_intersection == intersect_mh.inflate(a)
-        assert cmp.mh2_weighted_intersection == intersect_mh.inflate(b)
+        assert cmp.weighted_intersection(from_mh=cmp.mh1_cmp).hashes == intersect_mh.inflate(ds_a).hashes
+        assert cmp.weighted_intersection(from_mh=cmp.mh2_cmp).hashes == intersect_mh.inflate(ds_b).hashes
+        assert cmp.weighted_intersection(from_abundD=a_values).hashes == intersect_mh.inflate(a).hashes
+        assert cmp.weighted_intersection(from_abundD=b_values).hashes == intersect_mh.inflate(b).hashes
     else:
         with pytest.raises(TypeError) as exc:
             cmp.angular_similarity
@@ -172,16 +176,18 @@ def test_FracMinHashComparison_autodownsample(track_abundance):
             cmp.cosine_similarity
         print(str(exc))
         assert "Error: Angular (cosine) similarity requires both sketches to track hash abundance." in str(exc)
-        assert cmp.mh1_weighted_intersection == intersect_mh
-        assert cmp.mh2_weighted_intersection == intersect_mh
+        assert cmp.weighted_intersection(from_mh=cmp.mh1_cmp).hashes == intersect_mh.hashes
+        assert cmp.weighted_intersection(from_mh=cmp.mh2_cmp).hashes == intersect_mh.hashes
+
 
 def test_FracMinHashComparison_ignore_abundance(track_abundance):
-    # build FracMinHash Comparison and check values 
+    # build FracMinHash Comparison and check values
     a = MinHash(0, 21, scaled=1, track_abundance=track_abundance)
     b = MinHash(0, 21, scaled=1, track_abundance=track_abundance)
 
     a_values = { 1:5, 3:3, 5:2, 8:2}
     b_values = { 1:3, 3:2, 5:1, 6:1, 8:1, 10:1 }
+    intersection_w_abund = {1:8, 3:5, 5:3, 8:3}
     
     if track_abundance:
         a.set_abundances(a_values)
@@ -220,8 +226,48 @@ def test_FracMinHashComparison_ignore_abundance(track_abundance):
         cmp.cosine_similarity
     print(str(exc))
     assert "Error: Angular (cosine) similarity requires both sketches to track hash abundance." in str(exc)
-    assert cmp.mh1_weighted_intersection == intersect_mh
-    assert cmp.mh2_weighted_intersection == intersect_mh
+    assert not cmp.mh1_cmp.track_abundance
+    assert not cmp.mh2_cmp.track_abundance
+    assert cmp.weighted_intersection(from_mh=cmp.mh1_cmp).hashes == intersect_mh.hashes
+    assert cmp.weighted_intersection(from_mh=cmp.mh2_cmp).hashes == intersect_mh.hashes
+
+
+def test_FracMinHashComparison_fail_threshold(track_abundance):
+    # build FracMinHash Comparison and check values 
+    a = MinHash(0, 21, scaled=1, track_abundance=track_abundance)
+    b = MinHash(0, 21, scaled=1, track_abundance=track_abundance)
+
+    a_values = { 1:5, 3:3, 5:2, 8:2}
+    b_values = { 1:3, 3:2, 5:1, 6:1, 8:1, 10:1 }
+
+    if track_abundance:
+        a.set_abundances(a_values)
+        b.set_abundances(b_values)
+    else:
+        a.add_many(a_values.keys())
+        b.add_many(b_values.keys())
+
+    cmp_scaled = 2
+    ds_a = a.flatten().downsample(scaled=cmp_scaled)
+    ds_b = b.flatten().downsample(scaled=cmp_scaled)
+
+    # build FracMinHashComparison
+    cmp = FracMinHashComparison(a, b, cmp_scaled = cmp_scaled, threshold_bp=10)
+    assert cmp.mh1 == a
+    assert cmp.mh2 == b
+    assert cmp.ignore_abundance == False
+    assert cmp.cmp_scaled == cmp_scaled
+    assert cmp.ksize == 21
+    assert cmp.moltype == "DNA"
+    assert cmp.mh1_containment == a.contained_by(b)
+    assert cmp.mh2_containment == b.contained_by(a)
+    assert cmp.avg_containment == np.mean([a.contained_by(b), b.contained_by(a)])
+    assert cmp.max_containment == a.max_containment(b)
+    assert cmp.jaccard == a.jaccard(b) == b.jaccard(a)
+    intersect_mh = ds_a.flatten().intersection(ds_b.flatten())
+    assert cmp.intersect_mh == intersect_mh == ds_b.flatten().intersection(ds_a.flatten())
+    assert cmp.intersect_bp == 8
+    assert not cmp.pass_threshold # threshold is 10; this should fail
 
 
 def test_FracMinHashComparison_incompatible_ksize(track_abundance):

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -1828,6 +1828,7 @@ def test_search_metagenome_traverse_check_csv(runtmp):
         prefix_len = len(testdata_dir)
         r = csv.DictReader(fp)
         for row in r:
+            print(row)
             filename = row['filename']
             assert filename.startswith(testdata_dir), filename
             # should have full path to file sig was loaded from


### PR DESCRIPTION
This PR replaces `SearchResult`, `PrefetchResult`, `GatherResult` namedtuples with dataclasses, maintaining current csv output. It's now possible to calculate attributes for each result directly within the dataclass. I've tried to replace external computing with this, but there is certainly more optimization that can be done.

 To facilitate these comparison calculations, this PR also introduces `MinHashComparison` dataclasses, (`BaseMinHashComparison`, `FracMinHashComparison`, and `NumMinHashComparison`) which contain properties for all the comparisons we'd like to build when comparing two minhashes, including automatically downsampling to the lower resolution sketch for comparison.

It would be great to think about and/or standardize column output a bit more, ref https://github.com/sourmash-bio/sourmash/issues/1555, https://github.com/sourmash-bio/sourmash/issues/1737, but at least now the output is only specified in a single spot, so it should be easier to change. Columns can be easily added to the written output for each class by adding to the `*write_cols` list in the class.

**related:**
- https://github.com/sourmash-bio/sourmash/issues/1555
- https://github.com/sourmash-bio/sourmash/issues/1737.

**motivation**: I need to add several columns (and calculations) for ANI estimation, and namedtuples were getting repetitive and unruly.

**benefit:** Many of the params we're passing into our search results are calculated from the two sketches. We can automate this within the dataclass to avoid needing to write out the calculation each time.
