### PR TITLE
[MRG] remove unnecessary downsampling warnings

### DIFF
--- a/src/sourmash/commands.py
+++ b/src/sourmash/commands.py
@@ -648,7 +648,7 @@ def gather(args):
         error('query signature needs to be created with --scaled')
         sys.exit(-1)
 
-    if args.scaled:
+    if args.scaled and args.scaled != query.minhash.scaled:
         notify(f'downsampling query from scaled={query.minhash.scaled} to {int(args.scaled)}')
         query.minhash = query.minhash.downsample(scaled=args.scaled)
 
@@ -880,7 +880,7 @@ def multigather(args):
                 error('query signature needs to be created with --scaled; skipping')
                 continue
 
-            if args.scaled:
+            if args.scaled and args.scaled != query.minhash.scaled:
                 notify(f'downsampling query from scaled={query.minhash.scaled} to {int(args.scaled)}')
                 query.minhash = query.minhash.downsample(scaled=args.scaled)
 
@@ -1143,7 +1143,7 @@ def prefetch(args):
     if query_mh.track_abundance:
         query_mh = query_mh.flatten()
 
-    if args.scaled:
+    if args.scaled and args.scaled != query_mh.scaled:
         notify(f'downsampling query from scaled={query_mh.scaled} to {int(args.scaled)}')
         query_mh = query_mh.downsample(scaled=args.scaled)
 


### PR DESCRIPTION
Addresses the (unnecessary) warnings output in https://github.com/sourmash-bio/sourmash/issues/1970#issuecomment-1106319548; removes this output,
```
downsampling query from 1 to 1
```
when the numbers are equal.