### PR TITLE
Fix build/CI and unused imports papercuts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,12 +3,16 @@ updates:
 - package-ecosystem: pip
   directory: "/"
   schedule:
-    interval: daily
-    time: "13:00"
+    interval: weekly
   open-pull-requests-limit: 10
 - package-ecosystem: cargo
   directory: "/"
   schedule:
-    interval: daily
-    time: "13:00"
+    interval: weekly
+  allow:
+    - dependency-type: "direct"
   open-pull-requests-limit: 10
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: weekly

--- a/src/sourmash/search.py
+++ b/src/sourmash/search.py
@@ -3,8 +3,6 @@ Code for searching collections of signatures.
 """
 from collections import namedtuple
 from enum import Enum
-from multiprocessing.sharedctypes import Value
-from re import I
 import numpy as np
 from dataclasses import dataclass
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -2,7 +2,6 @@
 
 # CTB TODO: test search protocol with mock class?
 
-from pyparsing import original_text_for
 import pytest
 import sourmash_tst_utils as utils
 

--- a/tox.ini
+++ b/tox.ini
@@ -121,6 +121,15 @@ extras =
 commands = pip wheel -w {envtmpdir}/build --no-deps .
            twine check {envtmpdir}/build/*
 
+[testenv:mypy]
+description = run mypy checker
+basepython = python3.8
+passenv = {[testenv]passenv}
+          # without PROGRAMDATA cloning using git for Windows will fail with an `error setting certificate verify locations` error
+          PROGRAMDATA
+deps  = mypy
+commands = mypy src/sourmash
+
 [testenv:fix_lint]
 description = format the code base to adhere to our styles, and complain about what we cannot do automatically
 basepython = python3.8


### PR DESCRIPTION
- remove unused imports in `src/sourmash/search.py`
- add a `mypy` check task to `tox` (still need to be executed explicitly)
- set up dependabot for python, rust and gh action updates