### PR TITLE
[MRG] do not report untrusted jaccard ANI

### DIFF
--- a/src/sourmash/distance_utils.py
+++ b/src/sourmash/distance_utils.py
@@ -62,6 +62,7 @@ class jaccardANIResult(ANIResult):
     """Class for distance/ANI from jaccard (includes jaccard_error)."""
     jaccard_error: float = None
     je_threshold: float = 1e-4
+    return_ani_despite_threshold: bool = False
 
     def __post_init__(self):
         # check values
@@ -71,6 +72,13 @@ class jaccardANIResult(ANIResult):
             self.jaccard_error, self.je_exceeds_threshold = check_jaccard_error(self.jaccard_error, self.je_threshold)
         else:
             raise ValueError("Error: jaccard_error cannot be None.")
+
+    @property
+    def ani(self):
+        # if jaccard error is too high (exceeds threshold), do not trust ANI estimate
+        if self.je_exceeds_threshold and not self.return_ani_despite_threshold:
+            return "" # or 0?
+        return 1 - self.dist
 
 
 @dataclass

--- a/src/sourmash/distance_utils.py
+++ b/src/sourmash/distance_utils.py
@@ -77,7 +77,7 @@ class jaccardANIResult(ANIResult):
     def ani(self):
         # if jaccard error is too high (exceeds threshold), do not trust ANI estimate
         if self.je_exceeds_threshold and not self.return_ani_despite_threshold:
-            return "" # or 0?
+            return ""
         return 1 - self.dist
 
 

--- a/src/sourmash/search.py
+++ b/src/sourmash/search.py
@@ -321,9 +321,9 @@ class SearchResult(BaseResult):
         elif self.searchtype == SearchType.JACCARD:
             self.cmp.estimate_jaccard_ani(jaccard=self.similarity)
             self.ani = self.cmp.jaccard_ani
-            # Jaccard error was too high for ANI estimation.
-            # Just report, or do we want to do something else?
-            self.ani_untrustworthy = self.cmp.jaccard_ani_untrustworthy
+            # if jaccard ANI is untrustworthy, do not return ANI
+            if self.cmp.jaccard_ani_untrustworthy:
+                self.ani = ""
         # this can be set from any of the above
         self.potential_false_negative = self.cmp.potential_false_negative
 

--- a/src/sourmash/search.py
+++ b/src/sourmash/search.py
@@ -321,9 +321,6 @@ class SearchResult(BaseResult):
         elif self.searchtype == SearchType.JACCARD:
             self.cmp.estimate_jaccard_ani(jaccard=self.similarity)
             self.ani = self.cmp.jaccard_ani
-            # if jaccard ANI is untrustworthy, do not return ANI
-            if self.cmp.jaccard_ani_untrustworthy:
-                self.ani = ""
         # this can be set from any of the above
         self.potential_false_negative = self.cmp.potential_false_negative
 

--- a/tests/test_distance_utils.py
+++ b/tests/test_distance_utils.py
@@ -34,15 +34,18 @@ def test_aniresult_bad_distance():
 
 
 def test_jaccard_aniresult():
-    res = jaccardANIResult(0.4, 0.1, jaccard_error=0.03)
-    assert res.dist == 0.4
+    res = jaccardANIResult(0.4, 0.1, jaccard_error=0.03, return_ani_despite_threshold=True)
+    res2 = jaccardANIResult(0.4, 0.1, jaccard_error=0.03)
+    assert res.dist == res2.dist == 0.4
     assert res.ani == 0.6
-    assert res.p_nothing_in_common == 0.1
+    assert res2.ani == ""
+    assert res.p_nothing_in_common == res2.p_nothing_in_common == 0.1
     assert res.jaccard_error == 0.03
     assert res.p_exceeds_threshold ==True
     assert res.je_exceeds_threshold ==True
-    res2 = jaccardANIResult(0.4, 0.1, jaccard_error=0.03, je_threshold=0.1)
-    assert res2.je_exceeds_threshold ==False
+    res3 = jaccardANIResult(0.4, 0.1, jaccard_error=0.03, je_threshold=0.1)
+    assert res3.je_exceeds_threshold ==False
+    assert res3.ani == 0.6
 
 
 def test_jaccard_aniresult_nojaccarderror():
@@ -260,8 +263,8 @@ def test_jaccard_to_distance_scaled():
     res = jaccard_to_distance(jaccard,ksize,scaled,n_unique_kmers=nkmers)
     print(res)
     # check results
-    assert res.dist == 0.019122659390482077
-    assert res.ani == 0.9808773406095179
+    assert round(res.dist, 3) == round(0.019122659390482077, 3)
+    assert res.ani == ""
     assert res.p_exceeds_threshold == False
     assert res.jaccard_error == 0.00018351337045518042
     assert res.je_exceeds_threshold ==True
@@ -282,12 +285,12 @@ def test_jaccard_to_distance_k31():
     res = jaccard_to_distance(jaccard,ksize,scaled,n_unique_kmers=nkmers)
     print(res)
     # check results
-    assert res.ani == 0.9870056455892898
-    assert res.p_exceeds_threshold == False
     assert res.je_exceeds_threshold ==True
+    assert res.ani == ""
+    assert res.p_exceeds_threshold == False
     res2 = jaccard_to_distance(jaccard,ksize,scaled,n_unique_kmers=nkmers, err_threshold=0.1)
-    assert res2.ani == res.ani
     assert res2.je_exceeds_threshold == False
+    assert res2.ani == 0.9870056455892898
 
 
 def test_jaccard_to_distance_k31_2():

--- a/tests/test_minhash.py
+++ b/tests/test_minhash.py
@@ -2914,6 +2914,20 @@ def test_jaccard_ANI():
     assert (m1_jani_m2.ani, m1_jani_m2.p_nothing_in_common, m1_jani_m2.jaccard_error) == (0.9783711630110239, 0.0, 3.891666770716877e-07)
 
 
+def test_jaccard_ANI_untrustworthy():
+    f1 = utils.get_test_data('2.fa.sig')
+    f2 = utils.get_test_data('2+63.fa.sig')
+    mh1 = sourmash.load_one_signature(f1, ksize=31).minhash
+    mh2 = sourmash.load_one_signature(f2).minhash
+
+    print("\nJACCARD_ANI", mh1.jaccard_ani(mh2))
+
+    m1_jani_m2 = mh1.jaccard_ani(mh2, err_threshold=1e-7)
+    assert m1_jani_m2.ani == ""
+    assert m1_jani_m2.je_exceeds_threshold==True
+    assert m1_jani_m2.je_threshold == 1e-7
+
+
 def test_jaccard_ANI_precalc_jaccard():
     f1 = utils.get_test_data('2.fa.sig')
     f2 = utils.get_test_data('2+63.fa.sig')

--- a/tests/test_signature.py
+++ b/tests/test_signature.py
@@ -513,6 +513,20 @@ def test_jaccard_ANI():
     assert (s1_jani_s2.ani, s1_jani_s2.p_nothing_in_common, s1_jani_s2.jaccard_error) == (0.9783711630110239, 0.0, 3.891666770716877e-07)
 
 
+def test_jaccard_ANI_untrustworthy():
+    f1 = utils.get_test_data('2.fa.sig')
+    f2 = utils.get_test_data('2+63.fa.sig')
+    ss1 = sourmash.load_one_signature(f1, ksize=31)
+    ss2 = sourmash.load_one_signature(f2)
+
+    print("\nJACCARD_ANI", ss1.jaccard_ani(ss2))
+
+    s1_jani_s2 = ss1.jaccard_ani(ss2, err_threshold=1e-7)
+    assert s1_jani_s2.ani == ""
+    assert s1_jani_s2.je_exceeds_threshold==True
+    assert s1_jani_s2.je_threshold == 1e-7
+
+
 def test_jaccard_ANI_precalc_jaccard():
     f1 = utils.get_test_data('2.fa.sig')
     f2 = utils.get_test_data('2+63.fa.sig')


### PR DESCRIPTION
fixes #2004 

This PR modifies `jaccardANIResult` to only return an ANI value when the jaccard error does not exceed the recommended threshold. This means that ANI will not be returned to any jaccard ANI function (minhash, signature, compare, search, etc) if it is not trusted.

I haven't enabled forcibly returning ANI in `minhash` or `signature` because I still return the `distance` (so if you really want the untrustworthy ANI anyway, you can just do `1-distance`).