### PR TITLE
[MRG] prevent ANI estimation when sketch size estimate may be inaccurate

### DIFF
--- a/src/sourmash/compare.py
+++ b/src/sourmash/compare.py
@@ -35,7 +35,10 @@ def compare_serial(siglist, ignore_abundance, *, downsample=False, return_ani=Fa
 
     for i, j in iterator:
         if return_ani:
-            similarities[i][j] = similarities[j][i] = siglist[i].jaccard_ani(siglist[j],downsample=downsample).ani
+            ani = siglist[i].jaccard_ani(siglist[j],downsample=downsample).ani
+            if ani == None:
+                ani = 0.0
+            similarities[i][j] = similarities[j][i] = ani
         else:
             similarities[i][j] = similarities[j][i] = siglist[i].similarity(siglist[j], ignore_abundance=ignore_abundance, downsample=downsample)
 
@@ -58,9 +61,13 @@ def compare_serial_containment(siglist, *, downsample=False, return_ani=False):
     containments = np.ones((n, n))
     for i in range(n):
         for j in range(n):
-            if return_ani:
-                containments[i][j] = siglist[j].containment_ani(siglist[i],
-                                                                downsample=downsample).ani
+            if i == j:
+                containments[i][j] = 1
+            elif return_ani:
+                ani = siglist[j].containment_ani(siglist[i], downsample=downsample).ani
+                if ani == None:
+                    ani = 0.0
+                containments[i][j] = ani
             else:
                 containments[i][j] = siglist[j].contained_by(siglist[i],
                                                          downsample=downsample)
@@ -81,15 +88,20 @@ def compare_serial_max_containment(siglist, *, downsample=False, return_ani=Fals
 
     n = len(siglist)
 
+    # Combinations makes all unique sets of pairs, e.g. (A, B) but not (B, A)
+    iterator = itertools.combinations(range(n), 2)
+
     containments = np.ones((n, n))
-    for i in range(n):
-        for j in range(n):
-            if return_ani:
-                containments[i][j] = siglist[j].max_containment_ani(siglist[i],
-                                                             downsample=downsample).ani
-            else:
-                containments[i][j] = siglist[j].max_containment(siglist[i],
-                                                         downsample=downsample)
+
+    for i, j in iterator:
+        if return_ani:
+            ani = siglist[j].max_containment_ani(siglist[i], downsample=downsample).ani
+            if ani == None:
+                ani = 0.0
+            containments[i][j] = containments[j][i] = ani
+        else:
+            containments[i][j] = containments[j][i] = siglist[j].max_containment(siglist[i],
+                                                        downsample=downsample)
 
     return containments
 
@@ -99,7 +111,10 @@ def similarity_args_unpack(args, ignore_abundance, *, downsample, return_ani=Fal
     as it can only be given one argument."""
     sig1, sig2 = args
     if return_ani:
-        return sig1.jaccard_ani(sig2, downsample=downsample).ani
+        ani = sig1.jaccard_ani(sig2, downsample=downsample).ani
+        if ani == None:
+            ani = 0.0
+        return ani
     else:
         return sig1.similarity(sig2,
                            ignore_abundance=ignore_abundance,

--- a/src/sourmash/distance_utils.py
+++ b/src/sourmash/distance_utils.py
@@ -56,8 +56,8 @@ class ANIResult:
     @property
     def ani(self):
         if self.size_is_inaccurate:
-            notify("WARNING: Cannot estimate ANI because size estimation for these sketches is inaccurate.")
-            return 0
+            notify("WARNING: Cannot estimate ANI because size estimation for at least one of these sketches may be inaccurate.")
+            return None
         return 1 - self.dist
 
 
@@ -81,10 +81,10 @@ class jaccardANIResult(ANIResult):
         # if jaccard error is too high (exceeds threshold), do not trust ANI estimate
         if self.je_exceeds_threshold or self.size_is_inaccurate:
             if self.size_is_inaccurate:
-                notify("WARNING: Cannot estimate ANI because size estimation for at least one of these sketches is inaccurate.")
+                notify("WARNING: Cannot estimate ANI because size estimation for at least one of these sketches may be inaccurate.")
             if self.je_exceeds_threshold:
                 notify("WARNING: Cannot estimate ANI because jaccard estimation for these sketches is inaccurate.")
-            return 0
+            return None
         return 1 - self.dist
 
 
@@ -236,8 +236,10 @@ def containment_to_distance(
     sol1, sol2, point_estimate = None, None, None
     n_unique_kmers = handle_seqlen_nkmers(ksize, sequence_len_bp = sequence_len_bp, n_unique_kmers=n_unique_kmers)
     if containment <= 0.0001:
+#        point_estimate = 1.0
         point_estimate = sol1 = sol2 = 1.0
     elif containment >= 0.9999:
+        #point_estimate = 0.0
         point_estimate = sol1 = sol2 = 0.0
     else:
         point_estimate = 1.0 - containment ** (1.0 / ksize)

--- a/src/sourmash/distance_utils.py
+++ b/src/sourmash/distance_utils.py
@@ -236,9 +236,9 @@ def containment_to_distance(
     sol1, sol2, point_estimate = None, None, None
     n_unique_kmers = handle_seqlen_nkmers(ksize, sequence_len_bp = sequence_len_bp, n_unique_kmers=n_unique_kmers)
     if containment <= 0.0001:
-        point_estimate = 1.0
+        point_estimate = sol1 = sol2 = 1.0
     elif containment >= 0.9999:
-        point_estimate = 0.0
+        point_estimate = sol1 = sol2 = 0.0
     else:
         point_estimate = 1.0 - containment ** (1.0 / ksize)
         if estimate_ci:

--- a/src/sourmash/minhash.py
+++ b/src/sourmash/minhash.py
@@ -669,6 +669,9 @@ class MinHash(RustObject):
                                           n_unique_kmers=avg_n_kmers,
                                           prob_threshold = prob_threshold,
                                           err_threshold = err_threshold)
+        # zero out ANI if either mh size estimation is inaccurate
+        if not (self.size_is_accurate() and other.size_is_accurate()):
+            j_aniresult.size_is_inaccurate =True
         return j_aniresult
 
     def similarity(self, other, ignore_abundance=False, downsample=False):
@@ -728,6 +731,9 @@ class MinHash(RustObject):
         c_aniresult = containment_to_distance(containment, self_mh.ksize, self_mh.scaled,
                                                         n_unique_kmers=n_kmers, confidence=confidence,
                                                         estimate_ci = estimate_ci)
+        # zero out ANI if either mh size estimation is inaccurate
+        if not (self.size_is_accurate() and other.size_is_accurate()):
+            c_aniresult.size_is_inaccurate = True
         return c_aniresult
 
 
@@ -762,6 +768,9 @@ class MinHash(RustObject):
         c_aniresult = containment_to_distance(max_containment, self_mh.ksize, scaled,
                                            n_unique_kmers=n_kmers,confidence=confidence,
                                            estimate_ci = estimate_ci)
+        # zero out ANI if either mh size estimation is inaccurate
+        if not (self.size_is_accurate() and other.size_is_accurate()):
+            c_aniresult.size_is_inaccurate = True
         return c_aniresult
 
     def avg_containment(self, other, *, downsample=False):
@@ -934,7 +943,7 @@ class MinHash(RustObject):
         if any([not (0 <= relative_error <= 1), not (0 <= confidence <= 1)]):
             raise ValueError("Error: relative error and confidence values must be between 0 and 1.")
         
-        # TODO: replace len(self.hashes) with HLL estimate when that gets implemented
+        # TODO: replace set_size with HLL estimate when that gets implemented
         set_size = len(self.hashes) * self.scaled
         probability = set_size_chernoff(set_size, self.scaled, relative_error=relative_error)
         return probability >= confidence

--- a/src/sourmash/minhash.py
+++ b/src/sourmash/minhash.py
@@ -6,7 +6,7 @@ class MinHash - core MinHash class.
 class FrozenMinHash - read-only MinHash class.
 """
 from __future__ import unicode_literals, division
-from .distance_utils import jaccard_to_distance, containment_to_distance
+from .distance_utils import jaccard_to_distance, containment_to_distance, set_size_chernoff
 
 import numpy as np
 
@@ -922,7 +922,23 @@ class MinHash(RustObject):
         if not self.scaled:
             raise TypeError("can only calculate bp for scaled MinHashes")
         return len(self.hashes) * self.scaled
+
+    def size_is_accurate(self, relative_error=0.05, confidence=0.95):
+        """
+        Computes the probability that the estimate: sketch_size * scaled deviates from the true
+        set_size by more than relative_error. This relies on the fact that the sketch_size
+        is binomially distributed with parameters sketch_size and 1/scaled. The two-sided Chernoff
+        bounds are used.
+        Returns True if probability is greater than or equal to the desired confidence.
+        """
+        if any([not (0 <= relative_error <= 1), not (0 <= confidence <= 1)]):
+            raise ValueError("Error: relative error and confidence values must be between 0 and 1.")
         
+        # TODO: replace len(self.hashes) with HLL estimate when that gets implemented
+        set_size = len(self.hashes) * self.scaled
+        probability = set_size_chernoff(set_size, self.scaled, relative_error=relative_error)
+        return probability >= confidence
+
 
 class FrozenMinHash(MinHash):
     def add_sequence(self, *args, **kwargs):

--- a/src/sourmash/signature.py
+++ b/src/sourmash/signature.py
@@ -175,7 +175,7 @@ class SourmashSignature(RustObject):
         """
         return self.minhash.avg_containment(other.minhash, downsample=downsample)
 
-    def avg_containment_ani(self, other, *, downsample=False, max_containment=None, confidence=0.95, estimate_ci=False):
+    def avg_containment_ani(self, other, *, downsample=False):
         """
         Calculate average containment ANI.
         Note: this is average of the containment ANI's, *not* ANI using count_common/ avg_denom

--- a/src/sourmash/signature.py
+++ b/src/sourmash/signature.py
@@ -150,7 +150,7 @@ class SourmashSignature(RustObject):
 
     def contained_by(self, other, downsample=False):
         "Compute containment by the other signature. Note: ignores abundance."
-        return self.minhash.contained_by(other.minhash, downsample)
+        return self.minhash.contained_by(other.minhash, downsample=downsample)
 
     def containment_ani(self, other, *, downsample=False, containment=None, confidence=0.95, estimate_ci=False):
         "Use containment to estimate ANI between two FracMinHash signatures."
@@ -160,13 +160,27 @@ class SourmashSignature(RustObject):
 
     def max_containment(self, other, downsample=False):
         "Compute max containment w/other signature. Note: ignores abundance."
-        return self.minhash.max_containment(other.minhash, downsample)
+        return self.minhash.max_containment(other.minhash, downsample=downsample)
 
     def max_containment_ani(self, other, *, downsample=False, max_containment=None, confidence=0.95, estimate_ci=False):
         "Use max containment to estimate ANI between two FracMinHash signatures."
         return self.minhash.max_containment_ani(other.minhash, downsample=downsample,
                                                 max_containment=max_containment, confidence=confidence,
                                                 estimate_ci=estimate_ci)
+
+    def avg_containment(self, other, downsample=False):
+        """
+        Calculate average containment.
+        Note: this is average of the containments, *not* count_common/ avg_denom
+        """
+        return self.minhash.avg_containment(other.minhash, downsample=downsample)
+
+    def avg_containment_ani(self, other, *, downsample=False, max_containment=None, confidence=0.95, estimate_ci=False):
+        """
+        Calculate average containment ANI.
+        Note: this is average of the containment ANI's, *not* ANI using count_common/ avg_denom
+        """
+        return self.minhash.avg_containment_ani(other.minhash, downsample=downsample)
 
     def add_sequence(self, sequence, force=False):
         self._methodcall(lib.signature_add_sequence, to_bytes(sequence), force)

--- a/src/sourmash/sketchcomparison.py
+++ b/src/sourmash/sketchcomparison.py
@@ -6,7 +6,6 @@ from dataclasses import dataclass
 
 from .signature import MinHash
 
-
 @dataclass
 class BaseMinHashComparison:
     """Class for standard comparison between two MinHashes"""
@@ -89,6 +88,7 @@ class FracMinHashComparison(BaseMinHashComparison):
     threshold_bp: int = 0
     estimate_ani_ci: bool = False
     ani_confidence: float = 0.95
+#    pfn_threshold: float = 1e-3
 
     def __post_init__(self):
         "Initialize ScaledComparison using values from provided FracMinHashes"
@@ -116,6 +116,7 @@ class FracMinHashComparison(BaseMinHashComparison):
                                             containment=containment,
                                             confidence=self.ani_confidence,
                                             estimate_ci=self.estimate_ani_ci)
+#                                            prob_threshold=self.pfn_threshold)
         # propagate params
         self.mh1_containment_ani = m1_cani.ani
         if m1_cani.p_exceeds_threshold:
@@ -134,6 +135,7 @@ class FracMinHashComparison(BaseMinHashComparison):
                                             containment=containment,
                                             confidence=self.ani_confidence,
                                             estimate_ci=self.estimate_ani_ci)
+#                                            prob_threshold=self.pfn_threshold)
         self.mh2_containment_ani = m2_cani.ani
         if m2_cani.p_exceeds_threshold:
             self.potential_false_negative = True
@@ -150,6 +152,7 @@ class FracMinHashComparison(BaseMinHashComparison):
                                                 max_containment=max_containment,
                                                 confidence=self.ani_confidence,
                                                 estimate_ci=self.estimate_ani_ci)
+#                                                prob_threshold=self.pfn_threshold)
         # propagate params
         self.max_containment_ani = mc_ani_info.ani
         if mc_ani_info.p_exceeds_threshold:
@@ -171,7 +174,11 @@ class FracMinHashComparison(BaseMinHashComparison):
         "Estimate all containment ANI values."
         self.estimate_mh1_containment_ani()
         self.estimate_mh2_containment_ani()
-        self.max_containment_ani = max([self.mh1_containment_ani, self.mh2_containment_ani])
+        if any([self.mh1_containment_ani is None, self.mh2_containment_ani is None]):
+#            self.estimate_max_containment_ani()
+            self.max_containment_ani = None
+        else:
+            self.max_containment_ani = max([self.mh1_containment_ani, self.mh2_containment_ani])
 
     def weighted_intersection(self, from_mh=None, from_abundD={}):
          # map abundances to all intersection hashes.

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -25,9 +25,11 @@ def siglist():
 def scaled_siglist():
     demo_path = utils.get_test_data("scaled")
     filenames = sorted(glob.glob(os.path.join(demo_path, "*.sig")))
+    sigfiles = ["2.fa.sig", "2+63.fa.sig", "47.fa.sig", "63.fa.sig"]
+    filenames = [utils.get_test_data(c) for c in sigfiles]
     sigs = []
     for filename in filenames:
-        these_sigs = sourmash.load_file_as_signatures(filename)
+        these_sigs = sourmash.load_file_as_signatures(filename, ksize=31)
         scaled_sigs = [s for s in these_sigs if s.minhash.scaled != 0]
         sigs.extend(scaled_sigs)
     return sigs
@@ -76,13 +78,13 @@ def test_compare_all_pairs(siglist, ignore_abundance):
 
 def test_compare_serial_jaccardANI(scaled_siglist, ignore_abundance):
     jANI = compare_serial(scaled_siglist, ignore_abundance, downsample=False, return_ani=True)
-
+    print(jANI)
+    
     true_jaccard_ANI = np.array(
-        [[1., 0.942, 0.988, 0.986, 0.],
-        [0.942, 1., 0.960, 0., 0.],
-        [0.988, 0.960, 1., 0., 0.],
-        [0.986, 0., 0., 1., 0.],
-        [0., 0., 0., 0., 1.]])
+           [[1., 0., 0., 0.],
+           [0., 1., 0.96973012, 0.99262776],
+           [0., 0.96973012, 1., 0.97697011],
+           [0., 0.99262776, 0.97697011, 1.]])
 
     np.testing.assert_array_almost_equal(jANI, true_jaccard_ANI, decimal=3)
 
@@ -91,11 +93,10 @@ def test_compare_parallel_jaccardANI(scaled_siglist, ignore_abundance):
     jANI = compare_parallel(scaled_siglist, ignore_abundance, downsample=False, n_jobs=2, return_ani=True)
 
     true_jaccard_ANI = np.array(
-        [[1., 0.942, 0.988, 0.986, 0.],
-        [0.942, 1., 0.960, 0., 0.],
-        [0.988, 0.960, 1., 0., 0.],
-        [0.986, 0., 0., 1., 0.],
-        [0., 0., 0., 0., 1.]])
+           [[1., 0., 0., 0.],
+           [0., 1., 0.96973012, 0.99262776],
+           [0., 0.96973012, 1., 0.97697011],
+           [0., 0.99262776, 0.97697011, 1.]])
 
     np.testing.assert_array_almost_equal(jANI, true_jaccard_ANI, decimal=3)
 
@@ -108,24 +109,24 @@ def test_compare_all_pairs_jaccardANI(scaled_siglist, ignore_abundance):
 
 def test_compare_serial_containmentANI(scaled_siglist):
     containment_ANI = compare_serial_containment(scaled_siglist, return_ani=True)
+    print(containment_ANI)
 
     true_containment_ANI = np.array(
-        [[1., 1., 1., 1., 0.],
-        [0.92391599, 1., 0.94383993, 0., 0.],
-        [0.97889056, 1., 1., 0., 0.],
-        [0.97685474, 0., 0., 1., 0.],
-        [0., 0., 0., 0., 1.]])
+        [[0., 0., 0., 0.],
+        [0., 1., 0.97715525, 1.],
+        [0., 0.96377054, 1., 0.97678608],
+        [0., 0.98667513, 0.97715525, 1.]])
 
     np.testing.assert_array_almost_equal(containment_ANI, true_containment_ANI, decimal=3)
 
     # check max_containment ANI
     max_containment_ANI = compare_serial_max_containment(scaled_siglist, return_ani=True)
+    print(max_containment_ANI)
 
     true_max_containment_ANI = np.array(
-        [[1., 1., 1., 1., 0.],
-        [1., 1., 1., 0., 0.],
-        [1., 1., 1., 0., 0.],
-        [1., 0., 0., 1., 0.],
-        [0., 0., 0., 0., 1.,]])
+        [[0., 0., 0., 0.],
+        [0., 1., 0.97715525, 1.],
+        [0., 0.97715525, 1., 0.97715525],
+        [0., 1., 0.97715525, 1.]])
 
     np.testing.assert_array_almost_equal(max_containment_ANI, true_max_containment_ANI, decimal=3)

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -112,7 +112,7 @@ def test_compare_serial_containmentANI(scaled_siglist):
     print(containment_ANI)
 
     true_containment_ANI = np.array(
-        [[0., 0., 0., 0.],
+        [[1, 0., 0., 0.],
         [0., 1., 0.97715525, 1.],
         [0., 0.96377054, 1., 0.97678608],
         [0., 0.98667513, 0.97715525, 1.]])
@@ -124,7 +124,7 @@ def test_compare_serial_containmentANI(scaled_siglist):
     print(max_containment_ANI)
 
     true_max_containment_ANI = np.array(
-        [[0., 0., 0., 0.],
+        [[1., 0., 0., 0.],
         [0., 1., 0.97715525, 1.],
         [0., 0.97715525, 1., 0.97715525],
         [0., 1., 0.97715525, 1.]])

--- a/tests/test_distance_utils.py
+++ b/tests/test_distance_utils.py
@@ -36,12 +36,10 @@ def test_aniresult_bad_distance():
 
 
 def test_jaccard_aniresult():
-    res = jaccardANIResult(0.4, 0.1, jaccard_error=0.03, return_ani_despite_threshold=True)
-    res2 = jaccardANIResult(0.4, 0.1, jaccard_error=0.03)
-    assert res.dist == res2.dist == 0.4
-    assert res.ani == 0.6
-    assert res2.ani == ""
-    assert res.p_nothing_in_common == res2.p_nothing_in_common == 0.1
+    res = jaccardANIResult(0.4, 0.1, jaccard_error=0.03)
+    assert res.dist == 0.4
+    assert res.ani == 0
+    assert res.p_nothing_in_common == 0.1
     assert res.jaccard_error == 0.03
     assert res.p_exceeds_threshold ==True
     assert res.je_exceeds_threshold ==True
@@ -266,7 +264,7 @@ def test_jaccard_to_distance_scaled():
     print(res)
     # check results
     assert round(res.dist, 3) == round(0.019122659390482077, 3)
-    assert res.ani == ""
+    assert res.ani == 0
     assert res.p_exceeds_threshold == False
     assert res.jaccard_error == 0.00018351337045518042
     assert res.je_exceeds_threshold ==True
@@ -288,7 +286,7 @@ def test_jaccard_to_distance_k31():
     print(res)
     # check results
     assert res.je_exceeds_threshold ==True
-    assert res.ani == ""
+    assert res.ani == 0
     assert res.p_exceeds_threshold == False
     res2 = jaccard_to_distance(jaccard,ksize,scaled,n_unique_kmers=nkmers, err_threshold=0.1)
     assert res2.je_exceeds_threshold == False

--- a/tests/test_distance_utils.py
+++ b/tests/test_distance_utils.py
@@ -38,7 +38,7 @@ def test_aniresult_bad_distance():
 def test_jaccard_aniresult():
     res = jaccardANIResult(0.4, 0.1, jaccard_error=0.03)
     assert res.dist == 0.4
-    assert res.ani == 0
+    assert res.ani == None
     assert res.p_nothing_in_common == 0.1
     assert res.jaccard_error == 0.03
     assert res.p_exceeds_threshold ==True
@@ -264,7 +264,7 @@ def test_jaccard_to_distance_scaled():
     print(res)
     # check results
     assert round(res.dist, 3) == round(0.019122659390482077, 3)
-    assert res.ani == 0
+    assert res.ani == None
     assert res.p_exceeds_threshold == False
     assert res.jaccard_error == 0.00018351337045518042
     assert res.je_exceeds_threshold ==True
@@ -286,7 +286,7 @@ def test_jaccard_to_distance_k31():
     print(res)
     # check results
     assert res.je_exceeds_threshold ==True
-    assert res.ani == 0
+    assert res.ani == None
     assert res.p_exceeds_threshold == False
     res2 = jaccard_to_distance(jaccard,ksize,scaled,n_unique_kmers=nkmers, err_threshold=0.1)
     assert res2.je_exceeds_threshold == False

--- a/tests/test_distance_utils.py
+++ b/tests/test_distance_utils.py
@@ -78,8 +78,8 @@ def test_containment_to_distance_zero():
     res = containment_to_distance(contain,ksize,scaled, n_unique_kmers=nkmers, estimate_ci=True)
     print(res)
     # check results
-    exp_dist,exp_low,exp_high,pnc = 1.0,None,None,1.0
-    exp_id, exp_idlow,exp_idhigh,pnc = 0.0,None,None,1.0
+    exp_dist,exp_low,exp_high,pnc = 1.0,1.0,1.0,1.0
+    exp_id, exp_idlow,exp_idhigh,pnc = 0.0,0.0,0.0,1.0
     assert res.dist == exp_dist
     assert res.dist_low == exp_low
     assert res.dist_high == exp_high
@@ -90,7 +90,7 @@ def test_containment_to_distance_zero():
     # check without returning ci
     res2 = containment_to_distance(contain,ksize,scaled,n_unique_kmers=nkmers)
     print(res2)
-    exp_res = ciANIResult(dist=1.0, p_nothing_in_common=1.0, p_threshold=0.001)
+    exp_res = ciANIResult(dist=1.0, dist_low=1.0, dist_high=1.0, p_nothing_in_common=1.0, p_threshold=0.001)
     assert res2 == exp_res
 
 
@@ -101,8 +101,8 @@ def test_containment_to_distance_one():
     ksize=21
     res = containment_to_distance(contain,ksize,scaled,n_unique_kmers=nkmers,estimate_ci=True)
     print(res)
-    exp_dist, exp_low,exp_high,pnc = 0.0,None,None,0.0
-    exp_id, exp_idlow,exp_idhigh,pnc = 1.0,None,None,0.0
+    exp_dist, exp_low,exp_high,pnc = 0.0,0.0,0.0,0.0
+    exp_id, exp_idlow,exp_idhigh,pnc = 1.0,1.0,1.0,0.0
     assert res.dist == exp_dist
     assert res.dist_low == exp_low
     assert res.dist_high == exp_high
@@ -116,8 +116,8 @@ def test_containment_to_distance_one():
     assert res.dist == exp_dist
     assert res.ani == exp_id
     assert res.p_nothing_in_common == pnc
-    assert res.ani_low == None
-    assert res.ani_high == None
+    assert res.ani_low == 1.0
+    assert res.ani_high == 1.0
 
 
 def test_containment_to_distance_scaled1():

--- a/tests/test_distance_utils.py
+++ b/tests/test_distance_utils.py
@@ -2,9 +2,11 @@
 Tests for distance utils.
 """
 import pytest
+import numpy as np
 from sourmash.distance_utils import (containment_to_distance, get_exp_probability_nothing_common,
                                     handle_seqlen_nkmers, jaccard_to_distance,
-                                    ANIResult, ciANIResult, jaccardANIResult, var_n_mutated)
+                                    ANIResult, ciANIResult, jaccardANIResult, var_n_mutated,
+                                    set_size_chernoff)
 
 def test_aniresult():
     res = ANIResult(0.4, 0.1)
@@ -396,3 +398,24 @@ def test_handle_seqlen_nkmers():
     with pytest.raises(ValueError) as exc:
         nkmers = handle_seqlen_nkmers(ksize)
     assert("Error: distance estimation requires input of either 'sequence_len_bp' or 'n_unique_kmers'") in str(exc)
+
+
+def test_set_size_chernoff():
+    eps = 10**(-6)
+    rel_error = 0.01
+    set_size = 1000000
+    s = 1/0.1  # I'm used to using a scale value between 0 and 1
+    value_from_mathematica = 0.928652
+    assert np.abs(set_size_chernoff(set_size, s, relative_error=rel_error) - value_from_mathematica) < eps
+
+    rel_error = 0.05
+    set_size = 10000
+    s = 1
+    value_from_mathematica = 0.999519
+    assert np.abs(set_size_chernoff(set_size, s, relative_error=rel_error) - value_from_mathematica) < eps
+
+    rel_error = 0.001
+    set_size = 10
+    s = 1/.01
+    value_from_mathematica = -1
+    assert np.abs(set_size_chernoff(set_size, s,relative_error=rel_error) - value_from_mathematica) < eps

--- a/tests/test_minhash.py
+++ b/tests/test_minhash.py
@@ -3004,3 +3004,34 @@ def test_ANI_num_fail():
         mh1.jaccard_ani(mh2)
     assert "Error: can only calculate ANI for scaled MinHashes" in str(exc)
 
+
+def test_minhash_set_size_estimate_is_accurate():
+    f1 = utils.get_test_data('2.fa.sig')
+    f2 = utils.get_test_data('2+63.fa.sig')
+    mh1 = sourmash.load_one_signature(f1, ksize=31).minhash
+    mh2 = sourmash.load_one_signature(f2).minhash
+
+    # check accuracy using default thresholds (rel_err= 0.5, confidence=0.95)
+    assert mh1.size_is_accurate() == False
+    assert mh2.size_is_accurate() == True
+
+    # change rel err
+    assert mh1.size_is_accurate(relative_error=0.5) == True
+    assert mh2.size_is_accurate(relative_error=0.0001) == False
+
+    # change prob
+    assert mh1.size_is_accurate(confidence=0.5) == True
+    assert mh2.size_is_accurate(confidence=1) == False
+
+    # check that relative error and confidence must be between 0 and 1
+    with pytest.raises(ValueError) as exc:
+        mh2.size_is_accurate(relative_error=-1)
+    assert "Error: relative error and confidence values must be between 0 and 1." in str(exc)
+
+    with pytest.raises(ValueError) as exc:
+        mh2.size_is_accurate(confidence=-1)
+    assert "Error: relative error and confidence values must be between 0 and 1." in str(exc)
+
+    with pytest.raises(ValueError) as exc:
+        mh2.size_is_accurate(relative_error=-1, confidence=-1)
+    assert "Error: relative error and confidence values must be between 0 and 1." in str(exc)

--- a/tests/test_minhash.py
+++ b/tests/test_minhash.py
@@ -2830,22 +2830,31 @@ def test_containment_ANI():
     print("\nmh1 contained by mh2", m1_cont_m2)
     print("mh2 contained by mh1", m2_cont_m1)
 
-    assert (m1_cont_m2.ani, m1_cont_m2.ani_low, m1_cont_m2.ani_high, m1_cont_m2.p_nothing_in_common) == (0.0, None, None, 0.0)
+     # first, assess as-is. ANI should be 0, bc 2.fa.sig size is inaccurate
+    assert m1_cont_m2.ani == m2_cont_m1.ani == 0
+
+    # since size is inaccurate on 2.fa.sig, need to override to be able to get ani
+    m1_cont_m2.size_is_inaccurate = False
+    m2_cont_m1.size_is_inaccurate = False
+    
+    print("\nmh1 contained by mh2", m1_cont_m2)
+    print("mh2 contained by mh1", m2_cont_m1)
+
+    assert (round(m1_cont_m2.ani,3), m1_cont_m2.ani_low, m1_cont_m2.ani_high) == (1.0,1.0,1.0)#(1.0, None, None)
     assert (round(m2_cont_m1.ani,3), round(m2_cont_m1.ani_low,3), round(m2_cont_m1.ani_high,3)) == (0.966, 0.965, 0.967)
 
     m1_mc_m2 = mh1.max_containment_ani(mh2, estimate_ci =True)
     m2_mc_m1 = mh2.max_containment_ani(mh1, estimate_ci =True)
     print("mh1 max containment", m1_mc_m2)
     print("mh2 max containment", m2_mc_m1)
+    m1_mc_m2.size_is_inaccurate = False
+    m2_mc_m1.size_is_inaccurate = False
     assert m1_mc_m2 == m2_mc_m1
-    assert (m1_mc_m2.ani, m1_mc_m2.ani_low, m1_mc_m2.ani_high) == (1.0,None,None)
-    ac_m1 = mh1.avg_containment_ani(mh2)
-    ac_m2 = mh2.avg_containment_ani(mh1)
-    assert ac_m1 == ac_m2 == (m1_cont_m2.ani + m2_cont_m1.ani)/2
- 
+    assert (round(m1_mc_m2.ani, 3), round(m1_mc_m2.ani_low, 3), round(m1_mc_m2.ani_high, 3)) == (1.0,1.0,1.0)
+
 
 def test_containment_ANI_precalc_containment():
-    f1 = utils.get_test_data('2.fa.sig')
+    f1 = utils.get_test_data('47+63.fa.sig')
     f2 = utils.get_test_data('2+63.fa.sig')
     mh1 = sourmash.load_one_signature(f1, ksize=31).minhash
     mh2 = sourmash.load_one_signature(f2, ksize=31).minhash
@@ -2853,14 +2862,23 @@ def test_containment_ANI_precalc_containment():
     s1c = mh1.contained_by(mh2)
     s2c = mh2.contained_by(mh1)
     mc = max(s1c, s2c)
-    ac = (s1c + s2c)/2
-    print(ac)
 
     assert mh1.containment_ani(mh2, estimate_ci=True) ==  mh1.containment_ani(mh2, containment=s1c, estimate_ci=True)
     assert mh2.containment_ani(mh1) ==  mh2.containment_ani(mh1, containment=s2c)
     assert mh1.max_containment_ani(mh2) ==  mh2.max_containment_ani(mh1)
     assert mh1.max_containment_ani(mh2) ==  mh1.max_containment_ani(mh2, max_containment=mc)
     assert mh1.max_containment_ani(mh2) ==  mh2.max_containment_ani(mh1, max_containment=mc)
+
+
+def test_avg_containment_ani():
+    f1 = utils.get_test_data('47+63.fa.sig')
+    f2 = utils.get_test_data('2+63.fa.sig')
+    mh1 = sourmash.load_one_signature(f1, ksize=31).minhash
+    mh2 = sourmash.load_one_signature(f2, ksize=31).minhash
+    # check average_containment_ani
+    ac_m1 = mh1.avg_containment_ani(mh2)
+    ac_m2 = mh2.avg_containment_ani(mh1)
+    assert ac_m1 == ac_m2 == (mh1.containment_ani(mh2).ani + mh2.containment_ani(mh1).ani)/2 
 
 
 def test_containment_ANI_downsample():
@@ -2910,6 +2928,14 @@ def test_jaccard_ANI():
     m1_jani_m2 = mh1.jaccard_ani(mh2)
     m2_jani_m1 = mh2.jaccard_ani(mh1)
 
+    # first, assess as-is. ANI should be 0, bc 2.fa.sig size is inaccurate
+    assert m1_jani_m2 == m2_jani_m1
+    assert (m1_jani_m2.ani, m1_jani_m2.p_nothing_in_common, m1_jani_m2.jaccard_error) == (0, 0.0, 3.891666770716877e-07)
+
+    # since size is inaccurate on 2.fa.sig, need to override to be able to get ani
+    m1_jani_m2.size_is_inaccurate = False
+    m2_jani_m1.size_is_inaccurate = False
+
     assert m1_jani_m2 == m2_jani_m1
     assert (m1_jani_m2.ani, m1_jani_m2.p_nothing_in_common, m1_jani_m2.jaccard_error) == (0.9783711630110239, 0.0, 3.891666770716877e-07)
 
@@ -2923,7 +2949,11 @@ def test_jaccard_ANI_untrustworthy():
     print("\nJACCARD_ANI", mh1.jaccard_ani(mh2))
 
     m1_jani_m2 = mh1.jaccard_ani(mh2, err_threshold=1e-7)
-    assert m1_jani_m2.ani == ""
+
+    # since size is inaccurate on 2.fa.sig, need to override to be able to get ani
+    m1_jani_m2.size_is_inaccurate = False
+
+    assert m1_jani_m2.ani == 0
     assert m1_jani_m2.je_exceeds_threshold==True
     assert m1_jani_m2.je_threshold == 1e-7
 
@@ -2977,9 +3007,12 @@ def test_containment_ani_ci_tiny_testdata():
 
     m2_cani_m1 = mh2.containment_ani(mh1, estimate_ci=True)
     print(m2_cani_m1)
+    assert m2_cani_m1.ani == 0
+    m2_cani_m1.size_is_inaccurate = False
     assert m2_cani_m1.ani == 0.986394259982259
     assert m2_cani_m1.ani_low == None
     assert m2_cani_m1.ani_high == None
+
 
 def test_ANI_num_fail():
     f1 = utils.get_test_data('num/47.fa.sig')
@@ -3046,4 +3079,4 @@ def test_minhash_ani_inaccurate_size_est():
     assert mh1.size_is_accurate() == False
     assert mh2.size_is_accurate() == True
 
-    assert mh1.jaccard_ani(mh2).ani == ""
+    assert mh1.jaccard_ani(mh2).ani == 0

--- a/tests/test_minhash.py
+++ b/tests/test_minhash.py
@@ -2830,7 +2830,7 @@ def test_containment_ANI():
     print("\nmh1 contained by mh2", m1_cont_m2)
     print("mh2 contained by mh1", m2_cont_m1)
 
-    assert (m1_cont_m2.ani, m1_cont_m2.ani_low, m1_cont_m2.ani_high, m1_cont_m2.p_nothing_in_common) == (1.0, None, None, 0.0)
+    assert (m1_cont_m2.ani, m1_cont_m2.ani_low, m1_cont_m2.ani_high, m1_cont_m2.p_nothing_in_common) == (0.0, None, None, 0.0)
     assert (round(m2_cont_m1.ani,3), round(m2_cont_m1.ani_low,3), round(m2_cont_m1.ani_high,3)) == (0.966, 0.965, 0.967)
 
     m1_mc_m2 = mh1.max_containment_ani(mh2, estimate_ci =True)
@@ -3035,3 +3035,15 @@ def test_minhash_set_size_estimate_is_accurate():
     with pytest.raises(ValueError) as exc:
         mh2.size_is_accurate(relative_error=-1, confidence=-1)
     assert "Error: relative error and confidence values must be between 0 and 1." in str(exc)
+
+
+def test_minhash_ani_inaccurate_size_est():
+    f1 = utils.get_test_data('2.fa.sig')
+    f2 = utils.get_test_data('2+63.fa.sig')
+    mh1 = sourmash.load_one_signature(f1, ksize=31).minhash
+    mh2 = sourmash.load_one_signature(f2).minhash
+
+    assert mh1.size_is_accurate() == False
+    assert mh2.size_is_accurate() == True
+
+    assert mh1.jaccard_ani(mh2).ani == ""

--- a/tests/test_prefetch.py
+++ b/tests/test_prefetch.py
@@ -787,8 +787,8 @@ def test_prefetch_ani_csv_out_estimate_ci(runtmp, linear_gather):
             'ac_ani': '0.9769706656719734','mc_ani': '0.9771552502238963',
             'pfn': 'False'}
     exp2 = {'q_ani': '1.0','m_ani': '1.0',
-            'q_ani_low': "", 'q_ani_high': "",
-            'm_ani_low': "", "m_ani_high": "",
+            'q_ani_low': "1.0", 'q_ani_high': "1.0",
+            'm_ani_low': "1.0", "m_ani_high": "1.0",
                       'ac_ani': '1.0','mc_ani': '1.0',
                       'pfn': 'False'}
 

--- a/tests/test_signature.py
+++ b/tests/test_signature.py
@@ -439,8 +439,8 @@ def test_containment_ANI():
     print("\nss1 contained by ss2", s1_cont_s2)
     print("ss2 contained by ss1", s2_cont_s1)
 
-     # first, assess as-is. ANI should be 0, bc 2.fa.sig size is inaccurate
-    assert s1_cont_s2.ani == s2_cont_s1.ani == 0
+     # first, assess as-is. ANI should be None, bc 2.fa.sig size is inaccurate
+    assert s1_cont_s2.ani == s2_cont_s1.ani == None
 
     # since size is inaccurate on 2.fa.sig, need to override to be able to get ani
     s1_cont_s2.size_is_inaccurate = False
@@ -546,7 +546,7 @@ def test_jaccard_ANI():
 
     # first, assess as-is. ANI should be 0, bc 2.fa.sig size is inaccurate
     assert s1_jani_s2 == s2_jani_s1
-    assert (s1_jani_s2.ani, s1_jani_s2.p_nothing_in_common, s1_jani_s2.jaccard_error) == (0, 0.0, 3.891666770716877e-07)
+    assert (s1_jani_s2.ani, s1_jani_s2.p_nothing_in_common, s1_jani_s2.jaccard_error) == (None, 0.0, 3.891666770716877e-07)
 
     # since size is inaccurate on 2.fa.sig, need to override to be able to get ani
     s1_jani_s2.size_is_inaccurate = False
@@ -569,7 +569,7 @@ def test_jaccard_ANI_untrustworthy():
     # since size is inaccurate on 2.fa.sig, need to override to be able to get ani
     s1_jani_s2.size_is_inaccurate = False
 
-    assert s1_jani_s2.ani == 0
+    assert s1_jani_s2.ani == None
     assert s1_jani_s2.je_exceeds_threshold==True
     assert s1_jani_s2.je_threshold == 1e-7
 

--- a/tests/test_sketchcomparison.py
+++ b/tests/test_sketchcomparison.py
@@ -270,63 +270,51 @@ def test_FracMinHashComparison_fail_threshold(track_abundance):
     assert not cmp.pass_threshold # threshold is 10; this should fail
 
 
-def test_FracMinHashComparison_potential_false_negative(track_abundance):
-    a = MinHash(0, 21, scaled=10000, track_abundance=track_abundance)
-    b = MinHash(0, 21, scaled=10000, track_abundance=track_abundance)
-    c = MinHash(0, 21, scaled=10000, track_abundance=track_abundance)
-    # make sketch overlap quite small
-    a_values = {1:5}
-    b_values = {1:3, 3:2, 5:1, 6:1, 8:1, 10:1 }
-    c_values = {2:1}
-
-    if track_abundance:
-        a.set_abundances(a_values)
-        b.set_abundances(b_values)
-        c.set_abundances(c_values)
-    else:
-        a.add_many(a_values.keys())
-        b.add_many(b_values.keys())
-        c.add_many(c_values.keys())
+def test_FracMinHashComparison_potential_false_negative():
+    f1 = utils.get_test_data('scaled100/GCF_000005845.2_ASM584v2_genomic.fna.gz.sig.gz')
+    f2 = utils.get_test_data('scaled100/GCF_000006945.1_ASM694v1_genomic.fna.gz.sig.gz')
+    f3 = utils.get_test_data('scaled100/GCF_000783305.1_ASM78330v1_genomic.fna.gz.sig.gz')
+    a = load_one_signature(f1, ksize=21).minhash
+    b = load_one_signature(f2).minhash
+    c = load_one_signature(f3).minhash
+    assert a.size_is_accurate() == True
+    assert b.size_is_accurate() == True
+    assert c.size_is_accurate() == True
 
     # build FracMinHashComparison
     cmp = FracMinHashComparison(a, b)
     # check ani, potential false negative
     cmp.estimate_jaccard_ani()
     assert cmp.jaccard_ani == a.jaccard_ani(b).ani == b.jaccard_ani(a).ani
+    print(cmp.jaccard_ani)
     assert cmp.potential_false_negative == a.jaccard_ani(b).p_exceeds_threshold == b.jaccard_ani(a).p_exceeds_threshold
-    assert cmp.potential_false_negative == True
+    assert cmp.potential_false_negative == False
     assert cmp.jaccard_ani_untrustworthy == a.jaccard_ani(b).je_exceeds_threshold == b.jaccard_ani(a).je_exceeds_threshold
 
     cmp.estimate_mh1_containment_ani()
     a_cont_ani_manual = a.containment_ani(b)
     assert cmp.mh1_containment_ani == a_cont_ani_manual.ani
-    # potential false negative is false here. But since we got it above, don't want to set to False
-    assert cmp.potential_false_negative != a_cont_ani_manual.p_exceeds_threshold
-    assert cmp.potential_false_negative == True
+    print(a_cont_ani_manual.p_exceeds_threshold)
+    assert cmp.potential_false_negative == a_cont_ani_manual.p_exceeds_threshold
+    assert cmp.potential_false_negative == False
 
     cmp.estimate_mh2_containment_ani()
     b_cont_ani_manual = b.containment_ani(a)
     assert cmp.mh2_containment_ani == b_cont_ani_manual.ani
     assert cmp.potential_false_negative == b_cont_ani_manual.p_exceeds_threshold
-    assert cmp.potential_false_negative == True
+    assert cmp.potential_false_negative == False
 
     cmp.estimate_max_containment_ani()
     mc_ani_manual = a.max_containment_ani(b)
     assert cmp.max_containment_ani == max(a.containment_ani(b).ani, b.containment_ani(a).ani) == mc_ani_manual.ani
-    # potential false negative is false here. But since we got it above, don't want to set to False
-    assert cmp.potential_false_negative != mc_ani_manual.p_exceeds_threshold
+    assert cmp.potential_false_negative == mc_ani_manual.p_exceeds_threshold
     assert cmp.avg_containment_ani == np.mean([a.containment_ani(b).ani, b.containment_ani(a).ani])
+    assert cmp.potential_false_negative == False
+
+    #downsample to where it becomes a potential false negative
+    cmp = FracMinHashComparison(a, b, cmp_scaled=16000)
+    cmp.estimate_mh1_containment_ani()
     assert cmp.potential_false_negative == True
-
-    # comparison in opposite direction, so we can test potential_false_neg in other direction
-    cmp2 = FracMinHashComparison(b, a)
-    cmp2.estimate_mh1_containment_ani()
-    assert cmp2.potential_false_negative == True
-
-    # test max cont potential_false_neg (via no overlap at all)
-    cmp3 = FracMinHashComparison(a,c)
-    cmp3.estimate_max_containment_ani()
-    assert cmp3.potential_false_negative == True
 
 
 def test_FracMinHashComparison_incompatible_ksize(track_abundance):
@@ -842,11 +830,11 @@ def test_FracMinHashComparison_ANI_downsample(track_abundance):
     a = load_one_signature(f1, ksize=31).minhash
     b = load_one_signature(f2, ksize=31).minhash
 
-    cmp = FracMinHashComparison(a, b, cmp_scaled=2000, estimate_ani_ci=True)
+    cmp = FracMinHashComparison(a, b, cmp_scaled=1100, estimate_ani_ci=True)
 
     # now manually downsample
-    a = a.downsample(scaled=2000)
-    b = b.downsample(scaled=2000)
+    a = a.downsample(scaled=1100)
+    b = b.downsample(scaled=1100)
 
     # check jaccard ani
     cmp.estimate_jaccard_ani()

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -5615,7 +5615,7 @@ def test_search_jaccard_ani_downsample(c):
 
 
 def test_gather_ani_csv(runtmp, linear_gather, prefetch_gather):
-    testdata1 = utils.get_test_data('2+63.fa.sig')
+    testdata1 = utils.get_test_data('63.fa.sig')
     testdata2 = utils.get_test_data('47+63.fa.sig')
 
     runtmp.sourmash('index', '-k', '31', 'zzz', testdata2)
@@ -5639,19 +5639,19 @@ def test_gather_ani_csv(runtmp, linear_gather, prefetch_gather):
         assert gather_result_names_ci != list(row.keys())
         assert float(row['intersect_bp']) == 5238000.0
         assert float(row['unique_intersect_bp']) == 5238000.0
-        #assert float(row['remaining_bp']) == 2701000.0
-        assert float(row['f_orig_query']) == 0.6597808288197506
-        assert float(row['f_unique_to_query']) == 0.6597808288197506
+        assert float(row['remaining_bp']) == 0.0
+        assert float(row['f_orig_query']) == 1.0
+        assert float(row['f_unique_to_query']) == 1.0
         assert float(row['f_match']) == 0.6642150646715699
         assert row['filename'] == 'zzz'
         assert row['md5'] == '491c0a81b2cfb0188c0d3b46837c2f42'
         assert row['gather_result_rank'] == '0'
-        assert row['query_md5'] == '832a45e8'
-        assert row['query_bp'] == '7939000'
-        assert row['query_containment_ani']== '0.9866751346467802'
-        assert row['match_containment_ani'] == '0.9868883523107224'
-        assert row['average_containment_ani'] == '0.9867817434787514'
-        assert row['max_containment_ani'] =='0.9868883523107224'
+        assert row['query_md5'] == '38729c63'
+        assert row['query_bp'] == '5238000'
+        assert row['query_containment_ani']== '1.0'
+        assert round(float(row['match_containment_ani']), 3) == 0.987
+        assert round(float(row['average_containment_ani']), 3) ==  0.993
+        assert round(float(row['max_containment_ani']),3) == 1.0
         assert row['potential_false_negative'] == 'False'
 
 
@@ -5749,8 +5749,10 @@ def test_compare_containment_ani(c):
 def test_compare_jaccard_ani(c):
     import numpy
 
-    testdata_glob = utils.get_test_data('scaled/*.sig')
-    testdata_sigs = glob.glob(testdata_glob)
+#    testdata_glob = utils.get_test_data('scaled/*.sig')
+#    testdata_sigs = glob.glob(testdata_glob)
+    sigfiles = ["2.fa.sig", "2+63.fa.sig", "47.fa.sig", "63.fa.sig"]
+    testdata_sigs = [utils.get_test_data(c) for c in sigfiles]
 
     c.run_sourmash('compare', '-k', '31', '--estimate-ani',
                          '--csv', 'output.csv', *testdata_sigs)

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -5370,7 +5370,7 @@ def test_search_ani_jaccard_error_too_high(c):
         assert row['query_name'] == ''
         assert row['query_md5'] == '9191284a'
         #assert row['ani'] == "0.9987884602947684"
-        assert row['ani'] == ""
+        assert row['ani'] == '0'
 
 
 @utils.in_tempdir
@@ -5401,6 +5401,49 @@ def test_searchabund_no_ani(c):
 
 @utils.in_tempdir
 def test_search_ani_containment(c):
+    testdata1 = utils.get_test_data('2+63.fa.sig')
+    testdata2 = utils.get_test_data('47+63.fa.sig')
+
+    c.run_sourmash('search', '--containment', testdata1, testdata2, '-o', 'xxx.csv')
+    print(c.last_result.status, c.last_result.out, c.last_result.err)
+
+    search_result_names = SearchResult.search_write_cols
+
+    csv_file = c.output('xxx.csv')
+
+    with open(csv_file) as fp:
+        reader = csv.DictReader(fp)
+        row = next(reader)
+        print(row)
+        assert search_result_names == list(row.keys())
+        assert float(row['similarity']) == 0.6597808288197506 
+        assert row['filename'].endswith('47+63.fa.sig')
+        assert row['md5'] == '491c0a81b2cfb0188c0d3b46837c2f42'
+        assert row['query_name'] == ''
+        assert row['query_md5'] == '832a45e8'
+        assert row['ani'] == "0.9866751346467802"
+
+    # search other direction
+    c.run_sourmash('search', '--containment', testdata2, testdata1, '-o', 'xxxx.csv')
+    print(c.last_result.status, c.last_result.out, c.last_result.err)
+
+    csv_file = c.output('xxxx.csv')
+
+    with open(csv_file) as fp:
+        reader = csv.DictReader(fp)
+        row = next(reader)
+        print(row)
+        assert search_result_names == list(row.keys())
+        assert float(row['similarity']) == 0.6642150646715699
+        assert row['filename'].endswith('2+63.fa.sig')
+        assert row['md5'] == '832a45e85bdca6eaef5d73047e3e6321'
+        assert row['query_name'] == ''
+        assert row['query_md5'] == '491c0a81'
+        assert row['ani'] == "0.9868883523107224"
+
+
+@utils.in_tempdir
+def test_search_ani_containment_fail(c):
     testdata1 = utils.get_test_data('short.fa')
     testdata2 = utils.get_test_data('short2.fa')
     c.run_sourmash('sketch', 'dna', '-p', 'k=31,scaled=1', testdata1, testdata2)
@@ -5409,7 +5452,6 @@ def test_search_ani_containment(c):
     print(c.last_result.status, c.last_result.out, c.last_result.err)
 
     search_result_names = SearchResult.search_write_cols
-
     csv_file = c.output('xxx.csv')
 
     with open(csv_file) as fp:
@@ -5417,40 +5459,18 @@ def test_search_ani_containment(c):
         row = next(reader)
         print(row)
         assert search_result_names == list(row.keys())
-        assert float(row['similarity']) == 0.9556701030927836
-        assert row['filename'].endswith('short2.fa.sig')
-        assert row['md5'] == 'bf752903d635b1eb83c53fe4aae951db'
-        assert row['query_filename'].endswith('short.fa')
-        assert row['query_name'] == ''
-        assert row['query_md5'] == '9191284a'
-        assert row['ani'] == "0.9985384076863009"
+        assert float(row['similarity']) == 0.9556701030927836 
+        assert row['ani'] == "0"
+    
+    assert "WARNING: Cannot estimate ANI because size estimation for these sketches is inaccurate." in c.last_result.err
 
-    # search other direction
-    c.run_sourmash('search', '--containment', 'short2.fa.sig', 'short.fa.sig', '-o', 'xxxx.csv')
-    print(c.last_result.status, c.last_result.out, c.last_result.err)
-
-    csv_file = c.output('xxxx.csv')
-
-    with open(csv_file) as fp:
-        reader = csv.DictReader(fp)
-        row = next(reader)
-        print(row)
-        assert search_result_names == list(row.keys())
-        assert float(row['similarity']) == 0.9706806282722513
-        assert row['filename'].endswith('short.fa.sig')
-        assert row['md5'] == '9191284a3a23a913d8d410f3d53ce8f0'
-        assert row['query_filename'].endswith('short2.fa')
-        assert row['query_name'] == ''
-        assert row['query_md5'] == 'bf752903'
-        assert row['ani'] == "0.9990405323606487"
 
 @utils.in_tempdir
 def test_search_ani_containment_estimate_ci(c):
-    testdata1 = utils.get_test_data('short.fa')
-    testdata2 = utils.get_test_data('short2.fa')
-    c.run_sourmash('sketch', 'dna', '-p', 'k=31,scaled=1', testdata1, testdata2)
+    testdata1 = utils.get_test_data('2+63.fa.sig')
+    testdata2 = utils.get_test_data('47+63.fa.sig')
 
-    c.run_sourmash('search', '--containment', 'short.fa.sig', 'short2.fa.sig', '-o', 'xxx.csv', '--estimate-ani-ci')
+    c.run_sourmash('search', '--containment', testdata1, testdata2, '-o', 'xxx.csv', '--estimate-ani-ci')
     print(c.last_result.status, c.last_result.out, c.last_result.err)
 
     search_result_names_ci = SearchResult.search_write_cols_ci
@@ -5461,18 +5481,17 @@ def test_search_ani_containment_estimate_ci(c):
         row = next(reader)
         print(row)
         assert search_result_names_ci == list(row.keys())
-        assert float(row['similarity']) == 0.9556701030927836
-        assert row['filename'].endswith('short2.fa.sig')
-        assert row['md5'] == 'bf752903d635b1eb83c53fe4aae951db'
-        assert row['query_filename'].endswith('short.fa')
+        assert float(row['similarity']) == 0.6597808288197506 
+        assert row['filename'].endswith('47+63.fa.sig')
+        assert row['md5'] == '491c0a81b2cfb0188c0d3b46837c2f42'
         assert row['query_name'] == ''
-        assert row['query_md5'] == '9191284a'
-        assert row['ani'] == "0.9985384076863009"
-        assert row['ani_low'] == "0.9938337244993366"
-        assert row['ani_high'] == "0.9996796589835425"
+        assert row['query_md5'] == '832a45e8'
+        assert row['ani'] == "0.9866751346467802"
+        assert row['ani_low'] == "0.9861576758035308"
+        assert row['ani_high'] == "0.9871770716451368"
 
     # search other direction
-    c.run_sourmash('search', '--containment', 'short2.fa.sig', 'short.fa.sig', '-o', 'xxxx.csv', '--estimate-ani-ci')
+    c.run_sourmash('search', '--containment', testdata2, testdata1, '-o', 'xxxx.csv', '--estimate-ani-ci')
     print(c.last_result.status, c.last_result.out, c.last_result.err)
 
     csv_file = c.output('xxxx.csv')
@@ -5482,24 +5501,22 @@ def test_search_ani_containment_estimate_ci(c):
         row = next(reader)
         print(row)
         assert search_result_names_ci == list(row.keys())
-        assert float(row['similarity']) == 0.9706806282722513
-        assert row['filename'].endswith('short.fa.sig')
-        assert row['md5'] == '9191284a3a23a913d8d410f3d53ce8f0'
-        assert row['query_filename'].endswith('short2.fa')
+        assert float(row['similarity']) == 0.6642150646715699
+        assert row['filename'].endswith('2+63.fa.sig')
+        assert row['md5'] == '832a45e85bdca6eaef5d73047e3e6321'
         assert row['query_name'] == ''
-        assert row['query_md5'] == 'bf752903'
-        assert row['ani'] == "0.9990405323606487"
-        assert row['ani_low'] == "0.9946019114041683"
-        assert row['ani_high'] == "0.9998424422764817"
+        assert row['query_md5'] == '491c0a81'
+        assert row['ani'] == "0.9868883523107224"
+        assert row['ani_low'] == "0.986374049720872"
+        assert row['ani_high'] == "0.9873870188726516"
 
 
 @utils.in_tempdir
 def test_search_ani_max_containment(c):
-    testdata1 = utils.get_test_data('short.fa')
-    testdata2 = utils.get_test_data('short2.fa')
-    c.run_sourmash('sketch', 'dna', '-p', 'k=31,scaled=1', testdata1, testdata2)
+    testdata1 = utils.get_test_data('2+63.fa.sig')
+    testdata2 = utils.get_test_data('47+63.fa.sig')
 
-    c.run_sourmash('search', '--max-containment', 'short.fa.sig', 'short2.fa.sig', '-o', 'xxx.csv')
+    c.run_sourmash('search', '--max-containment', testdata1, testdata2, '-o', 'xxx.csv')
     print(c.last_result.status, c.last_result.out, c.last_result.err)
 
     csv_file = c.output('xxx.csv')
@@ -5510,22 +5527,20 @@ def test_search_ani_max_containment(c):
         row = next(reader)
         print(row)
         assert search_result_names == list(row.keys())
-        assert float(row['similarity']) == 0.9706806282722513
-        assert row['filename'].endswith('short2.fa.sig')
-        assert row['md5'] == 'bf752903d635b1eb83c53fe4aae951db'
-        assert row['query_filename'].endswith('short.fa')
+        assert float(row['similarity']) == 0.6642150646715699
+        assert row['filename'].endswith('47+63.fa.sig')
+        assert row['md5'] == '491c0a81b2cfb0188c0d3b46837c2f42'
         assert row['query_name'] == ''
-        assert row['query_md5'] == '9191284a'
-        assert row['ani'] == "0.9990405323606487"
+        assert row['query_md5'] == '832a45e8'
+        assert row['ani'] == "0.9868883523107224"
 
 
 @utils.in_tempdir
 def test_search_ani_max_containment_estimate_ci(c):
-    testdata1 = utils.get_test_data('short.fa')
-    testdata2 = utils.get_test_data('short2.fa')
-    c.run_sourmash('sketch', 'dna', '-p', 'k=31,scaled=1', testdata1, testdata2)
+    testdata1 = utils.get_test_data('2+63.fa.sig')
+    testdata2 = utils.get_test_data('47+63.fa.sig')
 
-    c.run_sourmash('search', '--max-containment', 'short.fa.sig', 'short2.fa.sig', '-o', 'xxx.csv', '--estimate-ani-ci')
+    c.run_sourmash('search', '--max-containment', testdata1, testdata2, '-o', 'xxx.csv', '--estimate-ani-ci')
     print(c.last_result.status, c.last_result.out, c.last_result.err)
 
     csv_file = c.output('xxx.csv')
@@ -5536,15 +5551,14 @@ def test_search_ani_max_containment_estimate_ci(c):
         row = next(reader)
         print(row)
         assert search_result_names_ci == list(row.keys())
-        assert float(row['similarity']) == 0.9706806282722513
-        assert row['filename'].endswith('short2.fa.sig')
-        assert row['md5'] == 'bf752903d635b1eb83c53fe4aae951db'
-        assert row['query_filename'].endswith('short.fa')
+        assert float(row['similarity']) == 0.6642150646715699
+        assert row['filename'].endswith('47+63.fa.sig')
+        assert row['md5'] == '491c0a81b2cfb0188c0d3b46837c2f42'
         assert row['query_name'] == ''
-        assert row['query_md5'] == '9191284a'
-        assert row['ani'] == "0.9990405323606487"
-        assert row['ani_low'] == "0.9946019114041683"
-        assert row['ani_high'] =="0.9998424422764817"
+        assert row['query_md5'] == '832a45e8'
+        assert row['ani'] == "0.9868883523107224"
+        assert row['ani_low'] == "0.986374049720872"
+        assert row['ani_high'] == "0.9873870188726516"
 
 
 @utils.in_tempdir
@@ -5581,36 +5595,34 @@ def test_search_jaccard_ani_downsample(c):
     ds_sig47 = c.output("ds_sig47.sig")
     c.run_sourmash('sig', "downsample", sig47, "--scaled", "2000", '-o', ds_sig47)
     c.run_sourmash('search', ds_sig47, sig4763, '-o', 'xxx.csv')
-
+#
     csv_file = c.output('xxx.csv')
     with open(csv_file) as fp:
         reader = csv.DictReader(fp)
         row = next(reader)
         print(row)
         assert round(float(row['similarity']), 3) == round(0.6634517766497462, 3)
-        assert round(float(row['ani']), 3) == round(0.992530907924384, 3)
+        #downsampled is too small, so ANI is 0. can get from dist, though
+        assert round(float(row['ani']), 3) == 0
 
     #downsample manually and assert same ANI
     ss47_ds = signature.load_one_signature(ds_sig47)
     print("SCALED:", ss47_ds.minhash.scaled, ss4763.minhash.scaled)
     ani_info = ss47_ds.jaccard_ani(ss4763, downsample=True)
     print(ani_info)
-    assert round(ani_info.ani, 3) == round(0.992530907924384, 3)
+    assert ani_info.ani == 0
+    assert (1 - round(ani_info.dist, 3)) == round(0.992530907924384, 3)
 
 
 def test_gather_ani_csv(runtmp, linear_gather, prefetch_gather):
-    testdata1 = utils.get_test_data('short.fa')
-    testdata2 = utils.get_test_data('short2.fa')
+    testdata1 = utils.get_test_data('2+63.fa.sig')
+    testdata2 = utils.get_test_data('47+63.fa.sig')
 
-    runtmp.sourmash('sketch','dna','-p','scaled=10', '--name-from-first', testdata1, testdata2)
-
-    runtmp.sourmash('sketch','dna','-p','scaled=10', '-o', 'query.fa.sig', '--name-from-first', testdata2)
-
-    runtmp.sourmash('index', '-k', '31', 'zzz', 'short.fa.sig', 'short2.fa.sig')
+    runtmp.sourmash('index', '-k', '31', 'zzz', testdata2)
 
     assert os.path.exists(runtmp.output('zzz.sbt.zip'))
 
-    runtmp.sourmash('gather', 'query.fa.sig', 'zzz', '-o', 'foo.csv', '--threshold-bp=1', linear_gather, prefetch_gather)
+    runtmp.sourmash('gather', testdata1, 'zzz', '-o', 'foo.csv', '--threshold-bp=1', linear_gather, prefetch_gather)
 
     print(runtmp.last_result.out)
     print(runtmp.last_result.err)
@@ -5625,24 +5637,21 @@ def test_gather_ani_csv(runtmp, linear_gather, prefetch_gather):
         print(row)
         assert gather_result_names == list(row.keys())
         assert gather_result_names_ci != list(row.keys())
-        assert float(row['intersect_bp']) == 910
-        assert float(row['unique_intersect_bp']) == 910
-        assert float(row['remaining_bp']) == 0
-        assert float(row['f_orig_query']) == 1.0
-        assert float(row['f_unique_to_query']) == 1.0
-        assert float(row['f_match']) == 1.0
+        assert float(row['intersect_bp']) == 5238000.0
+        assert float(row['unique_intersect_bp']) == 5238000.0
+        #assert float(row['remaining_bp']) == 2701000.0
+        assert float(row['f_orig_query']) == 0.6597808288197506
+        assert float(row['f_unique_to_query']) == 0.6597808288197506
+        assert float(row['f_match']) == 0.6642150646715699
         assert row['filename'] == 'zzz'
-        assert row['name'] == 'tr1 4'
-        assert row['md5'] == 'c9d5a795eeaaf58e286fb299133e1938'
+        assert row['md5'] == '491c0a81b2cfb0188c0d3b46837c2f42'
         assert row['gather_result_rank'] == '0'
-        assert row['query_filename'].endswith('short2.fa')
-        assert row['query_name'] == 'tr1 4'
-        assert row['query_md5'] == 'c9d5a795'
-        assert row['query_bp'] == '910'
-        assert row['query_containment_ani']== '1.0'
-        assert row['match_containment_ani'] == '1.0'
-        assert row['average_containment_ani'] == '1.0'
-        assert row['max_containment_ani'] =='1.0'
+        assert row['query_md5'] == '832a45e8'
+        assert row['query_bp'] == '7939000'
+        assert row['query_containment_ani']== '0.9866751346467802'
+        assert row['match_containment_ani'] == '0.9868883523107224'
+        assert row['average_containment_ani'] == '0.9867817434787514'
+        assert row['max_containment_ani'] =='0.9868883523107224'
         assert row['potential_false_negative'] == 'False'
 
 
@@ -5686,14 +5695,14 @@ def test_gather_ani_csv_estimate_ci(runtmp, linear_gather, prefetch_gather):
         assert row['query_name'] == 'tr1 4'
         assert row['query_md5'] == 'c9d5a795'
         assert row['query_bp'] == '910'
-        assert row['query_containment_ani']== '1.0'
+        assert row['query_containment_ani']== '0'
         assert row['query_containment_ani_low']== ''
         assert row['query_containment_ani_high']== ''
-        assert row['match_containment_ani'] == '1.0'
+        assert row['match_containment_ani'] == '0'
         assert row['match_containment_ani_low'] == ''
         assert row['match_containment_ani_high'] == ''
-        assert row['average_containment_ani'] == '1.0'
-        assert row['max_containment_ani'] =='1.0'
+        assert row['average_containment_ani'] == '0.0'
+        assert row['max_containment_ani'] =='0'
         assert row['potential_false_negative'] == 'False'
 
 


### PR DESCRIPTION
Using equations from @dkoslicki's #2031

- [x] integrate eqn's /create minhash method
- [x] when doing ANI comparisons, check set size accuracy, return "" when sizes are insufficient

Notes and concerns:

- Adding the bias term for changes the containment for small sketches, which we probably only want to do for major releases. If HLL cardinality estimation will be added soon, I'm not sure it's a good idea to do this, only to change it back for HLL. Containment values will change then too, but at least it will just be once? ref #2030.


