### PR TITLE
[MRG] add `sig collect` command

### DIFF
--- a/doc/command-line.md
+++ b/doc/command-line.md
@@ -1445,7 +1445,9 @@ For example,
 ```
 sourmash sig collect tests/test-data/gather/GCF*.sig -o mf.sqlmf
 ```
-will load all of the `GCF` signatures and build a manifest file `mf.sqlmf`.
+will load all of the `GCF` signatures and build a manifest file `mf.sqlmf`
+that contains references to all of the signatures, but not the signatures
+themselves.
 This manifest file can be loaded directly from the command line by sourmash.
 
 `sourmash sig collect` defaults to outputting SQLite manifests. It is
@@ -1728,7 +1730,7 @@ and then use the manifest directly for sourmash operations, for example:
 sourmash sig fileinfo manifest.sqlmf
 ```
 This manifest contains _references_ to the signatures (but not the
-signatures themselves) can then be used as a database target for most
+signatures themselves) and can then be used as a database target for most
 sourmash operations - search, gather, etc.
 
 Note that `sig collect` will generate manifests containing the

--- a/doc/command-line.md
+++ b/doc/command-line.md
@@ -1705,7 +1705,7 @@ signatures that were just created.
 
 ### Using manifests to explicitly refer to collections of files
 
-(sourmash v4.4.X and later - @CTB update version before merge!)
+(sourmash v4.4 and later)
 
 Manifests are metadata catalogs of signatures that are used for
 signature selection and loading. They are used extensively by sourmash

--- a/doc/command-line.md
+++ b/doc/command-line.md
@@ -1436,6 +1436,22 @@ sourmash database.
 `sourmash sig check` is particularly useful when working with large
 collections of signatures and identifiers.
 
+### `sourmash signature collect` - collect manifests across databases
+
+Collect manifests from across (many) files and merge into a single
+standalone manifest.
+
+For example,
+```
+sourmash sig collect tests/test-data/gather/GCF*.sig -o mf.sqlmf
+```
+will load all of the `GCF` signatures and build a manifest file `mf.sqlmf`.
+This manifest file can be loaded directly from the command line by sourmash.
+
+`sourmash sig collect` defaults to outputting SQLite manifests. It is
+particularly useful when working with large collections of signatures and
+identifiers, and has command line options for merging and updating manifests.
+
 ## Advanced command-line usage
 
 ### Loading signatures and databases
@@ -1689,7 +1705,7 @@ signatures that were just created.
 
 ### Using manifests to explicitly refer to collections of files
 
-(sourmash v4.4.0 and later)
+(sourmash v4.4.X and later - @CTB update version before merge!)
 
 Manifests are metadata catalogs of signatures that are used for
 signature selection and loading. They are used extensively by sourmash
@@ -1698,52 +1714,28 @@ pattern matching.
 
 Manifests can _also_ be used externally (via the command-line), and
 may be useful for organizing large collections of signatures. They can
-be generated with `sourmash sig manifest` as well as `sourmash sig check`.
+be generated with the `sig collect`, `sig manifest`, and `sig check`
+subcommands.
 
-Suppose you have a large collection of signature (`.sig` or `.sig.gz`
-files) under a directory. You can create a manifest file for them like so:
+Suppose you have a large collection of signatures (`.sig` or `.sig.gz`
+files) in a location (e.g., under a directory, or in a zip file). You
+can create a manifest file for them like so:
 ```
-sourmash sig manifest <dir> -o <dir>/manifest.csv
+sourmash sig collect <dir> <zipfile> -o manifest.sqlmf
 ```
-and then use the manifest directly for sourmash operations:
+and then use the manifest directly for sourmash operations, for example:
 ```
-sourmash sig fileinfo <dir>/manifest.csv
+sourmash sig fileinfo manifest.sqlmf
 ```
-This manifest can be used as a database target for most sourmash
-operations - search, gather, etc.  Note that manifests for directories
-must be placed within (and loaded from) the directory from which the
-manifest was generated; the specific manifest filename does not
-matter.
+This manifest contains _references_ to the signatures (but not the
+signatures themselves) can then be used as a database target for most
+sourmash operations - search, gather, etc.
 
-A more advanced and slightly tricky way to use explicit manifest files
-is with lists of files.  If you create a file with a path list
-containing the locations of loadable sourmash collections, you can run
-`sourmash sig manifest pathlist.txt -o mf.csv` to generate a manifest
-of all of the files.  The resulting manifest in `mf.csv` can then be
-loaded directly.  This is very handy when you have many sourmash
-signatures, or large signature files.  The tricky part in doing this
-is that the manifest will store the same paths listed in the pathlist
-file - whether they are relative or absolute paths - and these paths
-must be resolvable by sourmash from the current working directory.
-This makes explicit manifests built from pathlist files less portable
-within or across systems than the other sourmash collections, which
-are all relocatable.
-
-For example, if you create a pathlist file `paths.txt` containing the
-following:
-```
-/path/to/zipfile.zip
-local_directory/some_signature.sig.gz
-local_dir2/
-```
-and then run:
-```
-sourmash sig manifest paths.txt -o mf.csv
-```
-you will be able to use `mf.csv` as a database for `sourmash search`
-and `sourmash gather` commands.  But, because it contains two relative paths,
-you will only be able to use it _from the directory that contains those
-two relative paths_.
+Note that `sig collect` will generate manifests containing the
+pathnames given to it - so if you use relative paths, the references
+will be relative to the working directory in which `sig collect` was
+run.  You can use the `sig collect --abspath` to rewrite the paths
+into absolute paths.
 
 **Our advice:** We suggest using zip file collections for most
 situations; we primarily recommend using explicit manifests for

--- a/doc/command-line.md
+++ b/doc/command-line.md
@@ -1734,7 +1734,7 @@ sourmash operations - search, gather, etc.
 Note that `sig collect` will generate manifests containing the
 pathnames given to it - so if you use relative paths, the references
 will be relative to the working directory in which `sig collect` was
-run.  You can use the `sig collect --abspath` to rewrite the paths
+run.  You can use `sig collect --abspath` to rewrite the paths
 into absolute paths.
 
 **Our advice:** We suggest using zip file collections for most

--- a/doc/databases-advanced.md
+++ b/doc/databases-advanced.md
@@ -2,11 +2,11 @@
 
 sourmash uses a variety of different mechanisms and formats for storing, organizing, and searching signatures. Some of these mechanisms, "collections", just store the signatures; others ("indexed" databases) provide indices on the signatures for fast content-based search. _Most_ of the mechanisms now use manifests that permit fast selection and loading of signatures based on metadata. Below we refer to "databases" generically as any on-disk storage mechanism for sourmash signatures.
 
-Which database type is best to use depends on what you're doing - which is what this document is about! In general, however, sourmash should be fast enough that database choice will only impacts performance when searching 1000s of signatures, or doing many 1000s of searches.
+Which database type is best to use depends on what you're doing - which is what this document is about! In general, however, sourmash should be fast enough that database choice will only impact performance when searching thousands of signatures, or doing thousands of searches.
 
 The recommended file extensions below are conventions used to signal the output format when using `-o` with `sourmash sketch` and the `sourmash sig` subcommands; so, for example, `sourmash sketch dna *.fa -o xyz.zip` will output signatures in the .zip format.
 
-sourmash will automatically detect and load the database, based on the database _content_ in most cases.
+sourmash will automatically detect and load the database, based on the database _content_ and not the database extension, in most cases.
 
 Unless noted otherwise, the below database formats are supported in all release since sourmash v3.5.
 
@@ -56,15 +56,16 @@ We recommend SBT and LCA databases for use only in specific situations - e.g. SB
 
 ### Manifests
 
-Manifests are catalogs of signature metadata - name, molecule type, k-mer size, and other information - that can be used to select specific signatures for searching or processing. Typically when using manifests the actual signatures themselves are not loaded until they are needed.
+Manifests are catalogs of signature metadata - name, molecule type, k-mer size, and other information - that can be used to select specific signatures for searching or processing. Typically when using manifests the actual signatures themselves are not loaded until they are needed, although the efficiency of this depends on the signature storage mechanism; for example, JSON-format containers (`.sig` and `.lca.json` files) must be entirely loaded before any signature with them can be used, unlike zip containers.
 
 As of sourmash 4.4 manifests can be *directly* loaded from the command line as standalone collections. This lets manifests serve as a catalog of signatures stored in many different locations.
 
 Standalone manifests are preferable to both directory storage and pathlists (below), because they support fast selection and direct lazy loading. They are the most effective solution for managing custom collections of thousands to millions of signatures.
 
-Manifests can be created with `sourmash sig manifest` and `sourmash sig check`. For complex situations, we recommend using custom Python scripts to manage them - for example, see [sigs-to-manifest.py in database-examples](https://github.com/sourmash-bio/database-examples/blob/main/sigs-to-manifest.py).
+Standalone manifests can be created with `sourmash sig collect`.
+(@CTB check version - sourmash 4.4.0? or later?)
 
-Sourmash supports two manifest file formats - CSV and SQLite. SQLite manifests are much faster than CSV manifests in exchange for extra disk space.
+Sourmash supports two manifest file formats - CSV and SQLite. SQLite manifests are much faster and lower-memory than CSV manifests in exchange for consuming some extra disk space.
 
 ### Directories
 

--- a/doc/databases-advanced.md
+++ b/doc/databases-advanced.md
@@ -56,7 +56,7 @@ We recommend SBT and LCA databases for use only in specific situations - e.g. SB
 
 ### Manifests
 
-Manifests are catalogs of signature metadata - name, molecule type, k-mer size, and other information - that can be used to select specific signatures for searching or processing. Typically when using manifests the actual signatures themselves are not loaded until they are needed, although the efficiency of this depends on the signature storage mechanism; for example, JSON-format containers (`.sig` and `.lca.json` files) must be entirely loaded before any signature with them can be used, unlike zip containers.
+Manifests are catalogs of signature metadata - name, molecule type, k-mer size, and other information - that can be used to select specific signatures for searching or processing. Typically when using manifests the actual signatures themselves are not loaded until they are needed, although the efficiency of this depends on the signature storage mechanism; for example, JSON-format containers (`.sig` and `.lca.json` files) must be entirely loaded before any signature in the file them can be used, unlike zip containers.
 
 As of sourmash 4.4 manifests can be *directly* loaded from the command line as standalone collections. This lets manifests serve as a catalog of signatures stored in many different locations.
 

--- a/doc/databases-advanced.md
+++ b/doc/databases-advanced.md
@@ -62,8 +62,8 @@ As of sourmash 4.4 manifests can be *directly* loaded from the command line as s
 
 Standalone manifests are preferable to both directory storage and pathlists (below), because they support fast selection and direct lazy loading. They are the most effective solution for managing custom collections of thousands to millions of signatures.
 
-Standalone manifests can be created with `sourmash sig collect`.
-(@CTB check version - sourmash 4.4.0? or later?)
+Standalone manifests can be created with `sourmash sig collect`
+(sourmash v4.4 and later).
 
 Sourmash supports two manifest file formats - CSV and SQLite. SQLite manifests are much faster and lower-memory than CSV manifests in exchange for consuming some extra disk space.
 

--- a/src/sourmash/cli/sig/__init__.py
+++ b/src/sourmash/cli/sig/__init__.py
@@ -16,6 +16,7 @@ from . import fileinfo as summarize
 from . import grep
 from . import kmers
 from . import check
+from . import collect
 from . import intersect
 from . import inflate
 from . import manifest

--- a/src/sourmash/cli/sig/collect.py
+++ b/src/sourmash/cli/sig/collect.py
@@ -52,6 +52,9 @@ def subparser(subparsers):
     # @CTB
     subparser.add_argument('--merge-previous', action='store_true',
                    help='merge previous and new manifests')
+    subparser.add_argument('-f', '--force-overwrite',
+                           help='overwrite output file if it already exists',
+                           action='store_true')
 
     add_ksize_arg(subparser, 31)
     add_moltype_args(subparser)

--- a/src/sourmash/cli/sig/collect.py
+++ b/src/sourmash/cli/sig/collect.py
@@ -1,0 +1,62 @@
+"""collect manifest information across many files"""
+
+usage="""
+
+    sourmash sig collect <filenames> -o all.sqlmf
+
+This will collect manifests from across many files and save the information
+into a standalone manifest database.
+
+By default, 'sig collect' requires a pre-existing manifest for collections;
+this prevents potentially slow manifest rebuilding. You
+can turn this check off with '--no-require-manifest'.
+
+"""
+
+from sourmash.cli.utils import (add_moltype_args, add_ksize_arg,
+                                add_picklist_args, add_pattern_args)
+
+
+def subparser(subparsers):
+    subparser = subparsers.add_parser('collect', usage=usage)
+    subparser.add_argument('locations', nargs='*',
+                           help='locations of input signatures')
+    subparser.add_argument('-o', '--output', help='manifest output file',
+                   required=True)
+    subparser.add_argument(
+        '-q', '--quiet', action='store_true',
+        help='suppress non-error output'
+    )
+    subparser.add_argument(
+        '-d', '--debug', action='store_true',
+        help='provide debugging output'
+    )
+    subparser.add_argument(
+        '--from-file',
+        help='a text file containing a list of files to load signatures from'
+    )
+    subparser.add_argument(
+        '--no-require-manifest',
+        help='do not require a manifest; generate dynamically if needed',
+        action='store_true'
+    )
+    subparser.add_argument(
+        '-F', '--manifest-format',
+        help="format of manifest output file; default is 'csv')",
+        default='sql',
+        choices=['csv', 'sql'],
+    )
+
+    # @CTB
+    subparser.add_argument('--previous', help='previous manifest file')
+    # @CTB
+    subparser.add_argument('--merge-previous', action='store_true',
+                   help='merge previous and new manifests')
+
+    add_ksize_arg(subparser, 31)
+    add_moltype_args(subparser)
+
+
+def main(args):
+    import sourmash
+    return sourmash.sig.__main__.collect(args)

--- a/src/sourmash/cli/sig/collect.py
+++ b/src/sourmash/cli/sig/collect.py
@@ -55,6 +55,9 @@ def subparser(subparsers):
     subparser.add_argument('-f', '--force-overwrite',
                            help='overwrite output file if it already exists',
                            action='store_true')
+    subparser.add_argument('--abspath',
+                           help="convert all locations to absolute paths",
+                           action='store_true')
 
     add_ksize_arg(subparser, 31)
     add_moltype_args(subparser)

--- a/src/sourmash/cli/sig/collect.py
+++ b/src/sourmash/cli/sig/collect.py
@@ -47,14 +47,8 @@ def subparser(subparsers):
         choices=['csv', 'sql'],
     )
 
-    # @CTB
-    subparser.add_argument('--previous', help='previous manifest file')
-    # @CTB
     subparser.add_argument('--merge-previous', action='store_true',
-                   help='merge previous and new manifests')
-    subparser.add_argument('-f', '--force-overwrite',
-                           help='overwrite output file if it already exists',
-                           action='store_true')
+                           help='merge new manifests into existing')
     subparser.add_argument('--abspath',
                            help="convert all locations to absolute paths",
                            action='store_true')

--- a/src/sourmash/index/sqlite_index.py
+++ b/src/sourmash/index/sqlite_index.py
@@ -720,6 +720,12 @@ class SqliteCollectionManifest(BaseCollectionManifest):
             self._insert_row(c, row)
         return self
 
+    def __add__(self, other):
+        new_mf = self.create(":memory:")
+        new_mf += self
+        new_mf += other
+        return new_mf
+
     def close(self):
         self.conn.commit()
 

--- a/src/sourmash/index/sqlite_index.py
+++ b/src/sourmash/index/sqlite_index.py
@@ -657,6 +657,10 @@ class SqliteCollectionManifest(BaseCollectionManifest):
         )
         """)
 
+    def add_row(self, row):
+        c = self.conn.cursor()
+        self._insert_row(c, row)
+
     def _insert_row(self, cursor, row, *, call_is_from_index=False):
         "Insert a new manifest row."
         # check - is this manifest managed by SqliteIndex? If so, prevent

--- a/src/sourmash/index/sqlite_index.py
+++ b/src/sourmash/index/sqlite_index.py
@@ -699,6 +699,15 @@ class SqliteCollectionManifest(BaseCollectionManifest):
         self._num_rows = sum(1 for _ in self.rows)
         return self._num_rows
 
+    def __iadd__(self, other):
+        c = self.conn.cursor()
+        for row in other.rows:
+            self._insert_row(c, row)
+        return self
+
+    def close(self):
+        self.conn.commit()
+
     def _make_select(self):
         """Build a set of SQL SELECT conditions and matching value tuple
         that can be used to select the right sketches from the

--- a/src/sourmash/index/sqlite_index.py
+++ b/src/sourmash/index/sqlite_index.py
@@ -141,7 +141,8 @@ def load_sqlite_index(filename, *, request_manifest=False):
         is_lca_db = True
         debug_literal("load_sqlite_index: it's got a lineage table!")
 
-    if internal_d['SqliteManifest']:
+    # @CTB test me - load empty manifest, I think? see test_sig_collect_0_nothing
+    if 'SqliteManifest' in internal_d:
         v = internal_d['SqliteManifest']
         if v != '1.0':
             raise IndexNotSupported

--- a/src/sourmash/index/sqlite_index.py
+++ b/src/sourmash/index/sqlite_index.py
@@ -141,7 +141,6 @@ def load_sqlite_index(filename, *, request_manifest=False):
         is_lca_db = True
         debug_literal("load_sqlite_index: it's got a lineage table!")
 
-    # @CTB test me - load empty manifest, I think? see test_sig_collect_0_nothing
     if 'SqliteManifest' in internal_d:
         v = internal_d['SqliteManifest']
         if v != '1.0':

--- a/src/sourmash/index/sqlite_index.py
+++ b/src/sourmash/index/sqlite_index.py
@@ -599,6 +599,17 @@ class SqliteCollectionManifest(BaseCollectionManifest):
         return cls(conn)
 
     @classmethod
+    def create_or_open(cls, filename):
+        "Connect to 'filename' and create tables if not exist."
+        conn = sqlite3.connect(filename)
+        cursor = conn.cursor()
+        try:
+            cls._create_tables(cursor)
+        except sqlite3.OperationalError:
+            pass
+        return cls(conn)
+
+    @classmethod
     def load_from_manifest(cls, manifest, *, dbfile=":memory:", append=False):
         "Create a new sqlite manifest from an existing manifest object."
         return cls._create_manifest_from_rows(manifest.rows, location=dbfile,

--- a/src/sourmash/manifest.py
+++ b/src/sourmash/manifest.py
@@ -84,8 +84,11 @@ class BaseCollectionManifest:
     def load_from_sql(cls, filename):
         from sourmash.index.sqlite_index import load_sqlite_index
         db = load_sqlite_index(filename, request_manifest=True)
-        if db:
+        # @CTB test me - see test_sig_collect_0_nothing
+        if db is not None:
             return db.manifest
+
+        return None
 
     def write_to_filename(self, filename, *, database_format='csv',
                           ok_if_exists=False):

--- a/src/sourmash/manifest.py
+++ b/src/sourmash/manifest.py
@@ -78,7 +78,7 @@ class BaseCollectionManifest:
             row['signature'] = None
             manifest_list.append(row)
 
-        return cls(manifest_list)
+        return CollectionManifest(manifest_list)
 
     @classmethod
     def load_from_sql(cls, filename):
@@ -207,7 +207,7 @@ class CollectionManifest(BaseCollectionManifest):
     """
     An in-memory manifest that simply stores the rows in a list.
     """
-    def __init__(self, rows):
+    def __init__(self, rows=[]):
         "Initialize from an iterable of metadata dictionaries."
         self.rows = []
         self._md5_set = set()

--- a/src/sourmash/manifest.py
+++ b/src/sourmash/manifest.py
@@ -84,7 +84,6 @@ class BaseCollectionManifest:
     def load_from_sql(cls, filename):
         from sourmash.index.sqlite_index import load_sqlite_index
         db = load_sqlite_index(filename, request_manifest=True)
-        # @CTB test me - see test_sig_collect_0_nothing
         if db is not None:
             return db.manifest
 

--- a/src/sourmash/manifest.py
+++ b/src/sourmash/manifest.py
@@ -219,6 +219,9 @@ class CollectionManifest(BaseCollectionManifest):
         "Load this manifest from another manifest object."
         return cls(manifest.rows)
 
+    def add_row(self, row):
+        self._add_rows([row])
+
     def _add_rows(self, rows):
         self.rows.extend(rows)
 

--- a/src/sourmash/sig/__main__.py
+++ b/src/sourmash/sig/__main__.py
@@ -1456,7 +1456,7 @@ def collect(args):
         notify(f"Loading signature information from {loc}.")
 
         if n_files and n_files % 100 == 0:
-            notify(f'... loaded {collected_mf} sigs from {n_files} files', end='\r')
+            notify(f'... loaded {len(collected_mf)} sigs from {n_files} files')
         idx = sourmash.load_file_as_index(loc)
         if idx.manifest is None and require_manifest:
             error(f"ERROR on location '{loc}'")

--- a/src/sourmash/sig/__main__.py
+++ b/src/sourmash/sig/__main__.py
@@ -1414,8 +1414,8 @@ def collect(args):
     if args.manifest_format == 'sql':
         # create on-disk manifest
         from sourmash.index.sqlite_index import SqliteCollectionManifest
-        collected_mf = SqliteCollectionManifest.create(args.output)
 
+        collected_mf = SqliteCollectionManifest.create_or_open(args.output)
     else:
         # create in-memory manifest that will be saved as CSV
         assert args.manifest_format == 'csv'

--- a/src/sourmash/sig/__main__.py
+++ b/src/sourmash/sig/__main__.py
@@ -1389,7 +1389,9 @@ def check(args):
 def collect(args):
     "Collect signature metadata across many locations, save to manifest"
     # TODO:
-    # support manifest generation
+    # check what happens with directories :)
+    # support --abspath
+    # upgrade sig check to rewrite locations?
     set_quiet(False, args.debug)
 
     if args.previous and args.previous == args.output:

--- a/src/sourmash/sig/__main__.py
+++ b/src/sourmash/sig/__main__.py
@@ -1388,6 +1388,9 @@ def check(args):
 
 def collect(args):
     "Collect signature metadata across many locations, save to manifest"
+    # TODO:
+    # support manifest generation
+    # rewrite locations
     set_quiet(False, args.debug)
 
     if args.previous and args.previous == args.output:

--- a/src/sourmash/sig/__main__.py
+++ b/src/sourmash/sig/__main__.py
@@ -1439,6 +1439,14 @@ def collect(args):
             notify(f"ignoring {len(previous_locations)} locations from previous manifest")
             notify(f"(specify --merge-previous to merge previous manifest instead!)")
 
+    # require manifests? yes by default, since generating can be slow.
+    require_manifest = True
+    if args.no_require_manifest:
+        require_manifest = False
+        debug("sig check: manifest will not be required")
+    else:
+        debug("sig check: manifest required")
+
     n_files = 0
     locations = set(args.locations)
 
@@ -1456,6 +1464,12 @@ def collect(args):
         if n_files and n_files % 100 == 0:
             notify(f'... loaded {collected_mf} sigs from {n_files} files', end='\r')
         idx = sourmash.load_file_as_index(loc)
+        if idx.manifest is None and require_manifest:
+            error(f"ERROR on location '{loc}'")
+            error(f"sig collect requires a manifest by default, but no manifest present.")
+            error("specify --no-require-manifest to dynamically generate one.")
+            sys.exit(-1)
+
         mf = sourmash_args.get_manifest(idx)
 
         rows = []

--- a/src/sourmash/sig/__main__.py
+++ b/src/sourmash/sig/__main__.py
@@ -1409,7 +1409,7 @@ def collect(args):
         else:
             error(f"ERROR: '{args.output}' already exists!")
             error(f"ERROR: please specify --force-overwrite to continue")
-            error("ERROR: or repeat with --previous={args.output} --merge-previous for a merge.")
+            error(f"ERROR: or repeat with --previous={args.output} --merge-previous for a merge.")
             sys.exit(-1)
 
     if args.manifest_format == 'sql':

--- a/src/sourmash/sig/__main__.py
+++ b/src/sourmash/sig/__main__.py
@@ -1430,7 +1430,11 @@ def collect(args):
 
         # recover the filenames so that they can be ignored below.
         for row in previous.rows:
-            previous_locations.add(row['internal_location'])
+            iloc = row['internal_location']
+            if args.abspath:
+                iloc = os.path.abspath(iloc)
+
+            previous_locations.add(iloc)
 
         notify(f"loaded {len(previous)} rows with {len(previous_locations)} distinct locations from '{args.previous}'")
 
@@ -1456,11 +1460,15 @@ def collect(args):
     if args.from_file:
         locations.union_update(args.from_file)
 
+    # convert to abspath
+    if args.abspath:
+        locations = set(( os.path.abspath(iloc) for iloc in locations ))
+
     # remove previous_locations
     locations -= previous_locations
 
     # iterate through, loading all the things.
-    for n_files, loc in enumerate(args.locations):
+    for n_files, loc in enumerate(locations):
         notify(f"Loading signature information from {loc}.")
 
         if n_files and n_files % 100 == 0:

--- a/src/sourmash/sig/__main__.py
+++ b/src/sourmash/sig/__main__.py
@@ -1390,7 +1390,6 @@ def collect(args):
     "Collect signature metadata across many locations, save to manifest"
     # TODO:
     # support manifest generation
-    # rewrite locations
     set_quiet(False, args.debug)
 
     if args.previous and args.previous == args.output:
@@ -1457,8 +1456,8 @@ def collect(args):
         if n_files and n_files % 100 == 0:
             notify(f'... loaded {collected_mf} sigs from {n_files} files', end='\r')
         idx = sourmash.load_file_as_index(loc)
-        # @CTB: use get_manifest; update internal_location.
-        mf = idx.manifest
+        mf = sourmash_args.get_manifest(idx)
+
         rows = []
         for row in mf.rows:
             row['internal_location'] = loc

--- a/src/sourmash/sig/__main__.py
+++ b/src/sourmash/sig/__main__.py
@@ -1459,8 +1459,10 @@ def collect(args):
         idx = sourmash.load_file_as_index(loc)
         # @CTB: use get_manifest; update internal_location.
         mf = idx.manifest
-
-        collected_mf += mf
+        rows = []
+        for row in mf.rows:
+            row['internal_location'] = loc
+            collected_mf.add_row(row)
 
     if not collected_mf:
         notify(f"No new manifest rows detected. Exiting without saving!")

--- a/src/sourmash/sig/__main__.py
+++ b/src/sourmash/sig/__main__.py
@@ -1405,8 +1405,8 @@ def collect(args):
     elif args.merge_previous:
         notify(f"WARNING: --merge-previous specified, but output file '{args.output}' does not already exist?")
 
-    # @CTB: what happens if args.output is not of type manifest_type??
-
+    # load previous manifest for --merge-previous. This gets tricky with
+    # mismatched manifest types, which we forbid.
     try:
         if args.manifest_format == 'sql':
             # create on-disk manifest

--- a/src/sourmash/sig/__main__.py
+++ b/src/sourmash/sig/__main__.py
@@ -1423,7 +1423,6 @@ def collect(args):
         notify(f"loaded {len(previous)} rows with {len(previous_locations)} distinct locations from '{args.previous}'")
 
         if args.merge_previous:
-            # note, this is important for CSV manifests, but not for SQL manifests.
             notify(f"merging previous rows into current.")
             collected_mf += previous
         else:
@@ -1431,7 +1430,6 @@ def collect(args):
             notify(f"(specify --merge-previous to merge previous manifest instead!)")
 
     n_files = 0
-
     locations = set(args.locations)
 
     # load from_file
@@ -1442,13 +1440,13 @@ def collect(args):
     locations -= previous_locations
 
     # iterate through, loading all the things.
-    for loc in set(args.locations):
+    for n_files, loc in enumerate(args.locations):
         notify(f"Loading signature information from {loc}.")
 
         if n_files and n_files % 100 == 0:
             notify(f'... loaded {collected_mf} sigs from {n_files} files', end='\r')
         idx = sourmash.load_file_as_index(loc)
-        # @CTB: use get_manifest.
+        # @CTB: use get_manifest; update internal_location.
         mf = idx.manifest
 
         collected_mf += mf

--- a/src/sourmash/sig/__main__.py
+++ b/src/sourmash/sig/__main__.py
@@ -1341,11 +1341,18 @@ def check(args):
             sys.exit(-1)
 
         # has manifest, or ok to build (require_manifest=False) - continue!
-        manifest = sourmash_args.get_manifest(idx, require=True)
-        manifest_rows = manifest.select_to_manifest(picklist=picklist)
-        total_rows_examined += len(manifest)
-        total_manifest_rows += manifest_rows
-        debug_literal(f"examined {len(manifest)} new rows, found {len(manifest_rows)} matching rows")
+        new_manifest = sourmash_args.get_manifest(idx, require=True)
+        sub_manifest = new_manifest.select_to_manifest(picklist=picklist)
+        total_rows_examined += len(new_manifest)
+
+        # rewrite locations so that each signature can be found by filename
+        # of its container; this follows `sig collect` logic.
+        rows = []
+        for row in sub_manifest.rows:
+            row['internal_location'] = filename
+            total_manifest_rows.add_row(row)
+
+        debug_literal(f"examined {len(new_manifest)} new rows, found {len(sub_manifest)} matching rows")
 
     notify(f"loaded {total_rows_examined} signatures.")
 

--- a/src/sourmash/sig/__main__.py
+++ b/src/sourmash/sig/__main__.py
@@ -1462,7 +1462,7 @@ def collect(args):
     for n_files, loc in enumerate(args.locations):
         notify(f"Loading signature information from {loc}.")
 
-        if n_files and n_files % 100 == 0:
+        if n_files % 100 == 0:
             notify(f'... loaded {len(collected_mf)} sigs from {n_files} files')
         idx = sourmash.load_file_as_index(loc)
         if idx.manifest is None and require_manifest:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -70,6 +70,11 @@ def lca_db_format(request):
     return request.param
 
 
+@pytest.fixture(params=['csv', 'sql'])
+def manifest_db_format(request):
+    return request.param
+
+
 # --- BEGIN - Only run tests using a particular fixture --- #
 # Cribbed from: http://pythontesting.net/framework/pytest/pytest-run-tests-using-particular-fixture/
 def pytest_collection_modifyitems(items, config):

--- a/tests/test_cmd_signature_collect.py
+++ b/tests/test_cmd_signature_collect.py
@@ -197,7 +197,7 @@ def test_sig_collect_3_multiple(runtmp, manifest_db_format):
 
 
 def test_sig_collect_3_multiple_use_fromfile(runtmp, manifest_db_format):
-    # collect a manifest from two .zip files
+    # collect a manifest from two .zip files using --from-file
     protzip = utils.get_test_data('prot/protein.zip')
     hpzip = utils.get_test_data('prot/hp.zip')
     dayzip = utils.get_test_data('prot/dayhoff.zip')

--- a/tests/test_cmd_signature_collect.py
+++ b/tests/test_cmd_signature_collect.py
@@ -1,0 +1,75 @@
+"""
+Tests for 'sourmash sig collect'
+"""
+import pytest
+
+import sourmash
+from sourmash.manifest import BaseCollectionManifest
+
+import sourmash_tst_utils as utils
+from sourmash_tst_utils import SourmashCommandFailed
+
+
+def test_sig_collect_1_zipfile(runtmp, manifest_db_format):
+    # collect a manifest from a .zip file
+    protzip = utils.get_test_data('prot/protein.zip')
+
+    ext = 'sqlmf' if manifest_db_format == 'sql' else 'csv'
+
+    runtmp.sourmash('sig', 'collect', protzip, '-o', f'mf.{ext}',
+                    '-F', manifest_db_format)
+
+    manifest_fn = runtmp.output(f'mf.{ext}')
+    manifest = BaseCollectionManifest.load_from_filename(manifest_fn)
+
+    assert len(manifest) == 2
+    md5_list = [ row['md5'] for row in manifest.rows ]
+    assert '16869d2c8a1d29d1c8e56f5c561e585e' in md5_list
+    assert '120d311cc785cc9d0df9dc0646b2b857' in md5_list
+
+
+def test_sig_collect_2_exists_fail(runtmp, manifest_db_format):
+    # collect a manifest from two .zip files
+    protzip = utils.get_test_data('prot/protein.zip')
+    allzip = utils.get_test_data('prot/protein.zip')
+
+    ext = 'sqlmf' if manifest_db_format == 'sql' else 'csv'
+
+    runtmp.sourmash('sig', 'collect', protzip, '-o', f'mf.{ext}',
+                    '-F', manifest_db_format)
+
+    manifest_fn = runtmp.output(f'mf.{ext}')
+    manifest = BaseCollectionManifest.load_from_filename(manifest_fn)
+
+    assert len(manifest) == 2
+    md5_list = [ row['md5'] for row in manifest.rows ]
+    assert '16869d2c8a1d29d1c8e56f5c561e585e' in md5_list
+    assert '120d311cc785cc9d0df9dc0646b2b857' in md5_list
+
+    # now run with same filename - should fail
+    with pytest.raises(SourmashCommandFailed):
+        runtmp.sourmash('sig', 'collect', allzip, '-o', manifest_fn,
+                        '-F', manifest_db_format)
+
+
+def test_sig_collect_2_exists_force(runtmp, manifest_db_format):
+    # collect a manifest from two .zip files
+    protzip = utils.get_test_data('prot/protein.zip')
+    allzip = utils.get_test_data('prot/protein.zip')
+
+    ext = 'sqlmf' if manifest_db_format == 'sql' else 'csv'
+
+    runtmp.sourmash('sig', 'collect', protzip, '-o', f'mf.{ext}',
+                    '-F', manifest_db_format)
+
+    manifest_fn = runtmp.output(f'mf.{ext}')
+    manifest = BaseCollectionManifest.load_from_filename(manifest_fn)
+
+    assert len(manifest) == 2
+    md5_list = [ row['md5'] for row in manifest.rows ]
+    assert '16869d2c8a1d29d1c8e56f5c561e585e' in md5_list
+    assert '120d311cc785cc9d0df9dc0646b2b857' in md5_list
+
+    # now run with same filename - should fail
+    runtmp.sourmash('sig', 'collect', allzip, '-o', manifest_fn,
+                    '-F', manifest_db_format, '--force-overwrite')

--- a/tests/test_cmd_signature_collect.py
+++ b/tests/test_cmd_signature_collect.py
@@ -97,3 +97,9 @@ def test_sig_collect_3_multiple(runtmp, manifest_db_format):
     assert 'bb0e6d90df01b7bd5d0956a5f9e3ed12' in md5_list
     assert 'fbca5e5211e4d58427997fd5c8343e9a' in md5_list
     assert '1cbd888bf910f83ad8f1715509183223' in md5_list
+
+    locations = set([ row['internal_location'] for row in manifest.rows ])
+    assert protzip in locations
+    assert hpzip in locations
+    assert dayzip in locations
+    assert len(locations) == 3, locations

--- a/tests/test_cmd_signature_collect.py
+++ b/tests/test_cmd_signature_collect.py
@@ -55,7 +55,7 @@ def test_sig_collect_2_exists_fail(runtmp, manifest_db_format):
 def test_sig_collect_2_exists_force(runtmp, manifest_db_format):
     # collect a manifest from two .zip files
     protzip = utils.get_test_data('prot/protein.zip')
-    allzip = utils.get_test_data('prot/protein.zip')
+    allzip = utils.get_test_data('prot/all.zip')
 
     ext = 'sqlmf' if manifest_db_format == 'sql' else 'csv'
 
@@ -73,3 +73,27 @@ def test_sig_collect_2_exists_force(runtmp, manifest_db_format):
     # now run with same filename - should fail
     runtmp.sourmash('sig', 'collect', allzip, '-o', manifest_fn,
                     '-F', manifest_db_format, '--force-overwrite')
+
+
+def test_sig_collect_3_multiple(runtmp, manifest_db_format):
+    # collect a manifest from two .zip files
+    protzip = utils.get_test_data('prot/protein.zip')
+    hpzip = utils.get_test_data('prot/hp.zip')
+    dayzip = utils.get_test_data('prot/dayhoff.zip')
+
+    ext = 'sqlmf' if manifest_db_format == 'sql' else 'csv'
+
+    runtmp.sourmash('sig', 'collect', protzip, hpzip, dayzip,
+                    '-o', f'mf.{ext}', '-F', manifest_db_format)
+
+    manifest_fn = runtmp.output(f'mf.{ext}')
+    manifest = BaseCollectionManifest.load_from_filename(manifest_fn)
+
+    assert len(manifest) == 6
+    md5_list = [ row['md5'] for row in manifest.rows ]
+    assert '16869d2c8a1d29d1c8e56f5c561e585e' in md5_list
+    assert '120d311cc785cc9d0df9dc0646b2b857' in md5_list
+    assert 'ea2a1ad233c2908529d124a330bcb672' in md5_list
+    assert 'bb0e6d90df01b7bd5d0956a5f9e3ed12' in md5_list
+    assert 'fbca5e5211e4d58427997fd5c8343e9a' in md5_list
+    assert '1cbd888bf910f83ad8f1715509183223' in md5_list

--- a/tests/test_cmd_signature_collect.py
+++ b/tests/test_cmd_signature_collect.py
@@ -54,7 +54,7 @@ def test_sig_collect_2_exists_fail(runtmp, manifest_db_format):
                         '-F', manifest_db_format)
 
 
-def test_sig_collect_2_exists_force(runtmp, manifest_db_format):
+def test_sig_collect_2_exists_merge(runtmp, manifest_db_format):
     # collect a manifest from two .zip files
     protzip = utils.get_test_data('prot/protein.zip')
     allzip = utils.get_test_data('prot/all.zip')
@@ -72,9 +72,12 @@ def test_sig_collect_2_exists_force(runtmp, manifest_db_format):
     assert '16869d2c8a1d29d1c8e56f5c561e585e' in md5_list
     assert '120d311cc785cc9d0df9dc0646b2b857' in md5_list
 
-    # now run with same filename - should fail
+    # now run with same filename - should merge
     runtmp.sourmash('sig', 'collect', allzip, '-o', manifest_fn,
-                    '-F', manifest_db_format, '--force-overwrite')
+                    '-F', manifest_db_format, '--merge')
+
+    manifest = BaseCollectionManifest.load_from_filename(manifest_fn)
+    assert len(manifest) == 10
 
 
 def test_sig_collect_3_multiple(runtmp, manifest_db_format):

--- a/tests/test_cmd_signature_collect.py
+++ b/tests/test_cmd_signature_collect.py
@@ -94,6 +94,58 @@ def test_sig_collect_2_exists_merge(runtmp, manifest_db_format):
     assert len(manifest) == 10
 
 
+def test_sig_collect_2_exists_sql_merge_csv(runtmp, manifest_db_format):
+    # try to merge csv into sql
+    protzip = utils.get_test_data('prot/protein.zip')
+    allzip = utils.get_test_data('prot/all.zip')
+
+    ext = 'sqlmf'
+
+    # save as sql...
+    runtmp.sourmash('sig', 'collect', protzip, '-o', f'mf.{ext}',
+                    '-F', 'sql')
+
+    manifest_fn = runtmp.output(f'mf.{ext}')
+    manifest = BaseCollectionManifest.load_from_filename(manifest_fn)
+
+    assert len(manifest) == 2
+    md5_list = [ row['md5'] for row in manifest.rows ]
+    assert '16869d2c8a1d29d1c8e56f5c561e585e' in md5_list
+    assert '120d311cc785cc9d0df9dc0646b2b857' in md5_list
+
+    with pytest.raises(SourmashCommandFailed):
+        runtmp.sourmash('sig', 'collect', allzip, '-o', manifest_fn,
+                        '-F', 'csv', '--merge')
+
+    assert "ERROR loading" in runtmp.last_result.err
+
+
+def test_sig_collect_2_exists_csv_merge_sql(runtmp):
+    # try to merge sql into csv
+    protzip = utils.get_test_data('prot/protein.zip')
+    allzip = utils.get_test_data('prot/all.zip')
+
+    ext = 'csv'
+
+    # save as sql...
+    runtmp.sourmash('sig', 'collect', protzip, '-o', f'mf.{ext}',
+                    '-F', 'csv')
+
+    manifest_fn = runtmp.output(f'mf.{ext}')
+    manifest = BaseCollectionManifest.load_from_filename(manifest_fn)
+
+    assert len(manifest) == 2
+    md5_list = [ row['md5'] for row in manifest.rows ]
+    assert '16869d2c8a1d29d1c8e56f5c561e585e' in md5_list
+    assert '120d311cc785cc9d0df9dc0646b2b857' in md5_list
+
+    with pytest.raises(SourmashCommandFailed):
+        runtmp.sourmash('sig', 'collect', allzip, '-o', manifest_fn,
+                        '-F', 'sql', '--merge')
+
+    assert "ERROR loading" in runtmp.last_result.err
+
+
 def test_sig_collect_2_no_exists_merge(runtmp, manifest_db_format):
     # test 'merge' when args.output doesn't already exist => warning
     protzip = utils.get_test_data('prot/protein.zip')

--- a/tests/test_cmd_signature_collect.py
+++ b/tests/test_cmd_signature_collect.py
@@ -103,3 +103,56 @@ def test_sig_collect_3_multiple(runtmp, manifest_db_format):
     assert hpzip in locations
     assert dayzip in locations
     assert len(locations) == 3, locations
+
+
+def test_sig_collect_4_multiple_from_sig(runtmp, manifest_db_format):
+    # collect a manifest from sig files
+    sig43 = utils.get_test_data('47.fa.sig')
+    sig63 = utils.get_test_data('63.fa.sig')
+
+    ext = 'sqlmf' if manifest_db_format == 'sql' else 'csv'
+
+    runtmp.sourmash('sig', 'collect', sig43, sig63,
+                    '-o', f'mf.{ext}', '-F', manifest_db_format)
+
+    manifest_fn = runtmp.output(f'mf.{ext}')
+    manifest = BaseCollectionManifest.load_from_filename(manifest_fn)
+
+    assert len(manifest) == 2
+    md5_list = [ row['md5'] for row in manifest.rows ]
+    assert '09a08691ce52952152f0e866a59f6261' in md5_list
+    assert '38729c6374925585db28916b82a6f513' in md5_list
+
+    locations = set([ row['internal_location'] for row in manifest.rows ])
+    assert sig43 in locations
+    assert sig63 in locations
+    assert len(locations) == 2, locations
+
+
+def test_sig_collect_5_no_manifest_sbt_fail(runtmp, manifest_db_format):
+    # collect a manifest from files that don't have one
+    sbt_zip = utils.get_test_data('v6.sbt.zip')
+
+    ext = 'sqlmf' if manifest_db_format == 'sql' else 'csv'
+
+    with pytest.raises(SourmashCommandFailed):
+        runtmp.sourmash('sig', 'collect', sbt_zip,
+                        '-o', f'mf.{ext}', '-F', manifest_db_format)
+
+
+def test_sig_collect_5_no_manifest_sbt_succeed(runtmp, manifest_db_format):
+    # generate a manifest from files that don't have one when --no-require
+    sbt_zip = utils.get_test_data('v6.sbt.zip')
+
+    ext = 'sqlmf' if manifest_db_format == 'sql' else 'csv'
+
+    runtmp.sourmash('sig', 'collect', sbt_zip, '--no-require-manifest',
+                    '-o', f'mf.{ext}', '-F', manifest_db_format)
+
+    manifest_fn = runtmp.output(f'mf.{ext}')
+    manifest = BaseCollectionManifest.load_from_filename(manifest_fn)
+
+    assert len(manifest) == 7
+    locations = set([ row['internal_location'] for row in manifest.rows ])
+    assert len(locations) == 1, locations
+    assert sbt_zip in locations

--- a/tests/test_manifest_protocol.py
+++ b/tests/test_manifest_protocol.py
@@ -177,3 +177,35 @@ def test_manifest_filter_cols(manifest_obj):
     assert len(mf) == 1
     row = list(mf.rows)[0]
     assert row['name'] == 'NC_011663.1 Shewanella baltica OS223, complete genome'
+
+
+def test_manifest_iadd(manifest_obj):
+    # test the 'create_manifest' method
+    sig47 = utils.get_test_data('47.fa.sig')
+    ss = sourmash.load_one_signature(sig47)
+
+    def yield_sigs():
+        yield ss, 'fiz'
+
+    new_mf = manifest_obj.create_manifest(yield_sigs(),
+                                          include_signature=False)
+    assert len(new_mf) == 1
+
+    new_mf += manifest_obj
+    assert len(new_mf) == len(manifest_obj) + 1
+
+
+def test_manifest_add(manifest_obj):
+    # test the 'create_manifest' method
+    sig47 = utils.get_test_data('47.fa.sig')
+    ss = sourmash.load_one_signature(sig47)
+
+    def yield_sigs():
+        yield ss, 'fiz'
+
+    new_mf = manifest_obj.create_manifest(yield_sigs(),
+                                          include_signature=False)
+    assert len(new_mf) == 1
+
+    new_mf2 = new_mf + manifest_obj
+    assert len(new_mf2) == len(manifest_obj) + len(new_mf)

--- a/tests/test_sqlite_index.py
+++ b/tests/test_sqlite_index.py
@@ -775,6 +775,16 @@ def test_sqlite_manifest_load_existing_index_insert_fail():
     assert "must use SqliteIndex.insert to add to this manifest" in str(exc)
 
 
+def test_sqlite_manifest_create_load_empty(runtmp):
+    # try creating an empty manifest, then loading
+    mfname = runtmp.output("some.sqlmf")
+    mf = SqliteCollectionManifest.create(mfname)
+    mf.close()
+
+    mf2 = load_sqlite_index(mfname)
+    assert len(mf2) == 0
+
+
 def test_sqlite_lca_db_load_existing():
     # try loading an existing sqlite index
     filename = utils.get_test_data('sqlite/lca.sqldb')
@@ -819,8 +829,8 @@ def test_sqlite_lca_db_load_empty(runtmp):
     runtmp.sourmash('tax', 'prepare', '-F', 'sql', '-t', empty_tax,
                     '-o', dbname)
 
-    with pytest.raises(SourmashCommandFailed):
-        runtmp.sourmash('sig', 'describe', dbname)
+    runtmp.sourmash('sig', 'describe', dbname)
+    assert 'loaded 0 signatures' in runtmp.last_result.err
 
 
 def test_sqlite_lca_db_try_load_sqlite_index():


### PR DESCRIPTION
Adds `sourmash sig collect` by integrating [sigs-to-manifest.py](https://github.com/sourmash-bio/database-examples/blob/main/sigs-to-manifest.py) into sourmash.

This is the code that's used to maintain a manifest of wort-genomes signatures, among other things - see https://github.com/sourmash-bio/sourmash/issues/1965.

The main motivation behind this command addition is that it's really enabling for certain use cases, as shown most clearly by the way the documentation simplifies 😃 .

Guide into rendered docs from this PR:
- [sig collect docs](https://sourmash--2036.org.readthedocs.build/en/2036/command-line.html#sourmash-signature-collect-collect-manifests-across-databases)
- ["using manifests to refer to collections"](https://sourmash--2036.org.readthedocs.build/en/2036/command-line.html#using-manifests-to-explicitly-refer-to-collections-of-files)
- [advanced database page on manifests](https://sourmash--2036.org.readthedocs.build/en/2036/databases-advanced.html#manifests)