### PR TITLE
[MRG] add compare --avg-containment

### DIFF
--- a/src/sourmash/cli/compare.py
+++ b/src/sourmash/cli/compare.py
@@ -59,8 +59,12 @@ def subparser(subparsers):
         help='calculate max containment instead of similarity'
     )
     subparser.add_argument(
+        '--avg-containment', '--average-containment', action='store_true',
+        help='calculate average containment instead of similarity'
+    )
+    subparser.add_argument(
         '--estimate-ani', '--ANI', '--ani', action='store_true',
-        help='return ANI estimated from jaccard, containment, or max containment; see https://doi.org/10.1101/2022.01.11.475870'
+        help='return ANI estimated from jaccard, containment, average containment, or max containment; see https://doi.org/10.1101/2022.01.11.475870'
     )
     subparser.add_argument(
         '--from-file',

--- a/src/sourmash/compare.py
+++ b/src/sourmash/compare.py
@@ -106,6 +106,37 @@ def compare_serial_max_containment(siglist, *, downsample=False, return_ani=Fals
     return containments
 
 
+def compare_serial_avg_containment(siglist, *, downsample=False, return_ani=False):
+    """Compare all combinations of signatures and return a matrix
+    of avg_containments. Processes combinations serially on a single
+    process. Best to only use when there are few signatures.
+
+    :param list siglist: list of signatures to compare
+    :param boolean downsample by scaled if True
+    :return: np.array similarity matrix
+    """
+    import numpy as np
+
+    n = len(siglist)
+
+    # Combinations makes all unique sets of pairs, e.g. (A, B) but not (B, A)
+    iterator = itertools.combinations(range(n), 2)
+
+    containments = np.ones((n, n))
+
+    for i, j in iterator:
+        if return_ani:
+            ani = siglist[j].avg_containment_ani(siglist[i], downsample=downsample)
+            if ani == None:
+                ani = 0.0
+            containments[i][j] = containments[j][i] = ani
+        else:
+            containments[i][j] = containments[j][i] = siglist[j].avg_containment(siglist[i],
+                                                        downsample=downsample)
+
+    return containments
+
+
 def similarity_args_unpack(args, ignore_abundance, *, downsample, return_ani=False):
     """Helper function to unpack the arguments. Written to use in pool.imap
     as it can only be given one argument."""

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -7,7 +7,7 @@ import pytest
 import sourmash
 from sourmash.compare import (compare_all_pairs, compare_parallel,
                               compare_serial, compare_serial_containment,
-                              compare_serial_max_containment)
+                              compare_serial_max_containment, compare_serial_avg_containment)
 import sourmash_tst_utils as utils
 
 
@@ -130,3 +130,15 @@ def test_compare_serial_containmentANI(scaled_siglist):
         [0., 1., 0.97715525, 1.]])
 
     np.testing.assert_array_almost_equal(max_containment_ANI, true_max_containment_ANI, decimal=3)
+
+    # check avg_containment ANI
+    avg_containment_ANI = compare_serial_avg_containment(scaled_siglist, return_ani=True)
+    print(avg_containment_ANI)
+
+    true_avg_containment_ANI = np.array(
+        [[1., 0., 0., 0.],
+        [0., 1., 0.97046289, 0.99333757],
+        [0., 0.97046289, 1., 0.97697067],
+        [0., 0.99333757, 0.97697067, 1.]])
+
+    np.testing.assert_array_almost_equal(avg_containment_ANI, true_avg_containment_ANI, decimal=3)


### PR DESCRIPTION
add `--avg-containment` to `sourmash compare` command

Do we want to use this opportunity to set a different default ANI from `compare`? (answer: no, do this separately)