### PR TITLE
[MRG] emit fewer warnings about potential ANI estimation issues

### DIFF
--- a/src/sourmash/commands.py
+++ b/src/sourmash/commands.py
@@ -705,7 +705,6 @@ def gather(args):
         databases = [ LazyLinearIndex(db) for db in databases ]
 
     size_may_be_inaccurate = False
-    potential_false_negatives = False
     if args.prefetch:           # note: on by default!
         notify("Starting prefetch sweep across databases.")
         prefetch_query = query.copy()
@@ -870,8 +869,6 @@ def gather(args):
 
     if size_may_be_inaccurate:
         notify("WARNING: size estimation for at least one of these sketches may be inaccurate. ANI values cannot be generated for these comparisons.")
-    if potential_false_negatives:
-        notify("WARNING: Some of these sketches may have no hashes in common based on chance alone (false negatives). Consider decreasing your scaled value to prevent this.")
     # DONE w/gather function.
 
 
@@ -909,7 +906,6 @@ def multigather(args):
     # run gather on all the queries.
     n=0
     size_may_be_inaccurate = False
-    potential_false_negatives = False
     for queryfile in inp_files:
         # load the query signature(s) & figure out all the things
         for query in sourmash_args.load_file_as_signatures(queryfile,
@@ -981,8 +977,6 @@ def multigather(args):
                 # check for issues impacting ANI estimation
                 if result.size_may_be_inaccurate:
                     size_may_be_inaccurate = True
-                if result.potential_false_negative:
-                    potential_false_negatives = True
 
 
             # report on thresholding -
@@ -1049,8 +1043,6 @@ def multigather(args):
     notify(f'\nconducted gather searches on {n} signatures')
     if size_may_be_inaccurate:
         notify("WARNING: size estimation for at least one of these sketches may be inaccurate. ANI values cannot be generated for these comparisons.")
-    if potential_false_negatives:
-        notify("WARNING: Some of these sketches may have no hashes in common based on chance alone (false negatives). Consider decreasing your scaled value to prevent this.")
 
 
 def watch(args):
@@ -1230,7 +1222,6 @@ def prefetch(args):
 
     did_a_search = False        # track whether we did _any_ search at all!
     size_may_be_inaccurate = False
-    potential_false_negatives = False
     for dbfilename in args.databases:
         notify(f"loading signatures from '{dbfilename}'")
 
@@ -1285,8 +1276,6 @@ def prefetch(args):
             # keep track of inaccurate size estimation and potential false negatives
             if not size_may_be_inaccurate and result.size_may_be_inaccurate:
                 size_may_be_inaccurate = True
-            if not potential_false_negatives and result.potential_false_negative:
-                potential_false_negatives = True
 
         did_a_search = True
 
@@ -1351,7 +1340,5 @@ def prefetch(args):
 
     if size_may_be_inaccurate:
         notify("WARNING: size estimation for at least one of these sketches may be inaccurate. ANI values cannot be generated for these comparisons.")
-    if potential_false_negatives:
-        notify("WARNING: Some of these sketches may have no hashes in common based on chance alone (false negatives). Consider decreasing your scaled value to prevent this.")
 
     return 0

--- a/src/sourmash/commands.py
+++ b/src/sourmash/commands.py
@@ -133,13 +133,13 @@ def compare(args):
     if is_scaled:
         max_scaled = max(s.minhash.scaled for s in siglist)
         for s in siglist:
+            if not size_may_be_inaccurate and not s.minhash.size_is_accurate():
+                size_may_be_inaccurate = True
             if s.minhash.scaled != max_scaled:
                 if not printed_scaled_msg:
                     notify(f'downsampling to scaled value of {format(max_scaled)}')
                     printed_scaled_msg = True
                 s.minhash = s.minhash.downsample(scaled=max_scaled)
-                if not s.minhash.size_is_accurate():
-                    size_may_be_inaccurate = True
 
     if len(siglist) == 0:
         error('no signatures!')

--- a/src/sourmash/commands.py
+++ b/src/sourmash/commands.py
@@ -974,8 +974,9 @@ def multigather(args):
                               format_bp(result.intersect_bp), pct_query, pct_genome,
                               name)
                 found.append(result)
-                # check for issues impacting ANI estimation
-                if result.size_may_be_inaccurate:
+
+                # check for size estimation accuracy, which impacts ANI estimation
+                if not size_may_be_inaccurate and result.size_may_be_inaccurate:
                     size_may_be_inaccurate = True
 
 
@@ -1273,7 +1274,7 @@ def prefetch(args):
                 notify(f"total of {matches_out.count} matching signatures so far.",
                        end="\r")
 
-            # keep track of inaccurate size estimation and potential false negatives
+            # keep track of inaccurate size estimation
             if not size_may_be_inaccurate and result.size_may_be_inaccurate:
                 size_may_be_inaccurate = True
 

--- a/src/sourmash/commands.py
+++ b/src/sourmash/commands.py
@@ -979,7 +979,6 @@ def multigather(args):
                 if not size_may_be_inaccurate and result.size_may_be_inaccurate:
                     size_may_be_inaccurate = True
 
-
             # report on thresholding -
             if gather_iter.query.minhash:
                 # if still a query, then we failed the threshold.

--- a/src/sourmash/commands.py
+++ b/src/sourmash/commands.py
@@ -542,7 +542,6 @@ def search(args):
 
     size_may_be_inaccurate = False
     jaccard_ani_untrustworthy = False
-    potential_false_negatives = False
 
     # output!
     print_results("similarity   match")
@@ -554,8 +553,6 @@ def search(args):
         if sr.cmp_scaled is not None:
             if not size_may_be_inaccurate and sr.size_may_be_inaccurate:
                 size_may_be_inaccurate = True
-            if sr.potential_false_negative:
-                potential_false_negatives = True
             if not is_containment and sr.cmp.jaccard_ani_untrustworthy:
                 jaccard_ani_untrustworthy = True
 
@@ -586,8 +583,6 @@ def search(args):
         notify("WARNING: size estimation for at least one of these sketches may be inaccurate. ANI values cannot be generated for these comparisons.")
     if jaccard_ani_untrustworthy:
         notify("WARNING: Jaccard estimation for at least one of these comparisons is likely inaccurate. Could not estimate ANI for these comparisons.")
-    if potential_false_negatives:
-        notify("WARNING: Some of these sketches may have no hashes in common based on chance alone (false negatives). Consider decreasing your scaled value to prevent this.")
 
 def categorize(args):
     "Use a database to find the best match to many signatures."
@@ -753,10 +748,6 @@ def gather(args):
                     if prefetch_csvout_w is None:
                         prefetch_csvout_w = prefetch_result.init_dictwriter(prefetch_csvout_fp)
                     prefetch_result.write(prefetch_csvout_w)
-                    if prefetch_result.size_may_be_inaccurate:
-                        size_may_be_inaccurate = True
-                    if prefetch_result.potential_false_negative:
-                        potential_false_negatives = True
 
             counters.append(counter)
 
@@ -1292,9 +1283,9 @@ def prefetch(args):
                        end="\r")
 
             # keep track of inaccurate size estimation and potential false negatives
-            if result.size_may_be_inaccurate:
+            if not size_may_be_inaccurate and result.size_may_be_inaccurate:
                 size_may_be_inaccurate = True
-            if result.potential_false_negative:
+            if not potential_false_negatives and result.potential_false_negative:
                 potential_false_negatives = True
 
         did_a_search = True

--- a/src/sourmash/commands.py
+++ b/src/sourmash/commands.py
@@ -195,7 +195,7 @@ def compare(args):
                 w.writerow(y)
 
     if size_may_be_inaccurate:
-        notify("WARNING: size estimation for at least one of these sketches may be inaccurate. ANI values cannot be generated for these comparisons.")
+        notify("WARNING: size estimation for at least one of these sketches may be inaccurate. ANI values will be set to 0 for these comparisons.")
 
 
 def plot(args):

--- a/src/sourmash/commands.py
+++ b/src/sourmash/commands.py
@@ -580,7 +580,7 @@ def search(args):
         sourmash_args.report_picklist(args, picklist)
 
     if size_may_be_inaccurate:
-        notify("WARNING: size estimation for at least one of these sketches may be inaccurate. ANI values cannot be generated for these comparisons.")
+        notify("WARNING: size estimation for at least one of these sketches may be inaccurate. ANI values will not be reported for these comparisons.")
     if jaccard_ani_untrustworthy:
         notify("WARNING: Jaccard estimation for at least one of these comparisons is likely inaccurate. Could not estimate ANI for these comparisons.")
 
@@ -868,7 +868,7 @@ def gather(args):
         sourmash_args.report_picklist(args, picklist)
 
     if size_may_be_inaccurate:
-        notify("WARNING: size estimation for at least one of these sketches may be inaccurate. ANI values cannot be generated for these comparisons.")
+        notify("WARNING: size estimation for at least one of these sketches may be inaccurate. ANI values will not be reported for these comparisons.")
     # DONE w/gather function.
 
 
@@ -1042,7 +1042,7 @@ def multigather(args):
         # fini, next query!
     notify(f'\nconducted gather searches on {n} signatures')
     if size_may_be_inaccurate:
-        notify("WARNING: size estimation for at least one of these sketches may be inaccurate. ANI values cannot be generated for these comparisons.")
+        notify("WARNING: size estimation for at least one of these sketches may be inaccurate. ANI values will not be reported for these comparisons.")
 
 
 def watch(args):
@@ -1339,6 +1339,6 @@ def prefetch(args):
         sourmash_args.report_picklist(args, picklist)
 
     if size_may_be_inaccurate:
-        notify("WARNING: size estimation for at least one of these sketches may be inaccurate. ANI values cannot be generated for these comparisons.")
+        notify("WARNING: size estimation for at least one of these sketches may be inaccurate. ANI values will not be reported for these comparisons.")
 
     return 0

--- a/src/sourmash/distance_utils.py
+++ b/src/sourmash/distance_utils.py
@@ -79,10 +79,10 @@ class jaccardANIResult(ANIResult):
     def ani(self):
         # if jaccard error is too high (exceeds threshold), do not trust ANI estimate
         if self.je_exceeds_threshold or self.size_is_inaccurate:
-            if self.size_is_inaccurate:
-                notify("WARNING: Cannot estimate ANI because size estimation for at least one of these sketches may be inaccurate.")
-            if self.je_exceeds_threshold:
-                notify("WARNING: Cannot estimate ANI because jaccard estimation for these sketches is inaccurate.")
+#            if self.size_is_inaccurate:
+#                notify("WARNING: Cannot estimate ANI because size estimation for at least one of these sketches may be inaccurate.")
+#            if self.je_exceeds_threshold:
+#                notify("WARNING: Cannot estimate ANI because jaccard estimation for these sketches is inaccurate.")
             return None
         return 1 - self.dist
 

--- a/src/sourmash/distance_utils.py
+++ b/src/sourmash/distance_utils.py
@@ -25,14 +25,12 @@ def check_prob_threshold(val, threshold=1e-3):
     """
     exceeds_threshold = False
     if threshold is not None and val > threshold:
-#        notify("WARNING: These sketches may have no hashes in common based on chance alone.")
         exceeds_threshold = True
     return val, exceeds_threshold
 
 def check_jaccard_error(val, threshold=1e-4):
     exceeds_threshold = False
     if threshold is not None and val > threshold:
-#        notify(f"WARNING: Error on Jaccard distance point estimate is too high ({val :.4f}).")
         exceeds_threshold = True
     return val, exceeds_threshold
 
@@ -79,10 +77,6 @@ class jaccardANIResult(ANIResult):
     def ani(self):
         # if jaccard error is too high (exceeds threshold), do not trust ANI estimate
         if self.je_exceeds_threshold or self.size_is_inaccurate:
-#            if self.size_is_inaccurate:
-#                notify("WARNING: Cannot estimate ANI because size estimation for at least one of these sketches may be inaccurate.")
-#            if self.je_exceeds_threshold:
-#                notify("WARNING: Cannot estimate ANI because jaccard estimation for these sketches is inaccurate.")
             return None
         return 1 - self.dist
 

--- a/src/sourmash/distance_utils.py
+++ b/src/sourmash/distance_utils.py
@@ -25,14 +25,14 @@ def check_prob_threshold(val, threshold=1e-3):
     """
     exceeds_threshold = False
     if threshold is not None and val > threshold:
-        notify("WARNING: These sketches may have no hashes in common based on chance alone.")
+#        notify("WARNING: These sketches may have no hashes in common based on chance alone.")
         exceeds_threshold = True
     return val, exceeds_threshold
 
 def check_jaccard_error(val, threshold=1e-4):
     exceeds_threshold = False
     if threshold is not None and val > threshold:
-        notify(f"WARNING: Error on Jaccard distance point estimate is too high ({val :.4f}).")
+#        notify(f"WARNING: Error on Jaccard distance point estimate is too high ({val :.4f}).")
         exceeds_threshold = True
     return val, exceeds_threshold
 

--- a/src/sourmash/distance_utils.py
+++ b/src/sourmash/distance_utils.py
@@ -56,7 +56,6 @@ class ANIResult:
     @property
     def ani(self):
         if self.size_is_inaccurate:
-            notify("WARNING: Cannot estimate ANI because size estimation for at least one of these sketches may be inaccurate.")
             return None
         return 1 - self.dist
 

--- a/src/sourmash/minhash.py
+++ b/src/sourmash/minhash.py
@@ -711,8 +711,6 @@ class MinHash(RustObject):
             raise TypeError("can only calculate containment for scaled MinHashes")
         if not len(self):
             return 0.0
-        #if not self.size_is_accurate() or not other.size_is_accurate():
-        #    notify("WARNING: size estimation for at least one of these sketches may be inaccurate.")
         return self.count_common(other, downsample) / len(self)
         # with bias factor
         #return self.count_common(other, downsample) / (len(self) * (1- (1-1/self.scaled)^(len(self)*self.scaled)))

--- a/src/sourmash/minhash.py
+++ b/src/sourmash/minhash.py
@@ -711,8 +711,8 @@ class MinHash(RustObject):
             raise TypeError("can only calculate containment for scaled MinHashes")
         if not len(self):
             return 0.0
-        if not self.size_is_accurate() or not other.size_is_accurate():
-            notify("WARNING: size estimation for at least one of these sketches may be inaccurate.")
+        #if not self.size_is_accurate() or not other.size_is_accurate():
+        #    notify("WARNING: size estimation for at least one of these sketches may be inaccurate.")
         return self.count_common(other, downsample) / len(self)
         # with bias factor
         #return self.count_common(other, downsample) / (len(self) * (1- (1-1/self.scaled)^(len(self)*self.scaled)))
@@ -949,6 +949,8 @@ class MinHash(RustObject):
         bounds are used.
         Returns True if probability is greater than or equal to the desired confidence.
         """
+        if not self.scaled:
+            raise TypeError("Error: can only estimate dataset size for scaled MinHashes")
         if any([not (0 <= relative_error <= 1), not (0 <= confidence <= 1)]):
             raise ValueError("Error: relative error and confidence values must be between 0 and 1.")
         # to do: replace unique_dataset_hashes with HLL estimation when it gets implemented 

--- a/src/sourmash/search.py
+++ b/src/sourmash/search.py
@@ -192,12 +192,14 @@ class BaseResult:
         self.cmp_scaled = self.cmp.cmp_scaled
         self.query_scaled = self.mh1.scaled
         self.match_scaled = self.mh2.scaled
+        self.size_may_be_inaccurate = self.cmp.size_may_be_inaccurate
 
     def build_numminhashcomparison(self, cmp_num=None):
         self.cmp = NumMinHashComparison(self.mh1, self.mh2, cmp_num=cmp_num, ignore_abundance=self.ignore_abundance)
         self.cmp_num = self.cmp.cmp_num
         self.query_num = self.mh1.num
         self.match_num = self.mh2.num
+        self.size_may_be_inaccurate = self.cmp.size_may_be_inaccurate
 
     def get_cmpinfo(self):
         # grab signature /minhash metadata

--- a/src/sourmash/search.py
+++ b/src/sourmash/search.py
@@ -322,6 +322,7 @@ class SearchResult(BaseResult):
                 self.ani_high = self.cmp.max_containment_ani_high
         elif self.searchtype == SearchType.JACCARD:
             self.cmp.estimate_jaccard_ani(jaccard=self.similarity)
+            self.jaccard_ani_untrustworthy = self.cmp.jaccard_ani_untrustworthy
             self.ani = self.cmp.jaccard_ani
         # this can be set from any of the above
         self.potential_false_negative = self.cmp.potential_false_negative

--- a/src/sourmash/search.py
+++ b/src/sourmash/search.py
@@ -178,6 +178,7 @@ class BaseResult:
     threshold_bp: int = None
     cmp_scaled: int = None
     write_cols: list = None
+    potential_false_negative: bool = False
 
     def init_result(self):
         self.mh1 = self.query.minhash

--- a/src/sourmash/sketchcomparison.py
+++ b/src/sourmash/sketchcomparison.py
@@ -183,8 +183,13 @@ class FracMinHashComparison(BaseMinHashComparison):
 
     @property
     def avg_containment_ani(self):
-        "Returns single average_containment_ani value."
-        return self.mh1_cmp.avg_containment_ani(self.mh2_cmp)
+        "Returns single average_containment_ani value. Sets self.potential_false_negative internally."
+        self.estimate_mh1_containment_ani()
+        self.estimate_mh2_containment_ani()
+        if any([self.mh1_containment_ani is None, self.mh2_containment_ani is None]):
+            return None
+        else:
+            return (self.mh1_containment_ani + self.mh2_containment_ani)/2
 
     def estimate_all_containment_ani(self):
         "Estimate all containment ANI values."

--- a/src/sourmash/sketchcomparison.py
+++ b/src/sourmash/sketchcomparison.py
@@ -68,8 +68,7 @@ class BaseMinHashComparison:
     @property
     def cosine_similarity(self):
         return self.angular_similarity
-
-
+    
 @dataclass
 class NumMinHashComparison(BaseMinHashComparison):
     """Class for standard comparison between two num minhashes"""
@@ -80,6 +79,10 @@ class NumMinHashComparison(BaseMinHashComparison):
         if self.cmp_num is None: # record the num we're doing this comparison on
             self.cmp_num = min(self.mh1.num, self.mh2.num)
         self.check_compatibility_and_downsample(cmp_num=self.cmp_num)
+
+    @property
+    def size_may_be_inaccurate(self):
+        return False # not using size estimation, can ignore
 
 @dataclass
 class FracMinHashComparison(BaseMinHashComparison):
@@ -101,6 +104,14 @@ class FracMinHashComparison(BaseMinHashComparison):
     @property
     def pass_threshold(self):
         return self.total_unique_intersect_hashes >= self.threshold_bp
+
+    @property
+    def size_may_be_inaccurate(self):
+        # if either size estimation may be inaccurate
+        # NOTE: do we want to do this at original scaled instead?
+        if not self.mh1_cmp.size_is_accurate() or not self.mh2_cmp.size_is_accurate():
+            return True
+        return False
 
     @property
     def total_unique_intersect_hashes(self):

--- a/src/sourmash/sketchcomparison.py
+++ b/src/sourmash/sketchcomparison.py
@@ -12,6 +12,7 @@ class BaseMinHashComparison:
     mh1: MinHash
     mh2: MinHash
     ignore_abundance: bool = False # optionally ignore abundances
+    jaccard_ani_untrustworthy: bool = False
 
     def downsample_and_handle_ignore_abundance(self, cmp_num=None, cmp_scaled=None):
         """

--- a/tests/test_minhash.py
+++ b/tests/test_minhash.py
@@ -3093,3 +3093,13 @@ def test_minhash_ani_inaccurate_size_est():
     print(m2_ca_m3)
     assert round(m2_ca_m3.ani,3) == 0.987
     assert m2_ca_m3.size_is_inaccurate == False
+
+
+def test_size_num_fail():
+    f1 = utils.get_test_data('num/47.fa.sig')
+    mh1 = sourmash.load_one_signature(f1, ksize=31).minhash
+
+    with pytest.raises(TypeError) as exc:
+        mh1.size_is_accurate()
+    print(str(exc))
+    assert "Error: can only estimate dataset size for scaled MinHashes" in str(exc)

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -5441,7 +5441,7 @@ def test_search_ani_jaccard_error_too_high(c):
         assert row['ani'] == ''
 
     assert "WARNING: Jaccard estimation for at least one of these comparisons is likely inaccurate. Could not estimate ANI for these comparisons." in c.last_result.err
-    assert "WARNING: size estimation for at least one of these sketches may be inaccurate. ANI values cannot be generated for these comparisons." in c.last_result.err
+    assert "WARNING: size estimation for at least one of these sketches may be inaccurate. ANI values will not be reported for these comparisons." in c.last_result.err
 
 
 @utils.in_tempdir
@@ -5533,7 +5533,7 @@ def test_search_ani_containment_fail(c):
         assert float(row['similarity']) == 0.9556701030927836 
         assert row['ani'] == ""
 
-    assert "WARNING: size estimation for at least one of these sketches may be inaccurate. ANI values cannot be generated for these comparisons." in c.last_result.err
+    assert "WARNING: size estimation for at least one of these sketches may be inaccurate. ANI values will not be reported for these comparisons." in c.last_result.err
     
 
 @utils.in_tempdir

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -5819,6 +5819,11 @@ def test_compare_containment_ani(c):
 
                 assert containment_ani == mat_val #, (i, j)
 
+    print(c.last_result.err)
+    print(c.last_result.out)
+    assert "WARNING: Some of these sketches may have no hashes in common based on chance alone (false negatives). Consider decreasing your scaled value to prevent this." in c.last_result.err
+    assert "WARNING: size estimation for at least one of these sketches may be inaccurate. ANI values cannot be generated for these comparisons." in c.last_result.err
+
 
 @utils.in_tempdir
 def test_compare_jaccard_ani(c):
@@ -5867,6 +5872,11 @@ def test_compare_jaccard_ani(c):
 
                 assert jaccard_ani == mat_val #, (i, j)
 
+    print(c.last_result.err)
+    print(c.last_result.out)
+    assert "WARNING: Some of these sketches may have no hashes in common based on chance alone (false negatives). Consider decreasing your scaled value to prevent this." in c.last_result.err
+    assert "WARNING: size estimation for at least one of these sketches may be inaccurate. ANI values cannot be generated for these comparisons." in c.last_result.err
+
 
 @utils.in_tempdir
 def test_compare_max_containment_ani(c):
@@ -5914,6 +5924,11 @@ def test_compare_max_containment_ani(c):
 
                 assert containment_ani == mat_val, (i, j)
 
+    print(c.last_result.err)
+    print(c.last_result.out)
+    assert "WARNING: Some of these sketches may have no hashes in common based on chance alone (false negatives). Consider decreasing your scaled value to prevent this." in c.last_result.err
+    assert "WARNING: size estimation for at least one of these sketches may be inaccurate. ANI values cannot be generated for these comparisons." in c.last_result.err
+
 
 @utils.in_tempdir
 def test_compare_avg_containment_ani(c):
@@ -5960,6 +5975,11 @@ def test_compare_avg_containment_ani(c):
                     containment_ani = 0.0
 
                 assert containment_ani == mat_val, (i, j)
+
+    print(c.last_result.err)
+    print(c.last_result.out)
+    assert "WARNING: Some of these sketches may have no hashes in common based on chance alone (false negatives). Consider decreasing your scaled value to prevent this." in c.last_result.err
+    assert "WARNING: size estimation for at least one of these sketches may be inaccurate. ANI values cannot be generated for these comparisons." in c.last_result.err
 
 
 @utils.in_tempdir

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -5440,6 +5440,9 @@ def test_search_ani_jaccard_error_too_high(c):
         #assert row['ani'] == "0.9987884602947684"
         assert row['ani'] == ''
 
+    assert "WARNING: Jaccard estimation for at least one of these comparisons is likely inaccurate. Could not estimate ANI for these comparisons." in c.last_result.err
+    assert "WARNING: size estimation for at least one of these sketches may be inaccurate. ANI values cannot be generated for these comparisons." in c.last_result.err
+
 
 @utils.in_tempdir
 def test_searchabund_no_ani(c):
@@ -5529,6 +5532,8 @@ def test_search_ani_containment_fail(c):
         assert search_result_names == list(row.keys())
         assert float(row['similarity']) == 0.9556701030927836 
         assert row['ani'] == ""
+
+    assert "WARNING: size estimation for at least one of these sketches may be inaccurate. ANI values cannot be generated for these comparisons." in c.last_result.err
     
 
 @utils.in_tempdir

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -5827,7 +5827,7 @@ def test_compare_containment_ani(c):
     print(c.last_result.err)
     print(c.last_result.out)
     assert "WARNING: Some of these sketches may have no hashes in common based on chance alone (false negatives). Consider decreasing your scaled value to prevent this." in c.last_result.err
-    assert "WARNING: size estimation for at least one of these sketches may be inaccurate. ANI values cannot be generated for these comparisons." in c.last_result.err
+    assert "WARNING: size estimation for at least one of these sketches may be inaccurate. ANI values will be set to 0 for these comparisons." in c.last_result.err
 
 
 @utils.in_tempdir
@@ -5880,7 +5880,7 @@ def test_compare_jaccard_ani(c):
     print(c.last_result.err)
     print(c.last_result.out)
     assert "WARNING: Some of these sketches may have no hashes in common based on chance alone (false negatives). Consider decreasing your scaled value to prevent this." in c.last_result.err
-    assert "WARNING: size estimation for at least one of these sketches may be inaccurate. ANI values cannot be generated for these comparisons." in c.last_result.err
+    assert "WARNING: size estimation for at least one of these sketches may be inaccurate. ANI values will be set to 0 for these comparisons." in c.last_result.err
 
 
 @utils.in_tempdir
@@ -5937,7 +5937,7 @@ def test_compare_jaccard_ani_jaccard_error_too_high(c):
 
 
     assert "WARNING: Jaccard estimation for at least one of these comparisons is likely inaccurate. Could not estimate ANI for these comparisons." in c.last_result.err
-    assert "WARNING: size estimation for at least one of these sketches may be inaccurate. ANI values cannot be generated for these comparisons." in c.last_result.err
+    assert "WARNING: size estimation for at least one of these sketches may be inaccurate. ANI values will be set to 0 for these comparisons." in c.last_result.err
 
 
 @utils.in_tempdir
@@ -5989,7 +5989,7 @@ def test_compare_max_containment_ani(c):
     print(c.last_result.err)
     print(c.last_result.out)
     assert "WARNING: Some of these sketches may have no hashes in common based on chance alone (false negatives). Consider decreasing your scaled value to prevent this." in c.last_result.err
-    assert "WARNING: size estimation for at least one of these sketches may be inaccurate. ANI values cannot be generated for these comparisons." in c.last_result.err
+    assert "WARNING: size estimation for at least one of these sketches may be inaccurate. ANI values will be set to 0 for these comparisons." in c.last_result.err
 
 
 @utils.in_tempdir
@@ -6041,7 +6041,7 @@ def test_compare_avg_containment_ani(c):
     print(c.last_result.err)
     print(c.last_result.out)
     assert "WARNING: Some of these sketches may have no hashes in common based on chance alone (false negatives). Consider decreasing your scaled value to prevent this." in c.last_result.err
-    assert "WARNING: size estimation for at least one of these sketches may be inaccurate. ANI values cannot be generated for these comparisons." in c.last_result.err
+    assert "WARNING: size estimation for at least one of these sketches may be inaccurate. ANI values will be set to 0 for these comparisons." in c.last_result.err
 
 
 @utils.in_tempdir

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -5530,8 +5530,6 @@ def test_search_ani_containment_fail(c):
         assert float(row['similarity']) == 0.9556701030927836 
         assert row['ani'] == ""
     
-    assert "WARNING: Cannot estimate ANI because size estimation for at least one of these sketches may be inaccurate." in c.last_result.err
-
 
 @utils.in_tempdir
 def test_search_ani_containment_estimate_ci(c):


### PR DESCRIPTION
addresses #2058 by emitting fewer warnings.

- remove size accuracy warning during containment estimation
- for size accuracy and "jaccard error too high", warn at end in:
    - [x] `search`
    - [x] `prefetch`
    - [x] gather
    - [x] multigather
    - [x] compare
    - [x] add tests

Notes and Questions:
- I've removed the warnings from the underlying functions, so no warnings will show up when using the python api functions. There are ways to check these for each comparison in the python API, so maybe we should just recommend those for any folks getting ANI from the python API.
- For size accuracy and jaccard error, we now warn at the end of `compare`/`search`/`prefetch`/`gather` if there were any issues. For these, we do not currently have output columns for these properties, so if users get this warning, there will be no way to know _which_ of the comparisons generated the issue, other than the fact that ANI will not be estimated for these comparisons (ANI gets zeroed for both size accuracy and jaccard error issues).
- `potential false negatives` are a bit different. We now warn at the end of `compare` if there are any potential false negatives. But most of the time, this won't work for `search` because if there are no hashes in common, there will just be no match found during initial search, so a `SearchResult`/`PrefetchResult` etc will never be generated. I do currently store this as a property in `*Result`, but haven't figured out test data to get a `True` value out of it, so maybe this should not be included? Perhaps this is the situation where we want to warn immediately upon comparison, since it will mostly show up when the scaled value is too high/query sketch is too small?