### PR TITLE
[MRG] remove unnecessary `object` from `class` definitions

### DIFF
--- a/src/sourmash/command_compute.py
+++ b/src/sourmash/command_compute.py
@@ -130,7 +130,7 @@ def compute(args):
         _compute_individual(args, signatures_factory)
 
 
-class _signatures_for_compute_factory(object):
+class _signatures_for_compute_factory():
     "Build signatures on demand, based on args input to 'compute'."
     def __init__(self, args):
         self.args = args

--- a/src/sourmash/command_compute.py
+++ b/src/sourmash/command_compute.py
@@ -130,7 +130,7 @@ def compute(args):
         _compute_individual(args, signatures_factory)
 
 
-class _signatures_for_compute_factory():
+class _signatures_for_compute_factory:
     "Build signatures on demand, based on args input to 'compute'."
     def __init__(self, args):
         self.args = args
@@ -192,17 +192,17 @@ def _compute_individual(args, signatures_factory):
 
             # open output for signatures
             if open_output_each_time:
-                save_sigs.open()
+                save_sigs.open
             # or... is this the first time to write something to args.output?
             elif first_file_for_output:
                 save_sigs = sourmash_args.SaveSignaturesToLocation(args.output)
-                save_sigs.open()
+                save_sigs.open
                 first_file_for_output = False
 
             # make a new signature for each sequence?
             if args.singleton:
                 for n, record in enumerate(screed_iter):
-                    sigs = signatures_factory()
+                    sigs = signatures_factory
                     try:
                         add_seq(sigs, record.sequence,
                                 args.input_is_protein, args.check_sequence)
@@ -219,7 +219,7 @@ def _compute_individual(args, signatures_factory):
 
             # nope; make a single sig for the whole file
             else:
-                sigs = signatures_factory()
+                sigs = signatures_factory
 
                 # consume & calculate signatures
                 notify(f'... reading sequences from {filename}')
@@ -248,7 +248,7 @@ def _compute_individual(args, signatures_factory):
 
         # if not args.output, close output for every input filename.
         if open_output_each_time:
-            save_sigs.close()
+            save_sigs.close
             notify(f"saved {len(save_sigs)} signature(s) to '{save_sigs.location}'. Note: signature license is CC0.")
             save_sigs = None
 
@@ -256,13 +256,13 @@ def _compute_individual(args, signatures_factory):
     # if --output-dir specified, all collected signatures => args.output,
     # and we need to close here.
     if args.output and save_sigs is not None:
-        save_sigs.close()
+        save_sigs.close
         notify(f"saved {len(save_sigs)} signature(s) to '{save_sigs.location}'. Note: signature license is CC0.")
 
 
 def _compute_merged(args, signatures_factory):
     # make a signature for the whole file
-    sigs = signatures_factory()
+    sigs = signatures_factory
 
     total_seq = 0
     for filename in args.filenames:
@@ -342,7 +342,7 @@ class ComputeParameters(RustObject):
                  num_hashes=500,
                  track_abundance=False,
                  scaled=0):
-        self._objptr = lib.computeparams_new()
+        self._objptr = lib.computeparams_new
 
         self.seed = seed
         self.ksizes = ksizes
@@ -442,10 +442,10 @@ class ComputeParameters(RustObject):
 
     @staticmethod
     def from_args(args):
-        ptr = lib.computeparams_new()
+        ptr = lib.computeparams_new
         ret = ComputeParameters._from_objptr(ptr)
 
-        for arg, value in vars(args).items():
+        for arg, value in vars(args).items:
             try:
                 getattr(type(ret), arg).fset(ret, value)
             except AttributeError:

--- a/src/sourmash/command_compute.py
+++ b/src/sourmash/command_compute.py
@@ -130,7 +130,7 @@ def compute(args):
         _compute_individual(args, signatures_factory)
 
 
-class _signatures_for_compute_factory():
+class _signatures_for_compute_factory:
     "Build signatures on demand, based on args input to 'compute'."
     def __init__(self, args):
         self.args = args

--- a/src/sourmash/command_compute.py
+++ b/src/sourmash/command_compute.py
@@ -130,7 +130,7 @@ def compute(args):
         _compute_individual(args, signatures_factory)
 
 
-class _signatures_for_compute_factory:
+class _signatures_for_compute_factory():
     "Build signatures on demand, based on args input to 'compute'."
     def __init__(self, args):
         self.args = args
@@ -192,17 +192,17 @@ def _compute_individual(args, signatures_factory):
 
             # open output for signatures
             if open_output_each_time:
-                save_sigs.open
+                save_sigs.open()
             # or... is this the first time to write something to args.output?
             elif first_file_for_output:
                 save_sigs = sourmash_args.SaveSignaturesToLocation(args.output)
-                save_sigs.open
+                save_sigs.open()
                 first_file_for_output = False
 
             # make a new signature for each sequence?
             if args.singleton:
                 for n, record in enumerate(screed_iter):
-                    sigs = signatures_factory
+                    sigs = signatures_factory()
                     try:
                         add_seq(sigs, record.sequence,
                                 args.input_is_protein, args.check_sequence)
@@ -219,7 +219,7 @@ def _compute_individual(args, signatures_factory):
 
             # nope; make a single sig for the whole file
             else:
-                sigs = signatures_factory
+                sigs = signatures_factory()
 
                 # consume & calculate signatures
                 notify(f'... reading sequences from {filename}')
@@ -248,7 +248,7 @@ def _compute_individual(args, signatures_factory):
 
         # if not args.output, close output for every input filename.
         if open_output_each_time:
-            save_sigs.close
+            save_sigs.close()
             notify(f"saved {len(save_sigs)} signature(s) to '{save_sigs.location}'. Note: signature license is CC0.")
             save_sigs = None
 
@@ -256,13 +256,13 @@ def _compute_individual(args, signatures_factory):
     # if --output-dir specified, all collected signatures => args.output,
     # and we need to close here.
     if args.output and save_sigs is not None:
-        save_sigs.close
+        save_sigs.close()
         notify(f"saved {len(save_sigs)} signature(s) to '{save_sigs.location}'. Note: signature license is CC0.")
 
 
 def _compute_merged(args, signatures_factory):
     # make a signature for the whole file
-    sigs = signatures_factory
+    sigs = signatures_factory()
 
     total_seq = 0
     for filename in args.filenames:
@@ -342,7 +342,7 @@ class ComputeParameters(RustObject):
                  num_hashes=500,
                  track_abundance=False,
                  scaled=0):
-        self._objptr = lib.computeparams_new
+        self._objptr = lib.computeparams_new()
 
         self.seed = seed
         self.ksizes = ksizes
@@ -442,10 +442,10 @@ class ComputeParameters(RustObject):
 
     @staticmethod
     def from_args(args):
-        ptr = lib.computeparams_new
+        ptr = lib.computeparams_new()
         ret = ComputeParameters._from_objptr(ptr)
 
-        for arg, value in vars(args).items:
+        for arg, value in vars(args).items():
             try:
                 getattr(type(ret), arg).fset(ret, value)
             except AttributeError:

--- a/src/sourmash/command_sketch.py
+++ b/src/sourmash/command_sketch.py
@@ -85,12 +85,12 @@ def _parse_params_str(params_str):
     return moltype, params
 
 
-class _signatures_for_sketch_factory:
+class _signatures_for_sketch_factory():
     "Build sigs on demand, based on args input to 'sketch'."
     def __init__(self, params_str_list, default_moltype):
         # first, set up defaults per-moltype
         defaults = {}
-        for moltype, pstr in DEFAULTS.items:
+        for moltype, pstr in DEFAULTS.items():
             mt, d = _parse_params_str(pstr)
             assert mt is None             # defaults cannot have moltype set!
             defaults[moltype] = d
@@ -301,9 +301,9 @@ def translate(args):
 def _compute_sigs(to_build, output, *, check_sequence=False):
     "actually build the signatures in 'to_build' and output them to 'output'"
     save_sigs = sourmash_args.SaveSignaturesToLocation(output)
-    save_sigs.open
+    save_sigs.open()
 
-    for (name, filename), param_objs in to_build.items:
+    for (name, filename), param_objs in to_build.items():
         assert param_objs
 
         # now, set up to iterate over sequences.
@@ -347,7 +347,7 @@ def _compute_sigs(to_build, output, *, check_sequence=False):
             notify(f'calculated {len(sigs)} signatures for {n+1} sequences in {filename}')
 
 
-    save_sigs.close
+    save_sigs.close()
     notify(f"saved {len(save_sigs)} signature(s) to '{save_sigs.location}'. Note: signature license is CC0.")
 
 
@@ -358,10 +358,10 @@ def _output_csv_info(filename, sigs_to_build):
         w = csv.DictWriter(csv_fp, fieldnames=['filename', 'sketchtype',
                                                'output_index', 'name',
                                                'param_strs'])
-        w.writeheader
+        w.writeheader()
 
         output_n = 0
-        for (name, filename), param_objs in sigs_to_build.items:
+        for (name, filename), param_objs in sigs_to_build.items():
             param_strs = []
 
             # should all be the same!
@@ -373,7 +373,7 @@ def _output_csv_info(filename, sigs_to_build):
                 sketchtype = "protein"
 
             for p in param_objs:
-                param_strs.append(p.to_param_str)
+                param_strs.append(p.to_param_str())
 
             row = dict(filename=filename, sketchtype=sketchtype,
                        param_strs="-p " + " -p ".join(param_strs),
@@ -492,7 +492,7 @@ def fromfile(args):
     total_sigs = 0
     missing = defaultdict(list)
     missing_count = 0
-    for name, (genome, proteome) in all_names.items:
+    for name, (genome, proteome) in all_names.items():
         plist = already_done.get(name, [])
 
         # check list of already done against build parameters
@@ -562,9 +562,9 @@ def fromfile(args):
     print_results('---')
     print_results("summary of sketches to build:")
 
-    counter = Counter
+    counter = Counter()
     build_info_d = {}
-    for filename, param_objs in to_build.items:
+    for filename, param_objs in to_build.items():
         for p in param_objs:
             moltype = p.moltype
             assert len(p.ksizes) == 1
@@ -576,7 +576,7 @@ def fromfile(args):
                               abund=p.track_abundance)
             counter[ski] += 1
 
-    for ski, count in counter.items:
+    for ski, count in counter.items():
         mh_type = f"num={ski.num}" if ski.num else f"scaled={ski.scaled}"
         mh_abund = ", abund" if ski.abund else ""
 

--- a/src/sourmash/command_sketch.py
+++ b/src/sourmash/command_sketch.py
@@ -85,7 +85,7 @@ def _parse_params_str(params_str):
     return moltype, params
 
 
-class _signatures_for_sketch_factory(object):
+class _signatures_for_sketch_factory():
     "Build sigs on demand, based on args input to 'sketch'."
     def __init__(self, params_str_list, default_moltype):
         # first, set up defaults per-moltype

--- a/src/sourmash/command_sketch.py
+++ b/src/sourmash/command_sketch.py
@@ -85,7 +85,7 @@ def _parse_params_str(params_str):
     return moltype, params
 
 
-class _signatures_for_sketch_factory():
+class _signatures_for_sketch_factory:
     "Build sigs on demand, based on args input to 'sketch'."
     def __init__(self, params_str_list, default_moltype):
         # first, set up defaults per-moltype

--- a/src/sourmash/command_sketch.py
+++ b/src/sourmash/command_sketch.py
@@ -85,12 +85,12 @@ def _parse_params_str(params_str):
     return moltype, params
 
 
-class _signatures_for_sketch_factory():
+class _signatures_for_sketch_factory:
     "Build sigs on demand, based on args input to 'sketch'."
     def __init__(self, params_str_list, default_moltype):
         # first, set up defaults per-moltype
         defaults = {}
-        for moltype, pstr in DEFAULTS.items():
+        for moltype, pstr in DEFAULTS.items:
             mt, d = _parse_params_str(pstr)
             assert mt is None             # defaults cannot have moltype set!
             defaults[moltype] = d
@@ -301,9 +301,9 @@ def translate(args):
 def _compute_sigs(to_build, output, *, check_sequence=False):
     "actually build the signatures in 'to_build' and output them to 'output'"
     save_sigs = sourmash_args.SaveSignaturesToLocation(output)
-    save_sigs.open()
+    save_sigs.open
 
-    for (name, filename), param_objs in to_build.items():
+    for (name, filename), param_objs in to_build.items:
         assert param_objs
 
         # now, set up to iterate over sequences.
@@ -347,7 +347,7 @@ def _compute_sigs(to_build, output, *, check_sequence=False):
             notify(f'calculated {len(sigs)} signatures for {n+1} sequences in {filename}')
 
 
-    save_sigs.close()
+    save_sigs.close
     notify(f"saved {len(save_sigs)} signature(s) to '{save_sigs.location}'. Note: signature license is CC0.")
 
 
@@ -358,10 +358,10 @@ def _output_csv_info(filename, sigs_to_build):
         w = csv.DictWriter(csv_fp, fieldnames=['filename', 'sketchtype',
                                                'output_index', 'name',
                                                'param_strs'])
-        w.writeheader()
+        w.writeheader
 
         output_n = 0
-        for (name, filename), param_objs in sigs_to_build.items():
+        for (name, filename), param_objs in sigs_to_build.items:
             param_strs = []
 
             # should all be the same!
@@ -373,7 +373,7 @@ def _output_csv_info(filename, sigs_to_build):
                 sketchtype = "protein"
 
             for p in param_objs:
-                param_strs.append(p.to_param_str())
+                param_strs.append(p.to_param_str)
 
             row = dict(filename=filename, sketchtype=sketchtype,
                        param_strs="-p " + " -p ".join(param_strs),
@@ -492,7 +492,7 @@ def fromfile(args):
     total_sigs = 0
     missing = defaultdict(list)
     missing_count = 0
-    for name, (genome, proteome) in all_names.items():
+    for name, (genome, proteome) in all_names.items:
         plist = already_done.get(name, [])
 
         # check list of already done against build parameters
@@ -562,9 +562,9 @@ def fromfile(args):
     print_results('---')
     print_results("summary of sketches to build:")
 
-    counter = Counter()
+    counter = Counter
     build_info_d = {}
-    for filename, param_objs in to_build.items():
+    for filename, param_objs in to_build.items:
         for p in param_objs:
             moltype = p.moltype
             assert len(p.ksizes) == 1
@@ -576,7 +576,7 @@ def fromfile(args):
                               abund=p.track_abundance)
             counter[ski] += 1
 
-    for ski, count in counter.items():
+    for ski, count in counter.items:
         mh_type = f"num={ski.num}" if ski.num else f"scaled={ski.scaled}"
         mh_abund = ", abund" if ski.abund else ""
 

--- a/src/sourmash/sbt.py
+++ b/src/sourmash/sbt.py
@@ -36,7 +36,7 @@ STORAGES = {
 NodePos = namedtuple("NodePos", ["pos", "node"])
 
 
-class GraphFactory():
+class GraphFactory:
     """Build new nodegraphs (Bloom filters) of a specific (fixed) size.
 
     Parameters
@@ -62,7 +62,7 @@ class GraphFactory():
 
 
 class _NodesCache(Cache):
-    """A cache for SBT nodes that calls .unload() when the node is removed from cache.
+    """A cache for SBT nodes that calls .unload when the node is removed from cache.
 
     This is adapted from the LFU cache in https://github.com/tkem/cachetools,
     but removing the largest node ids first (those near the bottom/leaves of
@@ -71,7 +71,7 @@ class _NodesCache(Cache):
 
     def __init__(self, maxsize, getsizeof=None):
         Cache.__init__(self, maxsize, getsizeof)
-        self.__counter = Counter()
+        self.__counter = Counter
 
     def __getitem__(self, key, cache_getitem=Cache.__getitem__):
         value = cache_getitem(self, key)
@@ -91,7 +91,7 @@ class _NodesCache(Cache):
         try:
             # Select least frequently used keys,
             # limit to 50 items to avoid dealing with huge lists
-            common = self.__counter.most_common()[:50]
+            common = self.__counter.most_common[:50]
 
             # common might include different values, so let's use
             # only keys that have the same value as the first one
@@ -107,7 +107,7 @@ class _NodesCache(Cache):
             raise KeyError(msg) from None
         else:
             value = self.pop(key)
-            value.unload()
+            value.unload
             return (key, value)
 
 
@@ -141,7 +141,7 @@ class SBT(Index):
     def __init__(self, factory, *, d=2, storage=None, cache_size=None):
         self.factory = factory
         self._nodes = {}
-        self._missing_nodes = set()
+        self._missing_nodes = set
         self._leaves = {}
         self.d = d
         self.next_node = 0
@@ -169,7 +169,7 @@ class SBT(Index):
             for picklist in self.picklists:
                 manifest = manifest.select_to_manifest(picklist=picklist)
 
-            for loc in manifest.locations():
+            for loc in manifest.locations:
                 buf = self.storage.load(loc)
                 # if more than one signature can be in a file, we need
                 # to recheck picklists here.
@@ -177,7 +177,7 @@ class SBT(Index):
                 yield ss
         else:
             # no manifest? iterate over all leaves.
-            for k in self.leaves():
+            for k in self.leaves:
                 ss = k.data
                 if passes_all_picklists(ss, self.picklists):
                     yield ss
@@ -187,7 +187,7 @@ class SBT(Index):
 
         Note: does not limit signatures to subsets.
         """
-        for k in self.leaves():
+        for k in self.leaves:
             ss = k.data
             yield ss, k._path
 
@@ -211,7 +211,7 @@ class SBT(Index):
           the scaled values differ.
         """
         # pull out a signature from this collection -
-        first_sig = next(iter(self.signatures()))
+        first_sig = next(iter(self.signatures))
         db_mh = first_sig.minhash
 
         # check ksize.
@@ -264,7 +264,7 @@ class SBT(Index):
             self.next_node = 2
             return 1
 
-        min_leaf = min(self._leaves.keys())
+        min_leaf = min(self._leaves.keys)
 
         next_internal_node = None
         if self.next_node <= min_leaf:
@@ -276,7 +276,7 @@ class SBT(Index):
                     break
 
         if next_internal_node is None:
-            self.next_node = max(self._leaves.keys()) + 1
+            self.next_node = max(self._leaves.keys) + 1
         else:
             self.next_node = next_internal_node
 
@@ -286,7 +286,7 @@ class SBT(Index):
         "Add a new SourmashSignature in to the SBT."
         from .sbtmh import SigLeaf
         
-        leaf = SigLeaf(signature.md5sum(), signature)
+        leaf = SigLeaf(signature.md5sum, signature)
         self.add_node(leaf)
 
     def add_node(self, node):
@@ -347,7 +347,7 @@ class SBT(Index):
 
         # initialize search queue with top node of tree
         matches = []
-        visited, queue = set(), [0]
+        visited, queue = set, [0]
 
         # while the queue is not empty, load each node and apply search
         # function.
@@ -388,7 +388,7 @@ class SBT(Index):
                             queue.extend(c.pos for c in self.children(node_p))
 
                 if unload_data:
-                    node_g.unload()
+                    node_g.unload
 
         return matches
 
@@ -409,7 +409,7 @@ class SBT(Index):
         query_mh = query.minhash
 
         # figure out downsampling using the first leaf in the tree --
-        a_leaf = next(iter(self.leaves()))
+        a_leaf = next(iter(self.leaves))
         tree_scaled = a_leaf.data.minhash.scaled
 
         # scaled?
@@ -461,7 +461,7 @@ class SBT(Index):
 
                 subj_mh = downsample_node(node.data.minhash)
                 subj_size = len(subj_mh)
-                subj_mh = subj_mh.flatten()
+                subj_mh = subj_mh.flatten
 
                 assert not subj_mh.track_abundance
 
@@ -633,7 +633,7 @@ class SBT(Index):
 
             # align the storage prefix with what we do for FSStorage, below.
             subdir = '.sbt.{}'.format(name)
-            storage_args = FSStorage("", subdir, make_dirs=False).init_args()
+            storage_args = FSStorage("", subdir, make_dirs=False).init_args
             storage.save(subdir + "/", b"")
             storage.subdir = subdir
             index_filename = os.path.abspath(path)
@@ -656,8 +656,8 @@ class SBT(Index):
                 storage = FSStorage(location, subdir)
                 index_filename = os.path.join(location, index_filename)
 
-            backend = [k for (k, v) in STORAGES.items() if v == type(storage)][0]
-            storage_args = storage.init_args()
+            backend = [k for (k, v) in STORAGES.items if v == type(storage)][0]
+            storage_args = storage.init_args
 
         info['storage'] = {
             'backend': backend,
@@ -665,7 +665,7 @@ class SBT(Index):
         }
         info['factory'] = {
             'class': GraphFactory.__name__,
-            'args': self.factory.init_args()
+            'args': self.factory.init_args
         }
 
         nodes = {}
@@ -680,7 +680,7 @@ class SBT(Index):
                 continue
 
             if isinstance(node, Node):
-                if random() - sparseness <= 0:
+                if random - sparseness <= 0:
                     continue
 
             data = {
@@ -743,9 +743,9 @@ class SBT(Index):
         manifest = CollectionManifest(manifest_rows)
         manifest_name = f"{name}.manifest.csv"
 
-        manifest_fp = StringIO()
+        manifest_fp = StringIO
         manifest.write_to_csv(manifest_fp, write_header=True)
-        manifest_data = manifest_fp.getvalue().encode("utf-8")
+        manifest_data = manifest_fp.getvalue.encode("utf-8")
 
         if kind == "Zip":
             manifest_name = os.path.join(storage.subdir, manifest_name)
@@ -767,7 +767,7 @@ class SBT(Index):
         if kind == "Zip":
             save_path = "{}.sbt.json".format(name)
             storage.save(save_path, tree_data, overwrite=True)
-            storage.flush()
+            storage.flush
         elif kind == "FS":
             storage.save(index_filename, tree_data, overwrite=True)
         else:
@@ -813,14 +813,14 @@ class SBT(Index):
                         storage = ZipStorage(location2)
 
         if storage:
-            sbts = storage.list_sbts()
+            sbts = storage.list_sbts
             if len(sbts) == 1:
                 tree_data = storage.load(sbts[0])
 
-                tempfile = NamedTemporaryFile()
+                tempfile = NamedTemporaryFile
 
                 tempfile.write(tree_data)
-                tempfile.flush()
+                tempfile.flush
 
                 dirname = os.path.dirname(tempfile.name)
                 sbt_name = os.path.basename(tempfile.name)
@@ -842,7 +842,7 @@ class SBT(Index):
             raise ValueError(str(exc))
 
         if tempfile is not None:
-            tempfile.close()
+            tempfile.close
 
         version = 1
         if isinstance(jnodes, Mapping):
@@ -863,7 +863,7 @@ class SBT(Index):
         try:
             loader = loaders[version]
         except KeyError:
-            raise IndexNotSupported()
+            raise IndexNotSupported
 
         #if version >= 6:
         #    if jnodes.get("index_type", "SBT") == "LocalizedSBT":
@@ -927,7 +927,7 @@ class SBT(Index):
 
     @classmethod
     def _load_v2(cls, info, leaf_loader, dirname, storage, *, print_version_warning=True, cache_size=None):
-        nodes = {int(k): v for (k, v) in info['nodes'].items()}
+        nodes = {int(k): v for (k, v) in info['nodes'].items}
 
         if nodes[0] is None:
             raise ValueError("Empty tree!")
@@ -939,7 +939,7 @@ class SBT(Index):
         k, size, ntables = extract_nodegraph_info(sample_bf)[:3]
         factory = GraphFactory(k, size, ntables)
 
-        for k, node in nodes.items():
+        for k, node in nodes.items:
             if node is None:
                 continue
 
@@ -961,7 +961,7 @@ class SBT(Index):
 
     @classmethod
     def _load_v3(cls, info, leaf_loader, dirname, storage, *, print_version_warning=True, cache_size=None):
-        nodes = {int(k): v for (k, v) in info['nodes'].items()}
+        nodes = {int(k): v for (k, v) in info['nodes'].items}
 
         if not nodes:
             raise ValueError("Empty tree!")
@@ -972,7 +972,7 @@ class SBT(Index):
         factory = GraphFactory(*info['factory']['args'])
 
         max_node = 0
-        for k, node in nodes.items():
+        for k, node in nodes.items:
             if node is None:
                 continue
 
@@ -996,13 +996,13 @@ class SBT(Index):
             error("WARNING: this is an old index version, please run `sourmash migrate` to update it.")
             error("WARNING: proceeding with execution, but it will take longer to finish!")
 
-        tree._fill_min_n_below()
+        tree._fill_min_n_below
 
         return tree
 
     @classmethod
     def _load_v4(cls, info, leaf_loader, dirname, storage, *, print_version_warning=True, cache_size=None):
-        nodes = {int(k): v for (k, v) in info['nodes'].items()}
+        nodes = {int(k): v for (k, v) in info['nodes'].items}
 
         if not nodes:
             raise ValueError("Empty tree!")
@@ -1013,7 +1013,7 @@ class SBT(Index):
         factory = GraphFactory(*info['factory']['args'])
 
         max_node = 0
-        for k, node in nodes.items():
+        for k, node in nodes.items:
             if 'internal' in node['name']:
                 node['factory'] = factory
                 sbt_node = Node.load(node, storage)
@@ -1036,8 +1036,8 @@ class SBT(Index):
 
     @classmethod
     def _load_v5(cls, info, leaf_loader, dirname, storage, *, print_version_warning=True, cache_size=None):
-        nodes = {int(k): v for (k, v) in info['nodes'].items()}
-        leaves = {int(k): v for (k, v) in info['leaves'].items()}
+        nodes = {int(k): v for (k, v) in info['nodes'].items}
+        leaves = {int(k): v for (k, v) in info['leaves'].items}
 
         if not leaves:
             raise ValueError("Empty tree!")
@@ -1055,14 +1055,14 @@ class SBT(Index):
         factory = GraphFactory(*info['factory']['args'])
 
         max_node = 0
-        for k, node in nodes.items():
+        for k, node in nodes.items:
             node['factory'] = factory
             sbt_node = Node.load(node, storage)
 
             sbt_nodes[k] = sbt_node
             max_node = max(max_node, k)
 
-        for k, node in leaves.items():
+        for k, node in leaves.items:
             sbt_leaf = leaf_loader(node, storage)
             sbt_leaves[k] = sbt_leaf
             max_node = max(max_node, k)
@@ -1077,8 +1077,8 @@ class SBT(Index):
 
     @classmethod
     def _load_v6(cls, info, leaf_loader, dirname, storage, *, print_version_warning=True, cache_size=None):
-        nodes = {int(k): v for (k, v) in info['nodes'].items()}
-        leaves = {int(k): v for (k, v) in info['signatures'].items()}
+        nodes = {int(k): v for (k, v) in info['nodes'].items}
+        leaves = {int(k): v for (k, v) in info['signatures'].items}
 
         if not leaves:
             raise ValueError("Empty tree!")
@@ -1096,14 +1096,14 @@ class SBT(Index):
         factory = GraphFactory(*info['factory']['args'])
 
         max_node = 0
-        for k, node in nodes.items():
+        for k, node in nodes.items:
             node['factory'] = factory
             sbt_node = Node.load(node, storage)
 
             sbt_nodes[k] = sbt_node
             max_node = max(max_node, k)
 
-        for k, node in leaves.items():
+        for k, node in leaves.items:
             sbt_leaf = leaf_loader(node, storage)
             sbt_leaves[k] = sbt_leaf
             max_node = max(max_node, k)
@@ -1154,7 +1154,7 @@ class SBT(Index):
         self._fill_up(fill_nodegraphs)
 
     def _fill_up(self, search_fn, *args, **kwargs):
-        visited, queue = set(), list(reversed(sorted(self._leaves.keys())))
+        visited, queue = set, list(reversed(sorted(self._leaves.keys)))
         debug("started filling up")
         processed = 0
         while queue:
@@ -1206,7 +1206,7 @@ class SBT(Index):
         edge [arrowsize=0.8];
         """)
 
-        for i, node in self._nodes.items():
+        for i, node in self._nodes.items:
             if isinstance(node, Node):
                 print('"{}" [shape=box fillcolor=gray style=filled]'.format(
                       node.name))
@@ -1216,9 +1216,9 @@ class SBT(Index):
         print("}")
 
     def print(self):
-        visited, stack = set(), [0]
+        visited, stack = set, [0]
         while stack:
-            node_p = stack.pop()
+            node_p = stack.pop
             node_g = self._nodes.get(node_p, None)
             if node_p not in visited and node_g is not None:
                 visited.add(node_p)
@@ -1229,9 +1229,9 @@ class SBT(Index):
                                        if c.pos not in visited)
 
     def __iter__(self):
-        for i, node in self._nodes.items():
+        for i, node in self._nodes.items:
             yield (i, node)
-        for i, node in self._leaves.items():
+        for i, node in self._leaves.items:
             yield (i, node)
 
     def _parents(self, pos=0):
@@ -1244,13 +1244,13 @@ class SBT(Index):
                 p = self.parent(p.pos)
 
     def leaves(self, with_pos=False, unload_data=True):
-        for pos, data in self._leaves.items():
+        for pos, data in self._leaves.items:
             if with_pos:
                 yield (pos, data)
             else:
                 yield data
             if unload_data:
-                data.unload()
+                data.unload
 
     def combine(self, other):
         larger, smaller = self, other
@@ -1290,7 +1290,7 @@ class SBT(Index):
         return self
 
 
-class Node():
+class Node:
     "Internal node of SBT."
 
     def __init__(self, factory, name=None, path=None, storage=None):
@@ -1299,11 +1299,11 @@ class Node():
         self._factory = factory
         self._data = None
         self._path = path
-        self.metadata = dict()
+        self.metadata = dict
 
     def __str__(self):
         return '*Node:{name} [occupied: {nb}, fpr: {fpr:.2}]'.format(
-                name=self.name, nb=self.data.n_occupied(),
+                name=self.name, nb=self.data.n_occupied,
                 fpr=calc_expected_collisions(self.data, True, 1.1))
 
     def save(self, path):
@@ -1314,7 +1314,7 @@ class Node():
     def data(self):
         if self._data is None:
             if self._path is None:
-                self._data = self._factory()
+                self._data = self._factory
             else:
                 data = self.storage.load(self._path)
                 self._data = Nodegraph.from_buffer(data)
@@ -1349,7 +1349,7 @@ class Node():
             parent.metadata['min_n_below'] = min_n_below
 
 
-class Leaf():
+class Leaf:
     def __init__(self, metadata, data=None, name=None, storage=None, path=None):
         self.metadata = metadata
 
@@ -1365,7 +1365,7 @@ class Leaf():
     def __str__(self):
         return '**Leaf:{name} [occupied: {nb}, fpr: {fpr:.2}] -> {metadata}'.format(
                 name=self.name, metadata=self.metadata,
-                nb=self.data.n_occupied(),
+                nb=self.data.n_occupied,
                 fpr=calc_expected_collisions(self.data, True, 1.1))
 
     def make_manifest_row(self, location):
@@ -1421,8 +1421,8 @@ def filter_distance(filter_a, filter_b, n=1000):
     """
     from numpy import array
 
-    A = filter_a.graph.get_raw_tables()
-    B = filter_b.graph.get_raw_tables()
+    A = filter_a.graph.get_raw_tables
+    B = filter_b.graph.get_raw_tables
     distance = 0
     for q, p in zip(A, B):
         a = array(q, copy=False)
@@ -1440,7 +1440,7 @@ def convert_cmd(name, backend):
 
     options = backend.split('(')
     backend = options.pop(0)
-    backend = backend.lower().strip("'")
+    backend = backend.lower.strip("'")
 
     kwargs = {}
 
@@ -1452,14 +1452,14 @@ def convert_cmd(name, backend):
     else:
       options = []
 
-    if backend.lower() in ('ipfs', 'ipfsstorage'):
+    if backend.lower in ('ipfs', 'ipfsstorage'):
         backend = IPFSStorage
-    elif backend.lower() in ('redis', 'redisstorage'):
+    elif backend.lower in ('redis', 'redisstorage'):
         backend = RedisStorage
-    elif backend.lower() in ('zip', 'zipstorage'):
+    elif backend.lower in ('zip', 'zipstorage'):
         backend = ZipStorage
         kwargs['mode'] = 'w'
-    elif backend.lower() in ('fs', 'fsstorage'):
+    elif backend.lower in ('fs', 'fsstorage'):
         backend = FSStorage
         if options:
             options = [os.path.dirname(options[0]), os.path.basename(options[0])]

--- a/src/sourmash/sbt.py
+++ b/src/sourmash/sbt.py
@@ -36,7 +36,7 @@ STORAGES = {
 NodePos = namedtuple("NodePos", ["pos", "node"])
 
 
-class GraphFactory():
+class GraphFactory:
     """Build new nodegraphs (Bloom filters) of a specific (fixed) size.
 
     Parameters
@@ -1290,7 +1290,7 @@ class SBT(Index):
         return self
 
 
-class Node():
+class Node:
     "Internal node of SBT."
 
     def __init__(self, factory, name=None, path=None, storage=None):
@@ -1349,7 +1349,7 @@ class Node():
             parent.metadata['min_n_below'] = min_n_below
 
 
-class Leaf():
+class Leaf:
     def __init__(self, metadata, data=None, name=None, storage=None, path=None):
         self.metadata = metadata
 

--- a/src/sourmash/sbt.py
+++ b/src/sourmash/sbt.py
@@ -36,7 +36,7 @@ STORAGES = {
 NodePos = namedtuple("NodePos", ["pos", "node"])
 
 
-class GraphFactory(object):
+class GraphFactory():
     """Build new nodegraphs (Bloom filters) of a specific (fixed) size.
 
     Parameters
@@ -1290,7 +1290,7 @@ class SBT(Index):
         return self
 
 
-class Node(object):
+class Node():
     "Internal node of SBT."
 
     def __init__(self, factory, name=None, path=None, storage=None):
@@ -1349,7 +1349,7 @@ class Node(object):
             parent.metadata['min_n_below'] = min_n_below
 
 
-class Leaf(object):
+class Leaf():
     def __init__(self, metadata, data=None, name=None, storage=None, path=None):
         self.metadata = metadata
 

--- a/src/sourmash/sourmash_args.py
+++ b/src/sourmash/sourmash_args.py
@@ -573,7 +573,7 @@ def load_pathlist_from_file(filename):
     return file_list
 
 
-class FileOutput(object):
+class FileOutput():
     """A context manager for file outputs that handles sys.stdout gracefully.
 
     Usage:
@@ -655,7 +655,7 @@ class FileOutputCSV(FileOutput):
         return self.fp
 
 
-class SignatureLoadingProgress(object):
+class SignatureLoadingProgress():
     """A wrapper for signature loading progress reporting.
 
     Instantiate this class once, and then pass it to load_file_as_signatures

--- a/src/sourmash/sourmash_args.py
+++ b/src/sourmash/sourmash_args.py
@@ -573,7 +573,7 @@ def load_pathlist_from_file(filename):
     return file_list
 
 
-class FileOutput():
+class FileOutput:
     """A context manager for file outputs that handles sys.stdout gracefully.
 
     Usage:
@@ -655,7 +655,7 @@ class FileOutputCSV(FileOutput):
         return self.fp
 
 
-class SignatureLoadingProgress():
+class SignatureLoadingProgress:
     """A wrapper for signature loading progress reporting.
 
     Instantiate this class once, and then pass it to load_file_as_signatures

--- a/src/sourmash/sourmash_args.py
+++ b/src/sourmash/sourmash_args.py
@@ -194,7 +194,7 @@ def apply_picklist_and_pattern(db, picklist, pattern):
 
         manifest = manifest.filter_on_columns(pattern,
                                               ["name", "filename", "md5"])
-        pattern_picklist = manifest.to_picklist()
+        pattern_picklist = manifest.to_picklist
         db = db.select(picklist=pattern_picklist)
 
     return db
@@ -217,8 +217,8 @@ def load_query_signature(filename, ksize, select_moltype, select_md5=None):
     if len(sl) and select_md5:
         found_sig = None
         for sig in sl:
-            sig_md5 = sig.md5sum()
-            if sig_md5.startswith(select_md5.lower()):
+            sig_md5 = sig.md5sum
+            if sig_md5.startswith(select_md5.lower):
                 # make sure we pick only one --
                 if found_sig is not None:
                     error(f"Error! Multiple signatures start with md5 '{select_md5}'")
@@ -232,7 +232,7 @@ def load_query_signature(filename, ksize, select_moltype, select_md5=None):
     if len(sl) and ksize is None:
         ksizes = set([ ss.minhash.ksize for ss in sl ])
         if len(ksizes) == 1:
-            ksize = ksizes.pop()
+            ksize = ksizes.pop
             sl = [ ss for ss in sl if ss.minhash.ksize == ksize ]
             notify(f'select query k={ksize} automatically.')
         elif DEFAULT_LOAD_K in ksizes:
@@ -456,7 +456,7 @@ def _load_database(filename, traverse_yield_all, *, cache_size=None):
                          cache_size=cache_size)
         except ValueError:
             debug_literal(f"_load_databases: FAIL on fn {n} {desc}.")
-            debug_literal(traceback.format_exc())
+            debug_literal(traceback.format_exc)
 
         if db is not None:
             loaded = True
@@ -516,7 +516,7 @@ def load_file_as_signatures(filename, *, select_moltype=None, ksize=None,
     """Load 'filename' as a collection of signatures. Return an iterable.
 
     If 'filename' contains an SBT or LCA indexed database, or a regular
-    Zip file, will return a signatures() generator. If a Zip file and
+    Zip file, will return a signatures generator. If a Zip file and
     yield_all_files=True, will try to load all files within zip, not just
     .sig files.
 
@@ -545,7 +545,7 @@ def load_file_as_signatures(filename, *, select_moltype=None, ksize=None,
     # apply pattern search & picklist
     db = apply_picklist_and_pattern(db, picklist, pattern)
 
-    loader = db.signatures()
+    loader = db.signatures
 
     if progress is not None:
         return progress.start_file(filename, loader)
@@ -573,7 +573,7 @@ def load_pathlist_from_file(filename):
     return file_list
 
 
-class FileOutput():
+class FileOutput:
     """A context manager for file outputs that handles sys.stdout gracefully.
 
     Usage:
@@ -585,9 +585,9 @@ class FileOutput():
     is '-' or None. This makes it nicely compatible with argparse usage,
     e.g.
 
-    p = argparse.ArgumentParser()
+    p = argparse.ArgumentParser
     p.add_argument('--output')
-    args = p.parse_args()
+    args = p.parse_args
     ...
     with FileOutput(args.output, 'wt') as fp:
        ...
@@ -610,15 +610,15 @@ class FileOutput():
 
     def close(self):
         if self.fp is not None: # in case of stdout
-            self.fp.close()
+            self.fp.close
 
     def __enter__(self):
-        return self.open()
+        return self.open
 
     def __exit__(self, type, value, traceback):
         # do we need to handle exceptions here?
         if self.fp:
-            self.fp.close()
+            self.fp.close
 
         return False
 
@@ -635,9 +635,9 @@ class FileOutputCSV(FileOutput):
     is '-' or None. This makes it nicely compatible with argparse usage,
     e.g.
 
-    p = argparse.ArgumentParser()
+    p = argparse.ArgumentParser
     p.add_argument('--output')
-    args = p.parse_args()
+    args = p.parse_args
     ...
     with FileOutputCSV(args.output) as w:
        ...
@@ -655,7 +655,7 @@ class FileOutputCSV(FileOutput):
         return self.fp
 
 
-class SignatureLoadingProgress():
+class SignatureLoadingProgress:
     """A wrapper for signature loading progress reporting.
 
     Instantiate this class once, and then pass it to load_file_as_signatures
@@ -742,7 +742,7 @@ def load_many_signatures(locations, progress, *, yield_all_files=False,
             idx = apply_picklist_and_pattern(idx, picklist, pattern)
 
             # start up iterator,
-            loader = idx.signatures_with_location()
+            loader = idx.signatures_with_location
 
             # go!
             n = 0               # count signatures loaded
@@ -792,7 +792,7 @@ def get_manifest(idx, *, require=True, rebuild=False):
     # need to build one...
     try:
         notify("Generating a manifest...")
-        m = CollectionManifest.create_manifest(idx._signatures_with_internal(),
+        m = CollectionManifest.create_manifest(idx._signatures_with_internal,
                                                include_signature=False)
         debug_literal("get_manifest: rebuilt manifest.")
     except NotImplementedError:
@@ -812,7 +812,7 @@ def get_manifest(idx, *, require=True, rebuild=False):
 def _get_signatures_from_rust(siglist):
     for ss in siglist:
         try:
-            ss.md5sum()
+            ss.md5sum
             yield ss
         except sourmash.exceptions.Panic:
             # this deals with a disconnect between the way Rust
@@ -839,12 +839,12 @@ class _BaseSaveSignaturesToLocation:
 
     def __enter__(self):
         "provide context manager functionality"
-        self.open()
+        self.open
         return self
 
     def __exit__(self, type, value, traceback):
         "provide context manager functionality"
-        self.close()
+        self.close
 
     def add(self, ss):
         self.count += 1
@@ -857,7 +857,7 @@ class _BaseSaveSignaturesToLocation:
 class SaveSignatures_NoOutput(_BaseSaveSignaturesToLocation):
     "Do not save signatures."
     def __repr__(self):
-        return 'SaveSignatures_NoOutput()'
+        return 'SaveSignatures_NoOutput'
 
     def open(self):
         pass
@@ -869,7 +869,7 @@ class SaveSignatures_NoOutput(_BaseSaveSignaturesToLocation):
 class SaveSignatures_Directory(_BaseSaveSignaturesToLocation):
     "Save signatures within a directory, using md5sum names."
     def __init__(self, location):
-        super().__init__(location)
+        super.__init__(location)
 
     def __repr__(self):
         return f"SaveSignatures_Directory('{self.location}')"
@@ -887,8 +887,8 @@ class SaveSignatures_Directory(_BaseSaveSignaturesToLocation):
             sys.exit(-1)
 
     def add(self, ss):
-        super().add(ss)
-        md5 = ss.md5sum()
+        super.add(ss)
+        md5 = ss.md5sum
 
         # don't overwrite even if duplicate md5sum
         outname = os.path.join(self.location, f"{md5}.sig.gz")
@@ -907,7 +907,7 @@ class SaveSignatures_Directory(_BaseSaveSignaturesToLocation):
 class SaveSignatures_SqliteIndex(_BaseSaveSignaturesToLocation):
     "Save signatures within a directory, using md5sum names."
     def __init__(self, location):
-        super().__init__(location)
+        super.__init__(location)
         self.location = location
         self.idx = None
         self.cursor = None
@@ -916,28 +916,28 @@ class SaveSignatures_SqliteIndex(_BaseSaveSignaturesToLocation):
         return f"SaveSignatures_SqliteIndex('{self.location}')"
 
     def close(self):
-        self.idx.commit()
+        self.idx.commit
         self.cursor.execute('VACUUM')
-        self.idx.close()
+        self.idx.close
 
     def open(self):
         self.idx = SqliteIndex.create(self.location, append=True)
-        self.cursor = self.idx.cursor()
+        self.cursor = self.idx.cursor
 
     def add(self, add_sig):
         for ss in _get_signatures_from_rust([add_sig]):
-            super().add(ss)
+            super.add(ss)
             self.idx.insert(ss, cursor=self.cursor, commit=False)
 
             # commit every 1000 signatures.
             if self.count % 1000 == 0:
-                self.idx.commit()
+                self.idx.commit
 
 
 class SaveSignatures_SigFile(_BaseSaveSignaturesToLocation):
     "Save signatures to a .sig JSON file."
     def __init__(self, location):
-        super().__init__(location)
+        super.__init__(location)
         self.keep = []
         self.compress = 0
         if self.location.endswith('.gz'):
@@ -967,14 +967,14 @@ class SaveSignatures_SigFile(_BaseSaveSignaturesToLocation):
                                          compression=self.compress)
 
     def add(self, ss):
-        super().add(ss)
+        super.add(ss)
         self.keep.append(ss)
 
 
 class SaveSignatures_ZipFile(_BaseSaveSignaturesToLocation):
     "Save compressed signatures in an uncompressed Zip file."
     def __init__(self, location):
-        super().__init__(location)
+        super.__init__(location)
         self.storage = None
 
     def __repr__(self):
@@ -985,14 +985,14 @@ class SaveSignatures_ZipFile(_BaseSaveSignaturesToLocation):
         manifest = CollectionManifest(self.manifest_rows)
         manifest_name = f"SOURMASH-MANIFEST.csv"
 
-        manifest_fp = StringIO()
+        manifest_fp = StringIO
         manifest.write_to_csv(manifest_fp, write_header=True)
-        manifest_data = manifest_fp.getvalue().encode("utf-8")
+        manifest_data = manifest_fp.getvalue.encode("utf-8")
 
         self.storage.save(manifest_name, manifest_data, overwrite=True,
                           compress=True)
-        self.storage.flush()
-        self.storage.close()
+        self.storage.flush
+        self.storage.close
 
     def open(self):
         from .sbt_storage import ZipStorage
@@ -1018,7 +1018,7 @@ class SaveSignatures_ZipFile(_BaseSaveSignaturesToLocation):
             manifest_data = manifest_data.decode('utf-8')
             manifest_fp = StringIO(manifest_data)
             manifest = CollectionManifest.load_from_csv(manifest_fp)
-            self.manifest_rows = list(manifest._select())
+            self.manifest_rows = list(manifest._select)
 
         self.storage = storage
 
@@ -1035,7 +1035,7 @@ class SaveSignatures_ZipFile(_BaseSaveSignaturesToLocation):
 
         for ss in _get_signatures_from_rust([add_sig]):
             buf = sigmod.save_signatures([ss], compression=1)
-            md5 = ss.md5sum()
+            md5 = ss.md5sum
 
             storage = self.storage
             path = f'{storage.subdir}/{md5}.sig.gz'
@@ -1045,7 +1045,7 @@ class SaveSignatures_ZipFile(_BaseSaveSignaturesToLocation):
             row = CollectionManifest.make_manifest_row(ss, location,
                                                        include_signature=False)
             self.manifest_rows.append(row)
-            super().add(ss)
+            super.add(ss)
 
 
 class SigFileSaveType(Enum):

--- a/src/sourmash/utils.py
+++ b/src/sourmash/utils.py
@@ -3,10 +3,10 @@ import weakref
 from ._lowlevel import ffi, lib
 from .exceptions import exceptions_by_code, SourmashError
 
-attached_refs = weakref.WeakKeyDictionary
+attached_refs = weakref.WeakKeyDictionary()
 
 
-class RustObject:
+class RustObject():
     __dealloc_func__ = None
     _objptr = None
     _shared = False
@@ -22,7 +22,7 @@ class RustObject:
         return rv
 
     def _methodcall(self, func, *args):
-        return rustcall(func, self._get_objptr, *args)
+        return rustcall(func, self._get_objptr(), *args)
 
     def _get_objptr(self):
         if not self._objptr:
@@ -64,15 +64,15 @@ def encode_str(s):
 
 def rustcall(func, *args):
     """Calls rust method and does some error handling."""
-    lib.sourmash_err_clear
+    lib.sourmash_err_clear()
     rv = func(*args)
-    err = lib.sourmash_err_get_last_code
+    err = lib.sourmash_err_get_last_code()
     if not err:
         return rv
-    msg = lib.sourmash_err_get_last_message
+    msg = lib.sourmash_err_get_last_message()
     cls = exceptions_by_code.get(err, SourmashError)
     exc = cls(decode_str(msg))
-    backtrace = decode_str(lib.sourmash_err_get_backtrace)
+    backtrace = decode_str(lib.sourmash_err_get_backtrace())
     if backtrace:
         exc.rust_info = backtrace
     raise exc

--- a/src/sourmash/utils.py
+++ b/src/sourmash/utils.py
@@ -6,7 +6,7 @@ from .exceptions import exceptions_by_code, SourmashError
 attached_refs = weakref.WeakKeyDictionary()
 
 
-class RustObject(object):
+class RustObject():
     __dealloc_func__ = None
     _objptr = None
     _shared = False

--- a/src/sourmash/utils.py
+++ b/src/sourmash/utils.py
@@ -3,10 +3,10 @@ import weakref
 from ._lowlevel import ffi, lib
 from .exceptions import exceptions_by_code, SourmashError
 
-attached_refs = weakref.WeakKeyDictionary()
+attached_refs = weakref.WeakKeyDictionary
 
 
-class RustObject():
+class RustObject:
     __dealloc_func__ = None
     _objptr = None
     _shared = False
@@ -22,7 +22,7 @@ class RustObject():
         return rv
 
     def _methodcall(self, func, *args):
-        return rustcall(func, self._get_objptr(), *args)
+        return rustcall(func, self._get_objptr, *args)
 
     def _get_objptr(self):
         if not self._objptr:
@@ -64,15 +64,15 @@ def encode_str(s):
 
 def rustcall(func, *args):
     """Calls rust method and does some error handling."""
-    lib.sourmash_err_clear()
+    lib.sourmash_err_clear
     rv = func(*args)
-    err = lib.sourmash_err_get_last_code()
+    err = lib.sourmash_err_get_last_code
     if not err:
         return rv
-    msg = lib.sourmash_err_get_last_message()
+    msg = lib.sourmash_err_get_last_message
     cls = exceptions_by_code.get(err, SourmashError)
     exc = cls(decode_str(msg))
-    backtrace = decode_str(lib.sourmash_err_get_backtrace())
+    backtrace = decode_str(lib.sourmash_err_get_backtrace)
     if backtrace:
         exc.rust_info = backtrace
     raise exc

--- a/src/sourmash/utils.py
+++ b/src/sourmash/utils.py
@@ -6,7 +6,7 @@ from .exceptions import exceptions_by_code, SourmashError
 attached_refs = weakref.WeakKeyDictionary()
 
 
-class RustObject():
+class RustObject:
     __dealloc_func__ = None
     _objptr = None
     _shared = False


### PR DESCRIPTION
Fixes https://github.com/sourmash-bio/sourmash/issues/1188
remove inheritance of object from Python code

Original `grep` command
```bash=
(sourmash_dev) baumlerc@bm2:~/sourmash/src$ git grep object sourmash | grep class
sourmash/command_compute.py:class _signatures_for_compute_factory(object):
sourmash/command_sketch.py:class _signatures_for_sketch_factory(object):
sourmash/index/__init__.py:Index - abstract base class for all Index objects.
sourmash/index/__init__.py:    on index objects. So if this class wraps an SBT, for example, the
sourmash/index/__init__.py:    This class is useful when you have an index object that consume
sourmash/index/__init__.py:    on-disk Index object.  However, unlike LazyLoadedIndex, this class
sourmash/index/__init__.py:    objects. However, this class does not store any signatures in
sourmash/index/sqlite_index.py:* all of these classes share a single connection object, and it could
sourmash/sbt.py:class GraphFactory(object):
sourmash/sbt.py:class Node(object):
sourmash/sbt.py:class Leaf(object):
sourmash/sourmash_args.py:class FileOutput(object):
sourmash/sourmash_args.py:class SignatureLoadingProgress(object):
sourmash/utils.py:class RustObject(object):
sourmash/utils.py:        raise TypeError("Cannot instanciate %r objects" % self.__class__.__name__)
```

Modified `grep` command to focus only on `class MyClass(object):`
```
(sourmash_dev) baumlerc@bm2:~/sourmash/src$ git grep -rl "(object)" sourmash
sourmash/command_compute.py
sourmash/command_sketch.py
sourmash/sbt.py
sourmash/sourmash_args.py
sourmash/utils.py
(sourmash_dev) baumlerc@bm2:~/sourmash/src$ git grep -r "(object)" sourmash
sourmash/command_compute.py:class _signatures_for_compute_factory(object):
sourmash/command_sketch.py:class _signatures_for_sketch_factory(object):
sourmash/sbt.py:class GraphFactory(object):
sourmash/sbt.py:class Node(object):
sourmash/sbt.py:class Leaf(object):
sourmash/sourmash_args.py:class FileOutput(object):
sourmash/sourmash_args.py:class SignatureLoadingProgress(object):
sourmash/utils.py:class RustObject(object):
```

So,
```
(sourmash_dev) baumlerc@bm2:~/sourmash/src$ git grep -rl "(object)" sourmash | xargs sed -i -e 's/(object)/()/g'
(sourmash_dev) baumlerc@bm2:~/sourmash/src$ git grep -r "(object)" sourmash    
```