### PR TITLE
[MRG] split wheel building

### DIFF
--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -62,13 +62,17 @@ jobs:
       # Added due to weird error when building inside docker container
       # for other platforms...
       # https://github.com/JonasAlfredsson/docker-nginx-certbot/issues/30
-      - name: Run Docker on tmpfs
+      - name: Set Swap Space
         if: runner.os == 'Linux'
-        uses: JonasAlfredsson/docker-on-tmpfs@v1
+        uses: pierotofy/set-swap-space@v1.0
         with:
-          tmpfs_size: 5
-          swap_size: 4
-          swap_location: '/mnt/swapfile'
+          swap-size-gb: 10
+      - run: |
+          # Workaround for https://github.com/rust-lang/cargo/issues/8719
+          sudo mkdir -p /var/lib/docker
+          sudo mount -t tmpfs -o size=10G none /var/lib/docker
+          sudo systemctl restart docker
+        if: runner.os == 'Linux'
 
       - name: Set up QEMU
         if: runner.os == 'Linux'

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -59,6 +59,17 @@ jobs:
         with:
           python-version: '3.9'
 
+      # Added due to weird error when building inside docker container
+      # for other platforms...
+      # https://github.com/JonasAlfredsson/docker-nginx-certbot/issues/30
+      - name: Run Docker on tmpfs
+        if: runner.os == 'Linux'
+        uses: JonasAlfredsson/docker-on-tmpfs@v1
+        with:
+          tmpfs_size: 5
+          swap_size: 4
+          swap_location: '/mnt/swapfile'
+
       - name: Set up QEMU
         if: runner.os == 'Linux'
         uses: docker/setup-qemu-action@v2

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -24,19 +24,19 @@ jobs:
         ]
         include:
           - build: linux-x86_64
-            os: ubuntu-18.04
+            os: ubuntu-20.04
             arch: x86_64
             macos_target: ''
           - build: linux-aarch64
-            os: ubuntu-18.04
+            os: ubuntu-20.04
             arch: aarch64
             macos_target: ''
           - build: linux-ppc64le
-            os: ubuntu-18.04
+            os: ubuntu-20.04
             arch: ppc64le
             macos_target: ''
           - build: linux-s390x
-            os: ubuntu-18.04
+            os: ubuntu-20.04
             arch: s390x
             macos_target: ''
           - build: macos-x86_64

--- a/.github/workflows/build_wheel_all_archs.yml
+++ b/.github/workflows/build_wheel_all_archs.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [latest]
     tags: v*
-  pull_request:
   schedule:
     - cron: "0 0 * * *" # daily
 
@@ -15,23 +14,23 @@ jobs:
     strategy:
       matrix:
         build: [
-          linux-x86_64,
-          macos-x86_64,
-          macos-arm64,
+          linux-aarch64,
+          linux-ppc64le,
+          linux-s390x,
         ]
         include:
-          - build: linux-x86_64
+          - build: linux-aarch64
             os: ubuntu-20.04
-            arch: x86_64
+            arch: aarch64
             macos_target: ''
-          - build: macos-x86_64
-            os: macos-latest
-            arch: x86_64
-            macos_target: 'MACOSX_DEPLOYMENT_TARGET=10.11 CARGO_BUILD_TARGET=x86_64-apple-darwin'
-          - build: macos-arm64
-            os: macos-latest
-            arch: arm64
-            macos_target: 'MACOSX_DEPLOYMENT_TARGET=11 CARGO_BUILD_TARGET=aarch64-apple-darwin'
+          - build: linux-ppc64le
+            os: ubuntu-20.04
+            arch: ppc64le
+            macos_target: ''
+          - build: linux-s390x
+            os: ubuntu-20.04
+            arch: s390x
+            macos_target: ''
       fail-fast: false
 
     steps:
@@ -43,6 +42,27 @@ jobs:
         name: Install Python
         with:
           python-version: '3.9'
+
+      # Added due to weird error when building inside docker container
+      # for other platforms...
+      # https://github.com/JonasAlfredsson/docker-nginx-certbot/issues/30
+      - name: Set Swap Space
+        if: runner.os == 'Linux'
+        uses: pierotofy/set-swap-space@v1.0
+        with:
+          swap-size-gb: 10
+      - run: |
+          # Workaround for https://github.com/rust-lang/cargo/issues/8719
+          sudo mkdir -p /var/lib/docker
+          sudo mount -t tmpfs -o size=10G none /var/lib/docker
+          sudo systemctl restart docker
+        if: runner.os == 'Linux'
+
+      - name: Set up QEMU
+        if: runner.os == 'Linux'
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: all
 
       - name: Build wheels
         uses: pypa/cibuildwheel@2.6.1


### PR DESCRIPTION
- Split wheel building into "main" platforms (linux-x86_64, macos-x86_64, macos-aarch64) and secondary (linux-{aarch64, ppcle64, s390x}). Run the former on every PR, and latter on PR merges, new tags and nightly.
- Update builder image for ubuntu 20.04

secondary wheels are still broken, seems like it is a deep problem into `libgit2` (which is used by cargo, and where we see CI breaking)

# TODO

- [x] update required check when merged -- "Build wheels for ubuntu-18.04-x86_64" is now "Build wheels for ubuntu-20.04-x86_64"