### PR TITLE
[MRG] Fix downsample_scaled in `core`

### DIFF
--- a/src/core/src/encodings.rs
+++ b/src/core/src/encodings.rs
@@ -22,7 +22,7 @@ type IdxTracker = (vec_collections::VecSet<[Idx; 4]>, u64);
 type ColorToIdx = HashMap<Color, IdxTracker, BuildNoHashHasher<Color>>;
 
 #[allow(non_camel_case_types)]
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u32)]
 pub enum HashFunctions {
     murmur64_DNA = 1,

--- a/src/core/src/sketch/hyperloglog/mod.rs
+++ b/src/core/src/sketch/hyperloglog/mod.rs
@@ -25,7 +25,7 @@ use crate::HashIntoType;
 pub mod estimators;
 use estimators::CounterType;
 
-#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct HyperLogLog {
     registers: Vec<CounterType>,
     p: usize,

--- a/src/core/src/sketch/minhash.rs
+++ b/src/core/src/sketch/minhash.rs
@@ -778,21 +778,7 @@ impl KmerMinHash {
     // create a downsampled copy of self
     pub fn downsample_scaled(&self, scaled: u64) -> Result<KmerMinHash, Error> {
         let max_hash = max_hash_for_scaled(scaled);
-
-        let mut new_mh = KmerMinHash::new(
-            max_hash, // old max_hash => max_hash arg
-            self.ksize,
-            self.hash_function,
-            self.seed,
-            self.abunds.is_some(),
-            self.num,
-        );
-        if self.abunds.is_some() {
-            new_mh.add_many_with_abund(&self.to_vec_abunds())?;
-        } else {
-            new_mh.add_many(&self.mins)?;
-        }
-        Ok(new_mh)
+        self.downsample_max_hash(max_hash)
     }
 }
 
@@ -1537,6 +1523,12 @@ impl KmerMinHashBTree {
             new_mh.add_many(&self.mins())?;
         }
         Ok(new_mh)
+    }
+
+    // create a downsampled copy of self
+    pub fn downsample_scaled(&self, scaled: u64) -> Result<KmerMinHashBTree, Error> {
+        let max_hash = max_hash_for_scaled(scaled);
+        self.downsample_max_hash(max_hash)
     }
 
     pub fn to_vec_abunds(&self) -> Vec<(u64, u64)> {

--- a/src/core/tests/minhash.rs
+++ b/src/core/tests/minhash.rs
@@ -8,7 +8,9 @@ use proptest::proptest;
 use sourmash::encodings::HashFunctions;
 use sourmash::signature::SeqToHashes;
 use sourmash::signature::{Signature, SigsTrait};
-use sourmash::sketch::minhash::{max_hash_for_scaled, KmerMinHash, KmerMinHashBTree};
+use sourmash::sketch::minhash::{
+    max_hash_for_scaled, scaled_for_max_hash, KmerMinHash, KmerMinHashBTree,
+};
 use sourmash::sketch::Sketch;
 
 // TODO: use f64::EPSILON when we bump MSRV
@@ -251,7 +253,8 @@ fn oracle_mins_scaled(hashes in vec(u64::ANY, 1..10000)) {
     assert_eq!(c.count_common(&a, true).unwrap(), d.count_common(&b, true).unwrap());
 
     let mut e = a.downsample_max_hash(100).unwrap();
-    let mut f = b.downsample_max_hash(100).unwrap();
+    let scaled = scaled_for_max_hash(100);
+    let mut f = b.downsample_scaled(scaled).unwrap();
 
     // Can't compare different scaled without explicit downsample
     assert!(c.similarity(&e, false, false).is_err());
@@ -327,7 +330,8 @@ fn prop_merge(seq1 in "[ACGT]{6,100}", seq2 in "[ACGT]{6,200}") {
     assert!((a.similarity(&c, true, false).unwrap() - b.similarity(&d, true, false).unwrap()).abs() < EPSILON);
 
     let mut e = a.downsample_max_hash(100).unwrap();
-    let mut f = b.downsample_max_hash(100).unwrap();
+    let scaled = scaled_for_max_hash(100);
+    let mut f = b.downsample_scaled(scaled).unwrap();
 
     assert!((e.similarity(&c, false, true).unwrap() - f.similarity(&d, false, true).unwrap()).abs() < EPSILON);
     assert!((e.similarity(&c, true, true).unwrap() - f.similarity(&d, true, true).unwrap()).abs() < EPSILON);


### PR DESCRIPTION
`downsample_scaled` was using `max_hash` as the `scaled` value, leading to wrong results.

I don't think any part of the code was using it, so the error was not detected when the first arg of `KmerMinHash::new` changed from `max_hash` to `scaled`. I updated tests to check it too.

Also add `downsample_scaled` to `KmerMinHashBTree`, since it was missing.