### PR TITLE
[MRG] update release notes & pyproject.toml after v4.4.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ install: all
 	$(PYTHON) setup.py install
 
 dist: FORCE
-	$(PYTHON) setup.py sdist
+	$(PYTHON) -m build --sdist
 
 test:
 	tox -e py38

--- a/doc/release.md
+++ b/doc/release.md
@@ -8,7 +8,7 @@ Michael Crusoe.
 The basic build environment needed below can be created as follows:
 
 ```
-conda create -y -n sourmash-rc python=3.8 pip cxx-compiler make twine tox tox-conda "setuptools<60" setuptools_scm
+conda create -y -n sourmash-rc python=3.8 pip cxx-compiler make twine tox tox-conda setuptools setuptools_scm
 ```
 
 Then activate it with `conda activate sourmash-rc`.
@@ -53,7 +53,7 @@ git push --tags origin
 
 3\. Test the release candidate. Bonus: repeat on macOS:
 ```
-python -m pip install -U virtualenv wheel tox-setuptools-version
+python -m pip install -U virtualenv wheel tox-setuptools-version build
 
 cd ..
 python -m venv testenv1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ dynamic = ["version"]
 license = { text = "BSD 3-Clause License" }
 
 [project.urls]
-"Homepage" = "https://sourmash.readthedocs.io/"
+"Homepage" = "https://sourmash.bio/"
 "Documentation" = "https://sourmash.readthedocs.io"
 "CI" = "https://github.com/dib-lab/sourmash/actions"
 "Source" = "https://github.com/dib-lab/sourmash"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,9 +87,9 @@ dynamic = ["version"]
 
 [metadata]
 license = "BSD 3-Clause License"
-url = "https://sourmash.readthedocs.io/en/latest/"
 
 [project.urls]
+"Homepage" = "https://sourmash.readthedocs.io/"
 "Documentation" = "https://sourmash.readthedocs.io"
 "CI" = "https://github.com/dib-lab/sourmash/actions"
 "Source" = "https://github.com/dib-lab/sourmash"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,8 +82,9 @@ dependencies = [
   "bitstring>=3.1.9,<4",
 ]
 
+url = "https://sourmash.readthedocs.io/en/latest/"
 requires-python = ">=3.8"
-license = { file = "LICENSE" }
+license = "BSD 3-Clause License"
 dynamic = ["version"]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,10 +82,12 @@ dependencies = [
   "bitstring>=3.1.9,<4",
 ]
 
-url = "https://sourmash.readthedocs.io/en/latest/"
 requires-python = ">=3.8"
-license = "BSD 3-Clause License"
 dynamic = ["version"]
+
+[metadata]
+license = "BSD 3-Clause License"
+url = "https://sourmash.readthedocs.io/en/latest/"
 
 [project.urls]
 "Documentation" = "https://sourmash.readthedocs.io"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ requires-python = ">=3.8"
 dynamic = ["version"]
 
 [metadata]
-license = "BSD 3-Clause License"
+license = { text = "BSD 3-Clause License" }
 
 [project.urls]
 "Homepage" = "https://sourmash.readthedocs.io/"


### PR DESCRIPTION
This PR updates release information after [the switch to pyproject.toml](https://github.com/sourmash-bio/sourmash/pull/2097). Specifically,

* fixes the 'license' and sets the homepage link
* switches to using `python -m build --sdist` for making source distros.
* removes setuptools version pin

Example pypi results: https://test.pypi.org/project/sourmash/4.4.2rc3/

Fixes https://github.com/sourmash-bio/sourmash/issues/2112