### PR TITLE
[MRG] fix bug in `LCA_Database.downsample`

### DIFF
--- a/src/sourmash/lca/lca_db.py
+++ b/src/sourmash/lca/lca_db.py
@@ -460,7 +460,7 @@ class LCA_Database(Index):
         max_hash = _get_max_hash_for_scaled(scaled)
 
         # filter out all hashes over max_hash in value.
-        new_hashvals = {}
+        new_hashvals = defaultdict(set)
         for k, v in self._hashval_to_idx.items():
             if k < max_hash:
                 new_hashvals[k] = v

--- a/tests/test_lca.py
+++ b/tests/test_lca.py
@@ -425,6 +425,32 @@ def test_api_create_insert_two_then_scale():
     assert len(lca_db._hashval_to_idx) == len(combined_mins)
 
 
+def test_api_create_insert_two_then_scale_then_add():
+    # construct database, THEN downsample, then add another
+    ss = sourmash.load_one_signature(utils.get_test_data('47.fa.sig'),
+                                     ksize=31)
+    ss2 = sourmash.load_one_signature(utils.get_test_data('63.fa.sig'),
+                                      ksize=31)
+
+    lca_db = sourmash.lca.LCA_Database(ksize=31, scaled=1000)
+    lca_db.insert(ss)
+
+    # downsample everything to 5000
+    lca_db.downsample_scaled(5000)
+
+    # insert another after downsample
+    lca_db.insert(ss2)
+
+    # now test -
+    ss.minhash = ss.minhash.downsample(scaled=5000)
+    ss2.minhash = ss2.minhash.downsample(scaled=5000)
+
+    # & check...
+    combined_mins = set(ss.minhash.hashes.keys())
+    combined_mins.update(set(ss2.minhash.hashes.keys()))
+    assert len(lca_db._hashval_to_idx) == len(combined_mins)
+
+
 def test_api_create_insert_scale_two():
     # downsample while constructing database
     ss = sourmash.load_one_signature(utils.get_test_data('47.fa.sig'),


### PR DESCRIPTION
I discovered this bug while working on other things -

In the base `LCA_Database` implementation, a dictionary `_hashval_to_idx` is used to track which hash values (keys) belong to which set of signatures (individual signatures are referenced by integers, `idx`). The dictionary is created as a `collections.defaultdict(set)` [ref](https://docs.python.org/3/library/collections.html#collections.defaultdict) so that when adding a new key, it automatically comes with a new set as a value - this permits the call
```python
self._hashval_to_idx[hashval].add(idx)
```
in `LCA_Database.insert(...)`.

The bug is that after `LCA_Database.downsample(...)` is called, `_hashval_to_idx` is recreated as a regular dictionary, which causes `insert` to fail.

This PR adds a new test, `test_lca.py:test_api_create_insert_two_then_scale_then_add`, that does a downsample and _then_ does an insert. This test exposes the bug above, which the PR also fixes.