### PR TITLE
[MRG] circumvent a very slow `MinHash.remove_many(...)` call in `sourmash gather`

### DIFF
--- a/src/sourmash/commands.py
+++ b/src/sourmash/commands.py
@@ -661,7 +661,6 @@ def categorize(args):
 
 def gather(args):
     from .search import GatherDatabases, format_bp
-    from .minhash import flatten_and_intersect_scaled
 
     set_quiet(args.quiet, args.debug)
     moltype = sourmash_args.calculate_moltype(args)
@@ -736,16 +735,16 @@ def gather(args):
                     raise       # re-raise other errors, if no picklist.
 
             save_prefetch.add_many(counter.signatures())
-            # subtract found hashes as we can.
-            for found_sig in counter.signatures():
-                noident_mh.remove_many(found_sig.minhash)
 
-                intersect_mh = flatten_and_intersect_scaled(found_sig.minhash, prefetch_query.minhash)
-                ident_mh.add_many(intersect_mh)
+            # update found/not found hashes from the union/intersection of
+            # found.
+            union_found = counter.union_found
+            ident_mh.add_many(union_found)
+            noident_mh.remove_many(union_found)
 
                 # optionally calculate and output prefetch info to csv
-                if prefetch_csvout_fp:
-                    assert scaled
+            if prefetch_csvout_fp:
+                for found_sig in counter.signatures():
                     # calculate intersection stats and info
                     prefetch_result = PrefetchResult(prefetch_query, found_sig, cmp_scaled=scaled, 
                                                      threshold_bp=args.threshold_bp, estimate_ani_ci=args.estimate_ani_ci)

--- a/src/sourmash/index/__init__.py
+++ b/src/sourmash/index/__init__.py
@@ -750,6 +750,26 @@ class CounterGather:
         for ss in self.siglist.values():
             yield ss
 
+    @property
+    def union_found(self):
+        """Return a MinHash containing all found hashes in the query.
+
+        This calculates the union of the found matches, intersected
+        with the original query.
+        """
+        orig_query_mh = self.orig_query_mh
+
+        # create empty MinHash from orig query
+        found_mh = orig_query_mh.copy_and_clear()
+
+        # for each match, intersect match with query & then add to found_mh.
+        for ss in self.siglist.values():
+            intersect_mh = flatten_and_intersect_scaled(ss.minhash,
+                                                        orig_query_mh)
+            found_mh.add_many(intersect_mh)
+
+        return found_mh
+
     def peek(self, cur_query_mh, *, threshold_bp=0):
         "Get next 'gather' result for this database, w/o changing counters."
         self.query_started = 1

--- a/src/sourmash/search.py
+++ b/src/sourmash/search.py
@@ -2,7 +2,6 @@
 Code for searching collections of signatures.
 """
 import csv
-import time
 import numpy as np
 from enum import Enum
 import numpy as np
@@ -673,17 +672,12 @@ class GatherDatabases:
 
         # adjust for not found...
         if noident_mh is None:  # create empty
-            print('ZZZ noident_mh is empty')
             noident_mh = query_mh.copy_and_clear()
         self.noident_mh = noident_mh.to_frozen()
 
         if ident_mh is None:
             query_mh = query_mh.to_mutable()
-            print(f'XXX removing: {len(noident_mh)} from {len(query_mh)}')
-            start = time.time()
             query_mh.remove_many(noident_mh)
-            end = time.time()
-            print(f'XXX time: {end - start :.1f}')
         else:
             query_mh = ident_mh.to_mutable()
 

--- a/src/sourmash/search.py
+++ b/src/sourmash/search.py
@@ -2,6 +2,7 @@
 Code for searching collections of signatures.
 """
 import csv
+import time
 import numpy as np
 from enum import Enum
 import numpy as np
@@ -654,7 +655,7 @@ class GatherDatabases:
     "Iterator object for doing gather/min-set-cov."
 
     def __init__(self, query, counters, *,
-                 threshold_bp=0, ignore_abundance=False, noident_mh=None, estimate_ani_ci=False):
+                 threshold_bp=0, ignore_abundance=False, noident_mh=None, ident_mh=None, estimate_ani_ci=False):
         # track original query information for later usage?
         track_abundance = query.minhash.track_abundance and not ignore_abundance
         self.orig_query = query
@@ -672,11 +673,19 @@ class GatherDatabases:
 
         # adjust for not found...
         if noident_mh is None:  # create empty
+            print('ZZZ noident_mh is empty')
             noident_mh = query_mh.copy_and_clear()
         self.noident_mh = noident_mh.to_frozen()
 
-        query_mh = query_mh.to_mutable()
-        query_mh.remove_many(noident_mh)
+        if ident_mh is None:
+            query_mh = query_mh.to_mutable()
+            print(f'XXX removing: {len(noident_mh)} from {len(query_mh)}')
+            start = time.time()
+            query_mh.remove_many(noident_mh)
+            end = time.time()
+            print(f'XXX time: {end - start :.1f}')
+        else:
+            query_mh = ident_mh.to_mutable()
 
         orig_query_mh = query_mh.flatten()
         query.minhash = orig_query_mh.to_mutable()


### PR DESCRIPTION
In #1771, we find that gather on a ~90% unidentified query has a very slow call to `MinHash.remove_many(...)` in `GatherDatabases.__init__`.  Here the `remove_many` call is used to remove hashes without any overlaps in the prefetch signatures.

An alternative approach would be to build a set of all hashes _with_ some overlap, i.e. use the union of intersections.

And that's what this PR does - it replaces the single (slow) call to `remove_many` with many calls to intersection and then union. This is encapsulated in the `CounterGather` class via new property, `union_found`.

Ref https://github.com/sourmash-bio/sourmash/issues/1771#issuecomment-1186533334

## Benchmarking

Using the data set mentioned [here](https://github.com/sourmash-bio/sourmash/issues/1771#issuecomment-1186533334), on my laptop, I ran:

`sudo time py-spy record -o latest.svg -- sourmash gather SRR10988543.10k.zip bins.10k.zip`

and I see:

the `latest` branch:  214.63s
this branch: 65.9s

so that's much faster, yah. 😄 

## py-spy flamegraphs

from `latest` branch:

<img width="1434" alt="Screen Shot 2022-07-17 at 7 20 49 AM" src="https://user-images.githubusercontent.com/51016/179402847-37beb193-b14b-410c-9f5e-52cdb043cba3.png">

from this PR:

<img width="1422" alt="Screen Shot 2022-07-18 at 9 27 06 AM" src="https://user-images.githubusercontent.com/51016/179558507-8e0caf39-b277-4b5e-ba0e-80d3a3bf9858.png">
