### PR TITLE
[MRG] update release instructions after v4.4.2

### DIFF
--- a/doc/release.md
+++ b/doc/release.md
@@ -40,7 +40,7 @@ cd sourmash
 You might want to check [the releases page] for next version number,
 or you can run `make last-tag` and check the output.
 ```
-new_version=3.0.0
+new_version=4.X.X
 rc=rc1
 ```
 and then tag the release candidate with the new version number prefixed by the letter 'v':
@@ -75,7 +75,7 @@ make test
 cd ../../testenv2
 deactivate
 source bin/activate
-python -m pip install setuptools_scm
+python -m pip install setuptools_scm build
 python -m pip install -e git+https://github.com/sourmash-bio/sourmash.git@v${new_version}${rc}#egg=sourmash[test]
 cd src/sourmash
 make test
@@ -89,7 +89,7 @@ cd ../../../testenv3/
 deactivate
 source bin/activate
 python -m pip install sourmash*tar.gz
-python -m pip install pytest
+python -m pip install pytest build
 tar xzf sourmash-${new_version}${rc}.tar.gz
 cd sourmash-${new_version}${rc}
 python -m pip install -r requirements.txt
@@ -122,6 +122,11 @@ sourmash info  # should print "sourmash version ${new_version}${rc}"
 5\. Do any final testing:
 
  * check that the binder demo notebook is up to date
+
+6\. Wait for GitHub Actions to finish running on the release candidate tag.
+
+NOTE: If you delete the rc tag before the rc wheels are done building, they
+may get added to the wrong release.
 
 ## How to make a final release
 
@@ -213,6 +218,15 @@ prepared in the previous section to be available for installation,
 and tests are going to fail in Bioconda before that.
 
 An example PR for [`3.4.0`](https://github.com/bioconda/bioconda-recipes/pull/23171).
+
+## Double check everything:
+
+```
+- [ ] [PyPI page](https://pypi.org/project/sourmash/) updated
+- [ ] Zenodo DOI successfully minted upon new github release - [see search results](https://zenodo.org/search?page=1&size=20&q=sourmash)
+- [ ] `pip install sourmash` installs the correct version
+- [ ] `mamba create -n smash-release -y sourmash` installs the correct version
+```
 
 ## Announce it!
 

--- a/doc/release.md
+++ b/doc/release.md
@@ -190,6 +190,22 @@ Note that there will also be releases associated with the Rust `core`
 package, which is versioned differently than `sourmash`.  These will
 be of the form `rXX.YY.ZZ`, e.g. `r0.9.0`. Please just ignore them :)
 
+Draft release notes can be created with `git log --oneline
+v4.4.1..latest`, but should then be edited manually. We suggest
+putting PRs in the following categories:
+
+```
+Major new features:
+
+Minor new features:
+
+Bug fixes:
+
+Cleanup and documentation fixes:
+
+Developer updates:
+```
+
 ## Conda-forge
 
 The [sourmash-minimal feedstock](https://github.com/conda-forge/sourmash-minimal-feedstock/)


### PR DESCRIPTION
This PR:
* adds `pip install build` in appropriate places
* improves instructions for steps that I repeatedly mess up
* adds a checklist for successful release checks
* adds draft release note categories / `git diff` instructions

ref https://github.com/sourmash-bio/sourmash/issues/2129
