### PR TITLE
[MRG] speed up prefetch by adjusting calls to use `len(minhash)`

### DIFF
--- a/src/sourmash/minhash.py
+++ b/src/sourmash/minhash.py
@@ -970,7 +970,7 @@ class MinHash(RustObject):
         if not self.scaled:
             raise TypeError("can only approximate unique_dataset_hashes for scaled MinHashes")
         # TODO: replace set_size with HLL estimate when that gets implemented
-        return len(self.hashes) * self.scaled # + (self.ksize - 1) for bp estimation
+        return len(self) * self.scaled # + (self.ksize - 1) for bp estimation
 
     def size_is_accurate(self, relative_error=0.20, confidence=0.95):
         """

--- a/src/sourmash/search.py
+++ b/src/sourmash/search.py
@@ -235,8 +235,8 @@ class BaseResult:
         # could define in PrefetchResult instead, same reasoning as above
         self.query_abundance = self.mh1.track_abundance
         self.match_abundance = self.mh2.track_abundance
-        self.query_n_hashes = len(self.mh1.hashes)
-        self.match_n_hashes = len(self.mh2.hashes)
+        self.query_n_hashes = len(self.mh1)
+        self.match_n_hashes = len(self.mh2)
 
     @property
     def pass_threshold(self):


### PR DESCRIPTION
Several comparison dataclasses were introduced in https://github.com/sourmash-bio/sourmash/pull/1955 and https://github.com/sourmash-bio/sourmash/pull/2050, to facilitate gather/prefetch output and ANI calculation. Some of the methods in these dataclasses use `len(minhash.hashes)` which creates a new Python object and is typically quite slow.

This PR replaces `len(minhash.hashes)` in several key locations with `len(minhash)`, which returns the same result but does so directly in Rust; on at least one benchmark, the speedup is about 10x (see numbers below).

Fixes https://github.com/sourmash-bio/sourmash/issues/2124

## timings

Using the benchmark from https://github.com/sourmash-bio/sourmash/issues/1771#issuecomment-1186533334 and also used [here](https://github.com/sourmash-bio/sourmash/pull/2123), we find:

This PR:
```
49.20 real        46.12 user         3.23 sys
```

`latest` branch / v4.4.2 -
```
469.38 real       419.82 user        47.47 sys
```

## flamegraph profile for this PR

<img width="1424" alt="Screen Shot 2022-07-20 at 12 28 46 PM" src="https://user-images.githubusercontent.com/51016/180065894-fa2b6b05-f6ca-4d6c-bef3-2a16c5e4d128.png">

## flamegraph profile for `latest` branch (equiv v4.4.2)

<img width="1432" alt="Screen Shot 2022-07-20 at 1 22 01 PM" src="https://user-images.githubusercontent.com/51016/180074552-045369bb-c3af-4c21-9383-37f1b2b43936.png">
