### PR TITLE
[MRG] add `pytest-xdist` and `-n4` to pytest and tox configs

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -36,9 +36,9 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
-          key: ${{ runner.os }}-pip-v2-${{ hashFiles('**/setup.cfg') }}
+          key: ${{ runner.os }}-pip-v3-${{ hashFiles('**/setup.cfg') }}
           restore-keys: |
-            ${{ runner.os }}-pip-v2-
+            ${{ runner.os }}-pip-v3-
 
       - name: Install dependencies
         run: |
@@ -65,9 +65,9 @@ jobs:
         uses: actions/cache@v3
         with:
           path: .tox/
-          key: ${{ runner.os }}-tox-v2-${{ hashFiles('**/setup.cfg') }}
+          key: ${{ runner.os }}-tox-v3-${{ hashFiles('**/setup.cfg') }}
           restore-keys: |
-            ${{ runner.os }}-tox-v2-
+            ${{ runner.os }}-tox-v3-
 
       - name: Test with tox
         run: tox

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ install: all
 dist: FORCE
 	$(PYTHON) -m build --sdist
 
-test:
+test: .PHONY
 	tox -e py38
 	cargo test
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,7 @@ license = { text = "BSD 3-Clause License" }
 test = [
   "pytest>=6.2.4,<7.2.0",
   "pytest-cov>=2.12,<4.0",
+  "pytest-xdist",
   "pyyaml>=6,<7",
   "recommonmark",
   "hypothesis",
@@ -159,7 +160,7 @@ environment = { PATH="$HOME/.cargo/bin:$PATH" }
 build-verbosity = 3
 
 [tool.pytest.ini_options]
-addopts = "--doctest-glob='doc/*.md'"
+addopts = "--doctest-glob='doc/*.md' -n4"
 norecursedirs = [
   "utils",
   "build",

--- a/tox.ini
+++ b/tox.ini
@@ -40,7 +40,6 @@ extras =
     test
     storage
 commands = pytest \
-           -n4 \
            --cov "{envsitepackagesdir}/sourmash" \
            --cov-config "{toxinidir}/tox.ini" \
            --cov-report= \
@@ -54,7 +53,6 @@ deps =
 
 [testenv:hypothesis]
 commands = pytest \
-           -n4 \
            --cov "{envsitepackagesdir}/sourmash" \
            --cov-config "{toxinidir}/tox.ini" \
            --cov-report= \
@@ -69,7 +67,6 @@ basepython = python3.8
 deps =
   khmer
 commands = pytest \
-           -n4 \
            --cov "{envsitepackagesdir}/sourmash" \
            --cov-config "{toxinidir}/tox.ini" \
            --cov-report= \
@@ -82,7 +79,6 @@ basepython = python3.8
 deps =
   -e git+https://github.com/dib-lab/khmer.git#egg=khmer
 commands = pytest \
-           -n4 \
            --cov "{envsitepackagesdir}/sourmash" \
            --cov-config "{toxinidir}/tox.ini" \
            --cov-report= \

--- a/tox.ini
+++ b/tox.ini
@@ -40,6 +40,7 @@ extras =
     test
     storage
 commands = pytest \
+           -n4 \
            --cov "{envsitepackagesdir}/sourmash" \
            --cov-config "{toxinidir}/tox.ini" \
            --cov-report= \
@@ -53,6 +54,7 @@ deps =
 
 [testenv:hypothesis]
 commands = pytest \
+           -n4 \
            --cov "{envsitepackagesdir}/sourmash" \
            --cov-config "{toxinidir}/tox.ini" \
            --cov-report= \
@@ -67,6 +69,7 @@ basepython = python3.8
 deps =
   khmer
 commands = pytest \
+           -n4 \
            --cov "{envsitepackagesdir}/sourmash" \
            --cov-config "{toxinidir}/tox.ini" \
            --cov-report= \
@@ -79,6 +82,7 @@ basepython = python3.8
 deps =
   -e git+https://github.com/dib-lab/khmer.git#egg=khmer
 commands = pytest \
+           -n4 \
            --cov "{envsitepackagesdir}/sourmash" \
            --cov-config "{toxinidir}/tox.ini" \
            --cov-report= \


### PR DESCRIPTION
This PR:
* adds `pytest-xdist` to the dependencies in `pyproject.toml`.
* adds `-n4` to all pytest invocations by default, which runs the tests ~3x faster if 4 CPUs are available.
* adjusts the `Makefile` so that `make test` runs even if there's a `test/` directory or something lying around 🙄 

Fixes https://github.com/sourmash-bio/sourmash/issues/2040.
