### PR TITLE
[MRG] change rebase-strategy to disabled for rust dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,7 @@ updates:
   allow:
     - dependency-type: "direct"
   open-pull-requests-limit: 10
+  rebase-strategy: "disabled"  
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:


### PR DESCRIPTION
Our Rust dependency updates from dependabot sit around for a while and are often not something I can evaluate.  As they loiter, however, they are updated with every PR into `latest`. This PR (hopefully) changes that behavior so that the PRs will remain and can be evaluated and updated at a time of our choosing, without triggering lots of PR updates every time something new is merged into `latest`.

[rebase-strategy docs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#rebase-strategy)