### PR TITLE
[MRG] fix docs building for pip 22.2

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -12,7 +12,11 @@ conda:
   environment: doc/environment.yml
 
 python:
-  version: 3.10
+  # NOTE: doc/environment.yml specifies python=3.10, which is needed
+  # b/c of a pip problem; see
+  # https://github.com/sourmash-bio/sourmash/issues/2139
+  # this 'version' setting is effectively ignored, AFAICT. -- CTB 7/24/22
+  version: 3.8
   install:
     - method: pip
       path: .

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -12,7 +12,7 @@ conda:
   environment: doc/environment.yml
 
 python:
-  version: 3.8
+  version: 3.10
   install:
     - method: pip
       path: .

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -3,4 +3,5 @@ channels:
   - defaults
 dependencies:
   - rust
-  - python =3.8
+  - python=3.8
+  - pip

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -3,5 +3,5 @@ channels:
   - defaults
 dependencies:
   - rust
-  - python=3.8
+  - python=3.10
   - pip


### PR DESCRIPTION
This PR fixes https://github.com/sourmash-bio/sourmash/issues/2139.

In brief, docs building failed on readthedocs immediately after pip 22.2 was released. It looks very similar to https://github.com/pypa/pip/issues/11294 which is caused by some underlying distutils interaction.

The fix is to ask the conda environment for docs building to use python=3.10, in `doc/environment.yml`.

This PR also adds `pip` to the `doc/environment.yml` file per this message in the readthedocs build -
```
Warning: you have pip-installed dependencies in your environment file, but you do not list pip itself as one of your conda dependencies.  Conda may not use the correct pip to install your packages, and they may end up in the wrong place.  Please add an explicit pip dependency.  I'm adding one for you, but still nagging you.
```
