### PR TITLE
[MRG] fix readthedocs build for sphinx 5.10

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -37,7 +37,7 @@ extensions = [
     'sphinx.ext.doctest',
     'sphinx.ext.coverage',
     'sphinx.ext.viewcode',
-    'sphinx.ext.napoleon',
+#    'sphinx.ext.napoleon',
     'nbsphinx',
     'IPython.sphinxext.ipython_console_highlighting',
     'myst_parser'
@@ -74,7 +74,7 @@ version = '.'.join(release.split('.')[:2])
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:


### PR DESCRIPTION
Sphinx 5.10 was released today and (frustratingly) our doc builds broke. Again.

This PR fixes the doc builds by adjusting `doc/conf.py` to:
* disable the napoleon sphinx extension;
* setting `language='en'`;

sphinx release from https://pypi.org/project/Sphinx/#history:

<img width="781" alt="Screen Shot 2022-07-24 at 12 03 01 PM" src="https://user-images.githubusercontent.com/51016/180655914-a75a559e-c16d-4546-bb12-0f7e3ca59112.png">
