### PR TITLE
[MRG] fix notification message about query scaled

### DIFF
--- a/src/sourmash/commands.py
+++ b/src/sourmash/commands.py
@@ -1214,7 +1214,7 @@ def prefetch(args):
         notify(f'downsampling query from scaled={query_mh.scaled} to {int(args.scaled)}')
         query_mh = query_mh.downsample(scaled=args.scaled)
 
-    notify(f"all sketches will be downsampled to scaled={query_mh.scaled}")
+    notify(f"query sketch has scaled={query_mh.scaled}; will be dynamically downsampled as needed.")
     common_scaled = query_mh.scaled
 
     # empty?

--- a/tests/test_prefetch.py
+++ b/tests/test_prefetch.py
@@ -39,7 +39,7 @@ def test_prefetch_basic(runtmp, linear_gather):
     assert "WARNING: no output(s) specified! Nothing will be saved from this prefetch!" in c.last_result.err
     assert "selecting specified query k=31" in c.last_result.err
     assert "loaded query: NC_009665.1 Shewanella baltica... (k=31, DNA)" in c.last_result.err
-    assert "all sketches will be downsampled to scaled=1000" in c.last_result.err
+    assert "query sketch has scaled=1000; will be dynamically downsampled as needed" in c.last_result.err
 
     assert "total of 2 matching signatures." in c.last_result.err
     assert "of 5177 distinct query hashes, 5177 were found in matches above threshold." in c.last_result.err
@@ -141,7 +141,7 @@ def test_prefetch_query_abund(runtmp, linear_gather):
     assert "WARNING: no output(s) specified! Nothing will be saved from this prefetch!" in c.last_result.err
     assert "selecting specified query k=31" in c.last_result.err
     assert "loaded query: NC_009665.1 Shewanella baltica... (k=31, DNA)" in c.last_result.err
-    assert "all sketches will be downsampled to scaled=1000" in c.last_result.err
+    assert "query sketch has scaled=1000; will be dynamically downsampled as needed" in c.last_result.err
 
     assert "total of 2 matching signatures." in c.last_result.err
     assert "of 5177 distinct query hashes, 5177 were found in matches above threshold." in c.last_result.err
@@ -167,7 +167,7 @@ def test_prefetch_subj_abund(runtmp, linear_gather):
     assert "WARNING: no output(s) specified! Nothing will be saved from this prefetch!" in c.last_result.err
     assert "selecting specified query k=31" in c.last_result.err
     assert "loaded query: NC_009665.1 Shewanella baltica... (k=31, DNA)" in c.last_result.err
-    assert "all sketches will be downsampled to scaled=1000" in c.last_result.err
+    assert "query sketch has scaled=1000; will be dynamically downsampled as needed" in c.last_result.err
 
     assert "total of 2 matching signatures." in c.last_result.err
     assert "of 5177 distinct query hashes, 5177 were found in matches above threshold." in c.last_result.err
@@ -454,7 +454,7 @@ def test_prefetch_db_fromfile(runtmp, linear_gather):
     assert "WARNING: no output(s) specified! Nothing will be saved from this prefetch!" in c.last_result.err
     assert "selecting specified query k=31" in c.last_result.err
     assert "loaded query: NC_009665.1 Shewanella baltica... (k=31, DNA)" in c.last_result.err
-    assert "all sketches will be downsampled to scaled=1000" in c.last_result.err
+    assert "query sketch has scaled=1000; will be dynamically downsampled as needed" in c.last_result.err
 
     assert "total of 2 matching signatures." in c.last_result.err
     assert "of 5177 distinct query hashes, 5177 were found in matches above threshold." in c.last_result.err


### PR DESCRIPTION
New good message:
```
query sketch has scaled=1000; will be dynamically downsampled as needed.
```

Old bad message:
```
all sketches will be downsampled to scaled=1000
```

Fixes https://github.com/sourmash-bio/sourmash/issues/2182
