### PR TITLE
[MRG] update database load UX for `gather` etc.

### DIFF
--- a/src/sourmash/cli/gather.py
+++ b/src/sourmash/cli/gather.py
@@ -144,7 +144,7 @@ def subparser(subparsers):
         dest='fail_on_empty_database',
         help='continue past databases that contain no compatible signatures'
     )
-    subparser.set_defaults(fail_on_empty_database=False)
+    subparser.set_defaults(fail_on_empty_database=True)
 
     add_ksize_arg(subparser, 31)
     add_moltype_args(subparser)

--- a/src/sourmash/cli/gather.py
+++ b/src/sourmash/cli/gather.py
@@ -136,15 +136,15 @@ def subparser(subparsers):
         help='also output confidence intervals for ANI estimates'
     )
     subparser.add_argument(
-        '--fail-on-empty-database', action='store_false',
+        '--fail-on-empty-database', action='store_true',
         help='stop at databases that contain no compatible signatures'
     )
     subparser.add_argument(
-        '--no-fail-on-empty-database', action='store_true',
+        '--no-fail-on-empty-database', action='store_false',
         dest='fail_on_empty_database',
         help='continue past databases that contain no compatible signatures'
     )
-    subparser.set_defaults(fail_on_empty_database=True)
+    subparser.set_defaults(fail_on_empty_database=False)
 
     add_ksize_arg(subparser, 31)
     add_moltype_args(subparser)

--- a/src/sourmash/cli/gather.py
+++ b/src/sourmash/cli/gather.py
@@ -135,6 +135,10 @@ def subparser(subparsers):
         '--estimate-ani-ci', action='store_true',
         help='also output confidence intervals for ANI estimates'
     )
+    subparser.add_argument(
+        '--fail-on-empty-database', action='store_false',
+        help='continue past databases that contain no compatible signatures'
+    )
     add_ksize_arg(subparser, 31)
     add_moltype_args(subparser)
     add_picklist_args(subparser)

--- a/src/sourmash/cli/gather.py
+++ b/src/sourmash/cli/gather.py
@@ -137,8 +137,15 @@ def subparser(subparsers):
     )
     subparser.add_argument(
         '--fail-on-empty-database', action='store_false',
+        help='stop at databases that contain no compatible signatures'
+    )
+    subparser.add_argument(
+        '--no-fail-on-empty-database', action='store_true',
+        dest='fail_on_empty_database',
         help='continue past databases that contain no compatible signatures'
     )
+    subparser.set_defaults(fail_on_empty_database=True)
+
     add_ksize_arg(subparser, 31)
     add_moltype_args(subparser)
     add_picklist_args(subparser)

--- a/src/sourmash/cli/multigather.py
+++ b/src/sourmash/cli/multigather.py
@@ -73,15 +73,15 @@ def subparser(subparsers):
         help='also output confidence intervals for ANI estimates'
     )
     subparser.add_argument(
-        '--fail-on-empty-database', action='store_false',
+        '--fail-on-empty-database', action='store_true',
         help='stop at databases that contain no compatible signatures'
     )
     subparser.add_argument(
-        '--no-fail-on-empty-database', action='store_true',
+        '--no-fail-on-empty-database', action='store_false',
         dest='fail_on_empty_database',
         help='continue past databases that contain no compatible signatures'
     )
-    subparser.set_defaults(fail_on_empty_database=True)
+    subparser.set_defaults(fail_on_empty_database=False)
 
     add_ksize_arg(subparser, 31)
     add_moltype_args(subparser)

--- a/src/sourmash/cli/multigather.py
+++ b/src/sourmash/cli/multigather.py
@@ -72,6 +72,17 @@ def subparser(subparsers):
         '--estimate-ani-ci', action='store_true',
         help='also output confidence intervals for ANI estimates'
     )
+    subparser.add_argument(
+        '--fail-on-empty-database', action='store_false',
+        help='stop at databases that contain no compatible signatures'
+    )
+    subparser.add_argument(
+        '--no-fail-on-empty-database', action='store_true',
+        dest='fail_on_empty_database',
+        help='continue past databases that contain no compatible signatures'
+    )
+    subparser.set_defaults(fail_on_empty_database=True)
+
     add_ksize_arg(subparser, 31)
     add_moltype_args(subparser)
     add_scaled_arg(subparser, 0)

--- a/src/sourmash/cli/multigather.py
+++ b/src/sourmash/cli/multigather.py
@@ -81,7 +81,7 @@ def subparser(subparsers):
         dest='fail_on_empty_database',
         help='continue past databases that contain no compatible signatures'
     )
-    subparser.set_defaults(fail_on_empty_database=False)
+    subparser.set_defaults(fail_on_empty_database=True)
 
     add_ksize_arg(subparser, 31)
     add_moltype_args(subparser)

--- a/src/sourmash/cli/search.py
+++ b/src/sourmash/cli/search.py
@@ -101,6 +101,17 @@ def subparser(subparsers):
         '--md5', default=None,
         help='select the signature with this md5 as query'
     )
+    subparser.add_argument(
+        '--fail-on-empty-database', action='store_false',
+        help='stop at databases that contain no compatible signatures'
+    )
+    subparser.add_argument(
+        '--no-fail-on-empty-database', action='store_true',
+        dest='fail_on_empty_database',
+        help='continue past databases that contain no compatible signatures'
+    )
+    subparser.set_defaults(fail_on_empty_database=True)
+
     add_ksize_arg(subparser, 31)
     add_moltype_args(subparser)
     add_picklist_args(subparser)

--- a/src/sourmash/cli/search.py
+++ b/src/sourmash/cli/search.py
@@ -102,11 +102,11 @@ def subparser(subparsers):
         help='select the signature with this md5 as query'
     )
     subparser.add_argument(
-        '--fail-on-empty-database', action='store_false',
+        '--fail-on-empty-database', action='store_true',
         help='stop at databases that contain no compatible signatures'
     )
     subparser.add_argument(
-        '--no-fail-on-empty-database', action='store_true',
+        '--no-fail-on-empty-database', action='store_false',
         dest='fail_on_empty_database',
         help='continue past databases that contain no compatible signatures'
     )

--- a/src/sourmash/commands.py
+++ b/src/sourmash/commands.py
@@ -498,10 +498,6 @@ def search(args):
                                                 picklist=picklist,
                                                 pattern=pattern_search)
 
-    if not len(databases):
-        error('Nothing found to search!')
-        sys.exit(-1)
-
     # handle signatures with abundance
     if query.minhash.track_abundance:
         if args.ignore_abundance:
@@ -703,10 +699,6 @@ def gather(args):
                                                 cache_size=cache_size,
                                                 picklist=picklist,
                                                 pattern=pattern_search)
-
-    if not len(databases):
-        error('Nothing found to search!')
-        sys.exit(-1)
 
     if args.linear:             # force linear traversal?
         databases = [ LazyLinearIndex(db) for db in databases ]
@@ -912,10 +904,6 @@ def multigather(args):
     query = next(iter(sourmash_args.load_file_as_signatures(inp_files[0], ksize=args.ksize, select_moltype=moltype)))
 
     databases = sourmash_args.load_dbs_and_sigs(args.db, query, False)
-
-    if not len(databases):
-        error('Nothing found to search!')
-        sys.exit(-1)
 
     # run gather on all the queries.
     n=0

--- a/src/sourmash/commands.py
+++ b/src/sourmash/commands.py
@@ -938,7 +938,11 @@ def multigather(args):
 
             counters = []
             for db in databases:
-                counter = db.counter_gather(prefetch_query, args.threshold_bp)
+                try:
+                    counter = db.counter_gather(prefetch_query, args.threshold_bp)
+                except ValueError:
+                    # catch "no signatures to search" ValueError if empty db.
+                    continue
                 counters.append(counter)
 
                 # track found/not found hashes

--- a/src/sourmash/commands.py
+++ b/src/sourmash/commands.py
@@ -730,12 +730,8 @@ def gather(args):
             try:
                 counter = db.counter_gather(prefetch_query, args.threshold_bp)
             except ValueError:
-                if picklist or pattern_search:
-                    # catch "no signatures to search" ValueError from filtering
-                    continue
-                else:
-                    # @CTB test me?
-                    raise       # re-raise other errors, if no picklist.
+                # catch "no signatures to search" ValueError if empty db.
+                continue
 
             save_prefetch.add_many(counter.signatures())
 

--- a/src/sourmash/commands.py
+++ b/src/sourmash/commands.py
@@ -496,7 +496,8 @@ def search(args):
     databases = sourmash_args.load_dbs_and_sigs(args.databases, query,
                                                 not is_containment,
                                                 picklist=picklist,
-                                                pattern=pattern_search)
+                                                pattern=pattern_search,
+                                                fail_on_empty_database=args.fail_on_empty_database)
 
     # handle signatures with abundance
     if query.minhash.track_abundance:
@@ -905,7 +906,8 @@ def multigather(args):
     # need a query to get ksize, moltype for db loading
     query = next(iter(sourmash_args.load_file_as_signatures(inp_files[0], ksize=args.ksize, select_moltype=moltype)))
 
-    databases = sourmash_args.load_dbs_and_sigs(args.db, query, False)
+    databases = sourmash_args.load_dbs_and_sigs(args.db, query, False,
+                                                fail_on_empty_database=args.fail_on_empty_database)
 
     # run gather on all the queries.
     n=0

--- a/src/sourmash/commands.py
+++ b/src/sourmash/commands.py
@@ -698,7 +698,9 @@ def gather(args):
     databases = sourmash_args.load_dbs_and_sigs(args.databases, query, False,
                                                 cache_size=cache_size,
                                                 picklist=picklist,
-                                                pattern=pattern_search)
+                                                pattern=pattern_search,
+                                                fail_on_empty_database=args.fail_on_empty_database)
+
 
     if args.linear:             # force linear traversal?
         databases = [ LazyLinearIndex(db) for db in databases ]

--- a/src/sourmash/sourmash_args.py
+++ b/src/sourmash/sourmash_args.py
@@ -323,6 +323,7 @@ def load_dbs_and_sigs(filenames, query, is_similarity_query, *,
             notify(f"ERROR: cannot use '{filename}' for this query.")
             notify(str(exc))
             if fail_on_empty_database:
+                print('XXX')
                 sys.exit(-1)
             else:
                 db = LinearIndex([])

--- a/src/sourmash/sourmash_args.py
+++ b/src/sourmash/sourmash_args.py
@@ -340,12 +340,13 @@ def load_dbs_and_sigs(filenames, query, is_similarity_query, *,
     notify(f"loaded {total_signatures_loaded} total signatures from {len(databases)} locations.")
     notify(f"after selecting signatures compatible with search, {sum_signatures} remain.")
 
-    if databases:
+    if sum_signatures:
         print('')
     else:
         # @CTB should this be subject to fail_on_empty_databases?
+        # @CTB test me.
         notify('** ERROR: no signatures or databases loaded?')
-        sys.exit(-1)
+        #sys.exit(-1)
 
     return databases
 

--- a/src/sourmash/sourmash_args.py
+++ b/src/sourmash/sourmash_args.py
@@ -323,6 +323,8 @@ def load_dbs_and_sigs(filenames, query, is_similarity_query, *,
             notify(str(exc))
             if fail_on_empty_database:
                 sys.exit(-1)
+            else:
+                db = LinearIndex([])
 
         # 'select' returns nothing => all signatures filtered out. fail!
         if not db:
@@ -338,6 +340,7 @@ def load_dbs_and_sigs(filenames, query, is_similarity_query, *,
     # calc num loaded/num selected info & display.
     sum_signatures = sum([ len(db) for db in databases ])
 
+    notify("--")
     notify(f"loaded {total_signatures_loaded} total signatures from {len(databases)} locations.")
     notify(f"after selecting signatures compatible with search, {sum_signatures} remain.")
 

--- a/src/sourmash/sourmash_args.py
+++ b/src/sourmash/sourmash_args.py
@@ -297,6 +297,7 @@ def load_dbs_and_sigs(filenames, query, is_similarity_query, *,
         containment = False
 
     databases = []
+    sum_signatures = 0
     for filename in filenames:
         notify(f"loading from '{filename}'...", end='\r')
 
@@ -332,14 +333,14 @@ def load_dbs_and_sigs(filenames, query, is_similarity_query, *,
             if fail_on_empty_database:
                 sys.exit(-1)
 
+        sum_signatures += len(db)
+
         # last but not least, apply picklist!
         db = apply_picklist_and_pattern(db, picklist, pattern)
 
         databases.append(db)
 
-    # calc num loaded/num selected info & display.
-    sum_signatures = sum([ len(db) for db in databases ])
-
+    # display num loaded/num selected
     notify("--")
     notify(f"loaded {total_signatures_loaded} total signatures from {len(databases)} locations.")
     notify(f"after selecting signatures compatible with search, {sum_signatures} remain.")

--- a/src/sourmash/sourmash_args.py
+++ b/src/sourmash/sourmash_args.py
@@ -298,12 +298,13 @@ def load_dbs_and_sigs(filenames, query, is_similarity_query, *,
 
     databases = []
     for filename in filenames:
-        notify(f'loading from {filename}...', end='\r')
+        notify(f"loading from '{filename}'...", end='\r')
 
         try:
             db = _load_database(filename, False, cache_size=cache_size)
         except ValueError as e:
             # cannot load database!
+            notify(f"ERROR on loading from '{filename}':")
             notify(str(e))
             sys.exit(-1)
 
@@ -346,7 +347,7 @@ def load_dbs_and_sigs(filenames, query, is_similarity_query, *,
         # @CTB should this be subject to fail_on_empty_databases?
         # @CTB test me.
         notify('** ERROR: no signatures or databases loaded?')
-        #sys.exit(-1)
+        sys.exit(-1)
 
     return databases
 

--- a/src/sourmash/sourmash_args.py
+++ b/src/sourmash/sourmash_args.py
@@ -288,7 +288,6 @@ def load_dbs_and_sigs(filenames, query, is_similarity_query, *,
 
     'select' on compatibility with query, and apply picklists & patterns.
     """
-    total_signatures_loaded = 0
     query_mh = query.minhash
 
     # set selection parameter for containment
@@ -297,7 +296,8 @@ def load_dbs_and_sigs(filenames, query, is_similarity_query, *,
         containment = False
 
     databases = []
-    sum_signatures = 0
+    total_signatures_loaded = 0
+    sum_signatures_after_select = 0
     for filename in filenames:
         notify(f"loading from '{filename}'...", end='\r')
 
@@ -333,7 +333,7 @@ def load_dbs_and_sigs(filenames, query, is_similarity_query, *,
             if fail_on_empty_database:
                 sys.exit(-1)
 
-        sum_signatures += len(db)
+        sum_signatures_after_select += len(db)
 
         # last but not least, apply picklist!
         db = apply_picklist_and_pattern(db, picklist, pattern)
@@ -343,9 +343,9 @@ def load_dbs_and_sigs(filenames, query, is_similarity_query, *,
     # display num loaded/num selected
     notify("--")
     notify(f"loaded {total_signatures_loaded} total signatures from {len(databases)} locations.")
-    notify(f"after selecting signatures compatible with search, {sum_signatures} remain.")
+    notify(f"after selecting signatures compatible with search, {sum_signatures_after_select} remain.")
 
-    if sum_signatures:
+    if sum_signatures_after_select:
         print('')
     else:
         # @CTB should this be subject to fail_on_empty_databases?

--- a/src/sourmash/sourmash_args.py
+++ b/src/sourmash/sourmash_args.py
@@ -323,7 +323,6 @@ def load_dbs_and_sigs(filenames, query, is_similarity_query, *,
             notify(f"ERROR: cannot use '{filename}' for this query.")
             notify(str(exc))
             if fail_on_empty_database:
-                print('XXX')
                 sys.exit(-1)
             else:
                 db = LinearIndex([])

--- a/src/sourmash/sourmash_args.py
+++ b/src/sourmash/sourmash_args.py
@@ -344,14 +344,7 @@ def load_dbs_and_sigs(filenames, query, is_similarity_query, *,
     notify("--")
     notify(f"loaded {total_signatures_loaded} total signatures from {len(databases)} locations.")
     notify(f"after selecting signatures compatible with search, {sum_signatures_after_select} remain.")
-
-    if sum_signatures_after_select:
-        print('')
-    else:
-        # @CTB should this be subject to fail_on_empty_databases?
-        # @CTB test me.
-        notify('** ERROR: no signatures or databases loaded?')
-        sys.exit(-1)
+    print('')
 
     return databases
 

--- a/tests/sourmash_tst_utils.py
+++ b/tests/sourmash_tst_utils.py
@@ -187,7 +187,7 @@ class RunnerContext(object):
             kwargs['in_directory'] = self.location
 
         cmdlist = ['sourmash']
-        cmdlist.extend(args)
+        cmdlist.extend(( str(x) for x in args))
         self.last_command = " ".join(cmdlist)
         self.last_result = runscript('sourmash', args, **kwargs)
 

--- a/tests/test_lca.py
+++ b/tests/test_lca.py
@@ -2335,8 +2335,9 @@ def test_compare_csv_real(runtmp):
     assert '0 incompatible at rank species' in runtmp.last_result.err
 
 
-def test_incompat_lca_db_ksize_2(runtmp, lca_db_format):
-    # test on gather - create a database with ksize of 25
+def test_incompat_lca_db_ksize_2_fail(runtmp, lca_db_format):
+    # test on gather - create a database with ksize of 25 => fail
+    # because of incompatibility.
     c = runtmp
     testdata1 = utils.get_test_data('lca/TARA_ASE_MAG_00031.fa.gz')
     c.run_sourmash('sketch', 'dna', '-p', 'k=25,scaled=1000', testdata1,
@@ -2353,6 +2354,34 @@ def test_incompat_lca_db_ksize_2(runtmp, lca_db_format):
     # no compatible ksizes.
     with pytest.raises(SourmashCommandFailed) as e:
         c.run_sourmash('gather', utils.get_test_data('lca/TARA_ASE_MAG_00031.sig'), f'test.lca.{lca_db_format}')
+
+    err = c.last_result.err
+    print(err)
+
+    if lca_db_format == 'sql':
+        assert "no compatible signatures found in 'test.lca.sql'" in err
+    else:
+        assert "ERROR: cannot use 'test.lca.json' for this query." in err
+        assert "ksize on this database is 25; this is different from requested ksize of 31"
+
+
+def test_incompat_lca_db_ksize_2_nofail(runtmp, lca_db_format):
+    # test on gather - create a database with ksize of 25, no fail
+    # because of --no-fail-on-empty-databases
+    c = runtmp
+    testdata1 = utils.get_test_data('lca/TARA_ASE_MAG_00031.fa.gz')
+    c.run_sourmash('sketch', 'dna', '-p', 'k=25,scaled=1000', testdata1,
+                   '-o', 'test_db.sig')
+    print(c)
+
+    c.run_sourmash('lca', 'index', utils.get_test_data('lca/delmont-1.csv',),
+                   f'test.lca.{lca_db_format}', 'test_db.sig',
+                    '-k', '25', '--scaled', '10000',
+                   '-F', lca_db_format)
+    print(c)
+
+    # this should not fail despite mismatched ksize, b/c of --no-fail flag.
+    c.run_sourmash('gather', utils.get_test_data('lca/TARA_ASE_MAG_00031.sig'), f'test.lca.{lca_db_format}', '--no-fail-on-empty-database')
 
     err = c.last_result.err
     print(err)

--- a/tests/test_prefetch.py
+++ b/tests/test_prefetch.py
@@ -425,7 +425,7 @@ def test_prefetch_no_num_subj(runtmp, linear_gather):
     print(c.last_result.err)
 
     assert c.last_result.status != 0
-    assert "ERROR in prefetch: no compatible signatures in any databases?!" in c.last_result.err
+    assert "ERROR in prefetch: after picklists and patterns, no signatures to search!?" in c.last_result.err
 
 
 def test_prefetch_db_fromfile(runtmp, linear_gather):

--- a/tests/test_prefetch.py
+++ b/tests/test_prefetch.py
@@ -41,6 +41,10 @@ def test_prefetch_basic(runtmp, linear_gather):
     assert "loaded query: NC_009665.1 Shewanella baltica... (k=31, DNA)" in c.last_result.err
     assert "query sketch has scaled=1000; will be dynamically downsampled as needed" in c.last_result.err
 
+    err = c.last_result.err
+    assert "loaded 5 total signatures from 3 locations." in err
+    assert "after selecting signatures compatible with search, 3 remain." in err
+
     assert "total of 2 matching signatures." in c.last_result.err
     assert "of 5177 distinct query hashes, 5177 were found in matches above threshold." in c.last_result.err
     assert "a total of 0 query hashes remain unmatched." in c.last_result.err

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -2187,6 +2187,40 @@ def test_search_with_pattern_exclude(runtmp):
     assert "32.2%       NC_006905.1 Salmonella" in out
 
 
+def test_search_empty_db_fail(runtmp):
+    # search should fail on empty db with --fail-on-empty-database
+    query = utils.get_test_data('2.fa.sig')
+    against = utils.get_test_data('47.fa.sig')
+    against2 = utils.get_test_data('lca/47+63.lca.json')
+
+    with pytest.raises(SourmashCommandFailed):
+        runtmp.sourmash('search', query, against, against2, '-k', '51')
+
+
+    err = runtmp.last_result.err
+    assert "no compatible signatures found in " in err
+
+
+def test_search_empty_db_nofail(runtmp):
+    # search should not fail on empty db with --no-fail-on-empty-database
+    query = utils.get_test_data('2.fa.sig')
+    against = utils.get_test_data('47.fa.sig')
+    against2 = utils.get_test_data('lca/47+63.lca.json')
+
+    runtmp.sourmash('search', query, against, against2, '-k', '51',
+                    '--no-fail-on-empty-data')
+
+    out = runtmp.last_result.out
+    err = runtmp.last_result.err
+    print(out)
+    print(err)
+
+    assert "no compatible signatures found in " in err
+    assert "ksize on this database is 31; this is different from requested ksize of 51" in err
+    assert "loaded 50 total signatures from 2 locations" in err
+    assert "after selecting signatures compatible with search, 0 remain." in err
+
+
 def test_mash_csv_to_sig(runtmp):
     testdata1 = utils.get_test_data('short.fa.msh.dump')
     testdata2 = utils.get_test_data('short.fa')

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -4482,6 +4482,41 @@ def test_gather_output_unassigned_with_abundance(runtmp, prefetch_gather, linear
             assert nomatch_mh.hashes[hashval] == abund
 
 
+def test_gather_empty_db_fail(runtmp, linear_gather, prefetch_gather):
+    # gather should fail on empty db with --fail-on-empty-database
+    query = utils.get_test_data('2.fa.sig')
+    against = utils.get_test_data('47.fa.sig')
+    against2 = utils.get_test_data('lca/47+63.lca.json')
+
+    with pytest.raises(SourmashCommandFailed):
+        runtmp.sourmash('gather', query, against, against2, '-k', '51',
+                        linear_gather, prefetch_gather)
+
+
+    err = runtmp.last_result.err
+    assert "no compatible signatures found in " in err
+
+
+def test_gather_empty_db_nofail(runtmp, prefetch_gather, linear_gather):
+    # gather should not fail on empty db with --no-fail-on-empty-database
+    query = utils.get_test_data('2.fa.sig')
+    against = utils.get_test_data('47.fa.sig')
+    against2 = utils.get_test_data('lca/47+63.lca.json')
+
+    runtmp.sourmash('gather', query, against, against2, '-k', '51',
+                    '--no-fail-on-empty-data',
+                    linear_gather, prefetch_gather)
+
+    out = runtmp.last_result.out
+    err = runtmp.last_result.err
+    print(out)
+    print(err)
+
+    assert "no compatible signatures found in " in err
+    assert "ksize on this database is 31; this is different from requested ksize of 51" in err
+    assert "loaded 50 total signatures from 2 locations" in err
+    assert "after selecting signatures compatible with search, 0 remain." in err
+
 def test_multigather_output_unassigned_with_abundance(runtmp):
     c = runtmp
     query = utils.get_test_data('gather-abund/reads-s10x10-s11.sig')
@@ -4511,6 +4546,41 @@ def test_multigather_output_unassigned_with_abundance(runtmp):
         if hashval not in against_ss.minhash.hashes:
             assert nomatch_mh.hashes[hashval] == abund
 
+
+def test_multigather_empty_db_fail(runtmp):
+    # multigather should fail on empty db with --fail-on-empty-database
+    query = utils.get_test_data('2.fa.sig')
+    against = utils.get_test_data('47.fa.sig')
+    against2 = utils.get_test_data('lca/47+63.lca.json')
+
+    with pytest.raises(SourmashCommandFailed):
+        runtmp.sourmash('multigather', '--query', query,
+                        '--db', against, against2, '-k', '51')
+
+    err = runtmp.last_result.err
+    assert "no compatible signatures found in " in err
+
+
+def test_multigather_empty_db_nofail(runtmp):
+    # multigather should not fail on empty db with --no-fail-on-empty-database
+    query = utils.get_test_data('2.fa.sig')
+    against = utils.get_test_data('47.fa.sig')
+    against2 = utils.get_test_data('lca/47+63.lca.json')
+
+    runtmp.sourmash('multigather', '--query', query,
+                    '--db', against, against2, '-k', '51',
+                    '--no-fail-on-empty-data')
+
+    out = runtmp.last_result.out
+    err = runtmp.last_result.err
+    print(out)
+    print(err)
+
+    assert "no compatible signatures found in " in err
+    assert "ksize on this database is 31; this is different from requested ksize of 51" in err
+    assert "conducted gather searches on 0 signatures" in err
+    assert "loaded 50 total signatures from 2 locations" in err
+    assert "after selecting signatures compatible with search, 0 remain." in err
 
 def test_sbt_categorize(runtmp):
     testdata1 = utils.get_test_data('genome-s10.fa.gz.sig')

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -3957,7 +3957,11 @@ def test_gather_query_downsample(runtmp, linear_gather, prefetch_gather):
     print(runtmp.last_result.out)
     print(runtmp.last_result.err)
 
-    assert 'loaded 12 signatures' in runtmp.last_result.err
+    err = runtmp.last_result.err
+
+    assert 'loaded 36 total signatures from 12 locations.' in err
+    assert 'after selecting signatures compatible with search, 12 remain.' in err
+
     assert all(('4.9 Mbp      100.0%  100.0%' in runtmp.last_result.out,
                 'NC_003197.2' in runtmp.last_result.out))
 
@@ -3976,7 +3980,11 @@ def test_gather_query_downsample_explicit(runtmp, linear_gather, prefetch_gather
     print(runtmp.last_result.out)
     print(runtmp.last_result.err)
 
-    assert 'loaded 12 signatures' in runtmp.last_result.err
+    err = runtmp.last_result.err
+
+    assert 'loaded 36 total signatures from 12 locations.' in err
+    assert 'after selecting signatures compatible with search, 12 remain.' in err
+
     assert all(('4.9 Mbp      100.0%  100.0%' in runtmp.last_result.out,
                 'NC_003197.2' in runtmp.last_result.out))
 


### PR DESCRIPTION
Fixes https://github.com/sourmash-bio/sourmash/issues/2200
Fixes https://github.com/sourmash-bio/sourmash/issues/1637

This PR changes loading output during `gather` from:
```
loaded 64 signatures and 1 databases total.
```
to:
```
loaded 384 total signatures from 65 locations.
after selecting signatures compatible with search, 128 remain.
```
and also provides a command line switch `--fail-on-empty-databases` that (until v5) defaults to True.

This PR also removes the only non-diagnostic use of `Index.is_database`, addressing https://github.com/sourmash-bio/sourmash/issues/1894; it also converts `ValueError` on an `Index.select` into an empty database _but only for CLI purposes_, viz https://github.com/sourmash-bio/sourmash/issues/1940.

Fixes https://github.com/sourmash-bio/sourmash/issues/1940 (or, really, wontfix :)

## TODO

- [x] create v5 issue to change default on `--fail-on-empty-databases`
- [x] update other uses of `load_dbs_and_sigs`
- [x] write tests for `--no-fail-on-empty`
- [x] write more tests for `--fail-on-empty` 😆 