### PR TITLE
[MRG] use stderr for test output printing

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 from hypothesis import settings, Verbosity
 import pytest
@@ -7,7 +8,7 @@ import matplotlib.pyplot as plt
 plt.rcParams.update({'figure.max_open_warning': 0})
 
 from sourmash_tst_utils import TempDirectory, RunnerContext
-
+sys.stdout = sys.stderr
 
 @pytest.fixture
 def runtmp():


### PR DESCRIPTION
Sets `sys.stdout=sys.stderr`, per https://github.com/sourmash-bio/sourmash/pull/2138#issuecomment-1216779696. Suggested as a solution to `pytest-xdist` not printing test output here: https://github.com/pytest-dev/pytest-xdist/issues/354#issuecomment-430502446

restores test output printing

@ctb is this a desired solution? Or did you find a better workaround?