### PR TITLE
[MRG] fix ReadTheDocs by using a more recent conda version

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04, macos-latest]
+        os: [ubuntu-22.04, macos-latest]
         py: ["3.10", "3.9", "3.8"]
       fail-fast: false
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -17,11 +17,6 @@ conda:
   environment: doc/environment.yml
 
 python:
-  # NOTE: doc/environment.yml specifies python=3.10, which is needed
-  # b/c of a pip problem; see
-  # https://github.com/sourmash-bio/sourmash/issues/2139
-  # this 'version' setting is effectively ignored, AFAICT. -- CTB 7/24/22
-  version: 3.8
   install:
     - method: pip
       path: .

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,6 +4,11 @@
 
 version: 2
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: miniconda3-4.7
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: doc/conf.py


### PR DESCRIPTION
This PR adjusts `.readthedocs.yml` to use a more recent conda version per https://github.com/readthedocs/readthedocs.org/issues/9527#issuecomment-1222063156.

It also updates Ubuntu from 18.04 to 22.04 per github recommendations [here](https://github.com/actions/runner-images/issues/6002).

Fixes https://github.com/sourmash-bio/sourmash/issues/2227.
