### PR TITLE
[MRG] remove pre-calculated containment input as option for containment ani

### DIFF
--- a/src/sourmash/minhash.py
+++ b/src/sourmash/minhash.py
@@ -774,7 +774,7 @@ class MinHash(RustObject):
             return containment
 
 
-    def containment_ani(self, other, *, downsample=False, containment=None, confidence=0.95, estimate_ci = False, prob_threshold=1e-3):
+    def containment_ani(self, other, *, downsample=False, confidence=0.95, estimate_ci = False, prob_threshold=1e-3):
         "Use self contained by other to estimate ANI between two MinHash objects."
         if not (self.scaled and other.scaled):
             raise TypeError("Error: can only calculate ANI for scaled MinHashes")
@@ -786,7 +786,6 @@ class MinHash(RustObject):
             self_mh = self.downsample(scaled=scaled)
             other_mh = other.downsample(scaled=scaled)
         containment = self_mh.contained_by_debiased(other_mh) # recalc debiased containment
-        #containment = self_mh.contained_by(other_mh) # recalc debiased containment
         n_kmers = len(self_mh) * scaled # would be better if hll estimate - see #1798
 
         c_aniresult = containment_to_distance(containment, self_mh.ksize, self_mh.scaled,
@@ -831,7 +830,7 @@ class MinHash(RustObject):
         else:
             return max_containment
 
-    def max_containment_ani(self, other, *, downsample=False, max_containment=None, confidence=0.95, estimate_ci=False, prob_threshold=1e-3):  
+    def max_containment_ani(self, other, *, downsample=False, confidence=0.95, estimate_ci=False, prob_threshold=1e-3):
         "Use max_containment to estimate ANI between two MinHash objects."
         if not (self.scaled and other.scaled):
             raise TypeError("Error: can only calculate ANI for scaled MinHashes")

--- a/src/sourmash/signature.py
+++ b/src/sourmash/signature.py
@@ -153,20 +153,20 @@ class SourmashSignature(RustObject):
         "Compute containment by the other signature. Note: ignores abundance."
         return self.minhash.contained_by(other.minhash, downsample=downsample)
 
-    def containment_ani(self, other, *, downsample=False, containment=None, confidence=0.95, estimate_ci=False):
+    def containment_ani(self, other, *, downsample=False, confidence=0.95, estimate_ci=False):
         "Use containment to estimate ANI between two FracMinHash signatures."
         return self.minhash.containment_ani(other.minhash, downsample=downsample,
-                                        containment=containment, confidence=confidence,
+                                        confidence=confidence,
                                         estimate_ci=estimate_ci)
 
     def max_containment(self, other, downsample=False):
         "Compute max containment w/other signature. Note: ignores abundance."
         return self.minhash.max_containment(other.minhash, downsample=downsample)
 
-    def max_containment_ani(self, other, *, downsample=False, max_containment=None, confidence=0.95, estimate_ci=False):
+    def max_containment_ani(self, other, *, downsample=False, confidence=0.95, estimate_ci=False):
         "Use max containment to estimate ANI between two FracMinHash signatures."
         return self.minhash.max_containment_ani(other.minhash, downsample=downsample,
-                                                max_containment=max_containment, confidence=confidence,
+                                                confidence=confidence,
                                                 estimate_ci=estimate_ci)
 
     def avg_containment(self, other, downsample=False):

--- a/src/sourmash/sketchcomparison.py
+++ b/src/sourmash/sketchcomparison.py
@@ -127,10 +127,9 @@ class FracMinHashComparison(BaseMinHashComparison):
     def mh1_containment_in_mh2(self):
         return self.mh1_cmp.contained_by(self.mh2_cmp)
 
-    def estimate_ani_from_mh1_containment_in_mh2(self, containment = None):
+    def estimate_ani_from_mh1_containment_in_mh2(self):
         # build result once
         m1_cani = self.mh1_cmp.containment_ani(self.mh2_cmp,
-                                            containment=containment,
                                             confidence=self.ani_confidence,
                                             estimate_ci=self.estimate_ani_ci)
 #                                            prob_threshold=self.pfn_threshold)
@@ -147,9 +146,8 @@ class FracMinHashComparison(BaseMinHashComparison):
     def mh2_containment_in_mh1(self):
         return self.mh2_cmp.contained_by(self.mh1_cmp)
 
-    def estimate_ani_from_mh2_containment_in_mh1(self, containment=None):
+    def estimate_ani_from_mh2_containment_in_mh1(self):
         m2_cani =  self.mh2_cmp.containment_ani(self.mh1_cmp,
-                                            containment=containment,
                                             confidence=self.ani_confidence,
                                             estimate_ci=self.estimate_ani_ci)
 #                                            prob_threshold=self.pfn_threshold)
@@ -164,9 +162,8 @@ class FracMinHashComparison(BaseMinHashComparison):
     def max_containment(self):
         return self.mh1_cmp.max_containment(self.mh2_cmp)
 
-    def estimate_max_containment_ani(self, max_containment=None):
+    def estimate_max_containment_ani(self):
         mc_ani_info = self.mh1_cmp.max_containment_ani(self.mh2_cmp,
-                                                max_containment=max_containment,
                                                 confidence=self.ani_confidence,
                                                 estimate_ci=self.estimate_ani_ci)
 #                                                prob_threshold=self.pfn_threshold)

--- a/tests/test_minhash.py
+++ b/tests/test_minhash.py
@@ -2934,23 +2934,6 @@ def test_containment_ANI():
     assert (round(m1_mc_m2.ani, 3), round(m1_mc_m2.ani_low, 3), round(m1_mc_m2.ani_high, 3)) == (1.0,1.0,1.0)
 
 
-def test_containment_ANI_precalc_containment():
-    f1 = utils.get_test_data('47+63.fa.sig')
-    f2 = utils.get_test_data('2+63.fa.sig')
-    mh1 = sourmash.load_one_signature(f1, ksize=31).minhash
-    mh2 = sourmash.load_one_signature(f2, ksize=31).minhash
-    # precalc containments and assert same results
-    s1c = mh1.contained_by(mh2)
-    s2c = mh2.contained_by(mh1)
-    mc = max(s1c, s2c)
-
-    assert mh1.containment_ani(mh2, estimate_ci=True) ==  mh1.containment_ani(mh2, containment=s1c, estimate_ci=True)
-    assert mh2.containment_ani(mh1) ==  mh2.containment_ani(mh1, containment=s2c)
-    assert mh1.max_containment_ani(mh2) ==  mh2.max_containment_ani(mh1)
-    assert mh1.max_containment_ani(mh2) ==  mh1.max_containment_ani(mh2, max_containment=mc)
-    assert mh1.max_containment_ani(mh2) ==  mh2.max_containment_ani(mh1, max_containment=mc)
-
-
 def test_avg_containment_ani():
     f1 = utils.get_test_data('47+63.fa.sig')
     f2 = utils.get_test_data('2+63.fa.sig')

--- a/tests/test_signature.py
+++ b/tests/test_signature.py
@@ -470,23 +470,6 @@ def test_containment_ANI():
     assert (round(s1_mc_s2.ani, 3), round(s1_mc_s2.ani_low, 3), round(s1_mc_s2.ani_high, 3)) == (1.0,1.0,1.0)
 
 
-def test_containment_ANI_precalc_containment():
-    f1 = utils.get_test_data('47+63.fa.sig')
-    f2 = utils.get_test_data('2+63.fa.sig')
-    ss1 = sourmash.load_one_signature(f1, ksize=31)
-    ss2 = sourmash.load_one_signature(f2, ksize=31)
-    # precalc containments and assert same results
-    s1c = ss1.contained_by(ss2)
-    s2c = ss2.contained_by(ss1)
-    mc = max(s1c, s2c)
-
-    assert ss1.containment_ani(ss2, estimate_ci=True) ==  ss1.containment_ani(ss2, containment=s1c, estimate_ci=True)
-    assert ss2.containment_ani(ss1) ==  ss2.containment_ani(ss1, containment=s2c)
-    assert ss1.max_containment_ani(ss2) ==  ss2.max_containment_ani(ss1)
-    assert ss1.max_containment_ani(ss2) ==  ss1.max_containment_ani(ss2, max_containment=mc)
-    assert ss1.max_containment_ani(ss2) ==  ss2.max_containment_ani(ss1, max_containment=mc)
-
-
 def test_avg_containment():
     f1 = utils.get_test_data('47+63.fa.sig')
     f2 = utils.get_test_data('2+63.fa.sig')

--- a/tests/test_sketchcomparison.py
+++ b/tests/test_sketchcomparison.py
@@ -725,17 +725,17 @@ def test_FracMinHashComparison_ANI_provide_similarity(track_abundance):
     b_cont = b.contained_by(a)
     mc = a.max_containment(b)
 
-    cmp.estimate_ani_from_mh1_containment_in_mh2(containment=a_cont)
+    cmp.estimate_ani_from_mh1_containment_in_mh2()
     a_cont_ani_manual = a.containment_ani(b)
     assert cmp.ani_from_mh1_containment_in_mh2 == a_cont_ani_manual.ani
     assert cmp.potential_false_negative == a_cont_ani_manual.p_exceeds_threshold
 
-    cmp.estimate_ani_from_mh2_containment_in_mh1(containment=b_cont)
+    cmp.estimate_ani_from_mh2_containment_in_mh1()
     b_cont_ani_manual = b.containment_ani(a)
     assert cmp.ani_from_mh2_containment_in_mh1 == b_cont_ani_manual.ani
     assert cmp.potential_false_negative == b_cont_ani_manual.p_exceeds_threshold
 
-    cmp.estimate_max_containment_ani(max_containment=mc)
+    cmp.estimate_max_containment_ani()
     mc_ani_manual = a.max_containment_ani(b)
     assert cmp.max_containment_ani == max(a.containment_ani(b).ani, b.containment_ani(a).ani) == mc_ani_manual.ani
     assert cmp.potential_false_negative == mc_ani_manual.p_exceeds_threshold


### PR DESCRIPTION
Removes optional pre-calculated containment inputs to ANI functions. PR into #2057 

Because we're now forcing recalculation of de-biased containment in the ANI equations, any containment passed into ANI equations is not being used. I removed it entirely here, but kept this separate because if we end up using debiased containment more widely (5.0/6.0?), we may want to keep this functionality, so we can optionally avoid recalculating containment? 

If we want to remove the functionality: Merge this PR
Instead, keep the functionality: Discard this PR
