### PR TITLE
[MRG] do not allow `--force` to load gather results from query in multiple gather files

### DIFF
--- a/src/sourmash/tax/tax_utils.py
+++ b/src/sourmash/tax/tax_utils.py
@@ -109,13 +109,7 @@ def load_gather_results(gather_csv, *, delimiter=',',
             # check if we've seen this query already in a different gather CSV
             if query_name in seen_queries:
                 # do not allow loading of same query from a second CSV.
-                if force:
-                    if query_name not in gather_queries: # only notify once
-                        notify(f"Gather query {query_name} was found in more than one CSV. Cannot load from '{gather_csv}'.")
-                        gather_queries.add(query_name)
-                    continue # do not load this query
-                else:
-                    raise ValueError(f"Gather query {query_name} was found in more than one CSV. Cannot load from '{gather_csv}'.")
+                raise ValueError(f"Gather query {query_name} was found in more than one CSV. Cannot load from '{gather_csv}'.")
             else:
                 gather_results.append(row)
             # add query name to the gather_queries from this CSV
@@ -147,6 +141,9 @@ def check_and_load_gather_csvs(gather_csvs, tax_assign, *, fail_on_missing_taxon
             these_results, header, seen_queries = load_gather_results(gather_csv, seen_queries=seen_queries, force=force)
         except ValueError as exc:
             if force:
+                if "found in more than one CSV" in str(exc):
+                    notify('Cannot force past duplicated gather query. Exiting.')
+                    raise
                 notify(str(exc))
                 notify('--force is set. Attempting to continue to next set of gather results.')
                 n_ignored+=1

--- a/src/sourmash/tax/tax_utils.py
+++ b/src/sourmash/tax/tax_utils.py
@@ -109,7 +109,13 @@ def load_gather_results(gather_csv, *, delimiter=',',
             # check if we've seen this query already in a different gather CSV
             if query_name in seen_queries:
                 # do not allow loading of same query from a second CSV.
-                raise ValueError(f"Gather query {query_name} was found in more than one CSV. Cannot load from '{gather_csv}'.")
+                if force:
+                    if query_name not in gather_queries: # only notify once
+                        notify(f"Gather query {query_name} was found in more than one CSV. Cannot load from '{gather_csv}'.")
+                        gather_queries.add(query_name)
+                    continue # do not load this query
+                else:
+                    raise ValueError(f"Gather query {query_name} was found in more than one CSV. Cannot load from '{gather_csv}'.")
             else:
                 gather_results.append(row)
             # add query name to the gather_queries from this CSV
@@ -142,7 +148,6 @@ def check_and_load_gather_csvs(gather_csvs, tax_assign, *, fail_on_missing_taxon
         except ValueError as exc:
             if force:
                 notify(str(exc))
-                notify(f'No gather results loaded from {gather_csv}')
                 notify('--force is set. Attempting to continue to next set of gather results.')
                 n_ignored+=1
                 continue

--- a/src/sourmash/tax/tax_utils.py
+++ b/src/sourmash/tax/tax_utils.py
@@ -108,15 +108,8 @@ def load_gather_results(gather_csv, *, delimiter=',',
             query_name = row['query_name']
             # check if we've seen this query already in a different gather CSV
             if query_name in seen_queries:
-                if query_name not in gather_queries: #seen already in this CSV? (only want to warn once per query per CSV)
-                    notify(f"WARNING: Gather query {query_name} was already loaded from a separate gather CSV. Cannot load duplicate query from CSV {gather_csv}...")
-                if force:
-                    if query_name not in gather_queries:
-                        notify("--force is set, ignoring duplicate query.")
-                        gather_queries.add(query_name)
-                    continue
-                else:
-                    raise ValueError(f"Gather query {query_name} was found in more than one CSV. Cannot load from '{gather_csv}'.")
+                # do not allow loading of same query from a second CSV.
+                raise ValueError(f"Gather query {query_name} was found in more than one CSV. Cannot load from '{gather_csv}'.")
             else:
                 gather_results.append(row)
             # add query name to the gather_queries from this CSV
@@ -149,6 +142,7 @@ def check_and_load_gather_csvs(gather_csvs, tax_assign, *, fail_on_missing_taxon
         except ValueError as exc:
             if force:
                 notify(str(exc))
+                notify(f'No gather results loaded from {gather_csv}')
                 notify('--force is set. Attempting to continue to next set of gather results.')
                 n_ignored+=1
                 continue

--- a/tests/test_tax.py
+++ b/tests/test_tax.py
@@ -721,6 +721,7 @@ def test_metagenome_gather_duplicate_query(runtmp):
 
 
 def test_metagenome_gather_duplicate_query_force(runtmp):
+    # do not load same query from multiple files. Instead, ignore query in second file.
     c = runtmp
     taxonomy_csv = utils.get_test_data('tax/test.taxonomy.csv')
     g_res = utils.get_test_data('tax/test1.gather.csv')
@@ -739,15 +740,13 @@ def test_metagenome_gather_duplicate_query_force(runtmp):
     print(c.last_result.err)
 
     assert c.last_result.status == 0
-    assert '--force is set, ignoring duplicate query.' in c.last_result.err
-    assert 'No gather results loaded from ' in c.last_result.err
-    assert 'loaded 4 results total from 1 gather CSVs' in c.last_result.err
+
+    assert "Gather query test1 was found in more than one CSV." in c.last_result.err
+    assert "--force is set. Attempting to continue to next set of gather results." in c.last_result.err
+    assert "loaded 4 results total from 1 gather CSVs" in c.last_result.err
     assert 'query_name,rank,fraction,lineage,query_md5,query_filename,f_weighted_at_rank,bp_match_at_rank' in c.last_result.out
     assert 'test1,superkingdom,0.204,d__Bacteria,md5,test1.sig,0.131,1024000' in c.last_result.out
-    assert 'test1,superkingdom,0.796,unclassified,md5,test1.sig,0.869,3990000' in c.last_result.out
-    assert 'test1,phylum,0.116,d__Bacteria;p__Bacteroidota,md5,test1.sig,0.073,582000' in c.last_result.out
-    assert 'test1,phylum,0.088,d__Bacteria;p__Proteobacteria,md5,test1.sig,0.058,442000' in c.last_result.out
-    assert 'test1,phylum,0.796,unclassified,md5,test1.sig,0.869,3990000' in c.last_result.out
+    assert 'No gather results loaded from ' in c.last_result.err
 
 
 def test_metagenome_gather_duplicate_filename(runtmp):
@@ -1199,11 +1198,13 @@ def test_genome_gather_from_file_duplicate_query_force(runtmp):
     print(c.last_result.err)
 
     assert c.last_result.status == 0
+
+    assert "Gather query test1 was found in more than one CSV." in c.last_result.err
+    assert "--force is set. Attempting to continue to next set of gather results." in c.last_result.err
+    assert "loaded 4 results total from 1 gather CSVs" in c.last_result.err
     assert 'query_name,status,rank,fraction,lineage,query_md5,query_filename,f_weighted_at_rank,bp_match_at_rank' in c.last_result.out
     assert 'test1,match,species,0.089,d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Bacteroidales;f__Bacteroidaceae;g__Prevotella;s__Prevotella copri,md5,test1.sig,0.057,444000.0' in c.last_result.out
-    assert '--force is set, ignoring duplicate query.' in c.last_result.err
     assert 'No gather results loaded from ' in c.last_result.err
-    assert 'loaded 4 results total from 1 gather CSVs' in c.last_result.err
 
 
 def test_genome_gather_cli_and_from_file(runtmp):

--- a/tests/test_tax.py
+++ b/tests/test_tax.py
@@ -721,7 +721,7 @@ def test_metagenome_gather_duplicate_query(runtmp):
 
 
 def test_metagenome_gather_duplicate_query_force(runtmp):
-    # do not load same query from multiple files. Instead, ignore query in second file.
+    # do not load same query from multiple files.
     c = runtmp
     taxonomy_csv = utils.get_test_data('tax/test.taxonomy.csv')
     g_res = utils.get_test_data('tax/test1.gather.csv')
@@ -732,21 +732,18 @@ def test_metagenome_gather_duplicate_query_force(runtmp):
         for line in open(g_res, 'r'):
             fp.write(line)
 
-    c.run_sourmash('tax', 'metagenome',  '--gather-csv', g_res, g_res2,
+    with pytest.raises(SourmashCommandFailed) as exc:
+        c.run_sourmash('tax', 'metagenome',  '--gather-csv', g_res, g_res2,
                    '--taxonomy-csv', taxonomy_csv, '--force')
 
     print(c.last_result.status)
     print(c.last_result.out)
     print(c.last_result.err)
 
-    assert c.last_result.status == 0
+    assert c.last_result.status == -1
 
     assert "Gather query test1 was found in more than one CSV." in c.last_result.err
-    assert "--force is set. Attempting to continue to next set of gather results." in c.last_result.err
-    assert "loaded 4 results total from 1 gather CSVs" in c.last_result.err
-    assert 'query_name,rank,fraction,lineage,query_md5,query_filename,f_weighted_at_rank,bp_match_at_rank' in c.last_result.out
-    assert 'test1,superkingdom,0.204,d__Bacteria,md5,test1.sig,0.131,1024000' in c.last_result.out
-    assert 'No gather results loaded from ' in c.last_result.err
+    assert "Cannot force past duplicated gather query. Exiting." in c.last_result.err
 
 
 def test_metagenome_gather_duplicate_filename(runtmp):
@@ -1190,21 +1187,18 @@ def test_genome_gather_from_file_duplicate_query_force(runtmp):
         f_csv.write(f"{g_res}\n")
         f_csv.write(f"{g_res2}\n")
 
-    c.run_sourmash('tax', 'genome', '--from-file', g_from_file, '--taxonomy-csv', taxonomy_csv,
+    with pytest.raises(SourmashCommandFailed) as exc:
+        c.run_sourmash('tax', 'genome', '--from-file', g_from_file, '--taxonomy-csv', taxonomy_csv,
                    '--rank', 'species', '--containment-threshold', '0', '--force')
 
     print(c.last_result.status)
     print(c.last_result.out)
     print(c.last_result.err)
 
-    assert c.last_result.status == 0
+    assert c.last_result.status == -1
 
     assert "Gather query test1 was found in more than one CSV." in c.last_result.err
-    assert "--force is set. Attempting to continue to next set of gather results." in c.last_result.err
-    assert "loaded 4 results total from 1 gather CSVs" in c.last_result.err
-    assert 'query_name,status,rank,fraction,lineage,query_md5,query_filename,f_weighted_at_rank,bp_match_at_rank' in c.last_result.out
-    assert 'test1,match,species,0.089,d__Bacteria;p__Bacteroidota;c__Bacteroidia;o__Bacteroidales;f__Bacteroidaceae;g__Prevotella;s__Prevotella copri,md5,test1.sig,0.057,444000.0' in c.last_result.out
-    assert 'No gather results loaded from ' in c.last_result.err
+    assert "Cannot force past duplicated gather query. Exiting." in c.last_result.err
 
 
 def test_genome_gather_cli_and_from_file(runtmp):


### PR DESCRIPTION
Fixes #2155 

Gather results are only useful/valid if run for all databases at once. Gathers run separately to two different databases should not be combined. This PR fixes a bug that allowed `--force` to combine results for a single query found across multiple csv files.

Here, we allow results from the first gather file and either 1. fail upon seeing this query in another file (no `--force`) or 2. ignore the second file of gather results (`--force`).