### PR TITLE
[MRG] fix `query_abundance` column when `--ignore-abundance` is set

### DIFF
--- a/src/sourmash/search.py
+++ b/src/sourmash/search.py
@@ -507,6 +507,7 @@ class GatherResult(PrefetchResult):
             self.f_unique_weighted = self.n_unique_weighted_found / self.total_weighted_hashes
         else:
             self.f_unique_weighted = self.f_unique_to_query
+            self.query_abundance = False
 
     def __post_init__(self):
         self.check_gatherresult_input()

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -3151,6 +3151,9 @@ def test_gather_csv(runtmp, linear_gather, prefetch_gather):
         assert row['query_md5'] == 'c9d5a795'
         assert row['query_bp'] == '910'
 
+        assert row['query_abundance'] == 'False'
+        assert row['n_unique_weighted_found'] == ''
+
 
 def test_gather_csv_gz(runtmp, linear_gather, prefetch_gather):
     # test 'gather -o csvfile.gz'

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -4718,6 +4718,9 @@ def test_gather_abund_10_1_ignore_abundance(runtmp, linear_gather, prefetch_gath
             assert row['median_abund'] == ''
             assert row['std_abund'] == ''
 
+            assert row['query_abundance'] == 'False', row['query_abundance']
+            assert row['n_unique_weighted_found'] == ''
+
         assert some_results
 
 


### PR DESCRIPTION
When digging into https://github.com/sourmash-bio/sourmash/issues/2250 and questions of how to detect whether a gather was done on a non-abund sketch, I noticed that `query_abundance` was incorrectly set for `gather --ignore-abund`.

This fixes it and provides a test, as well as double-checking that `n_unique_weighted_found` is empty, for both flat query signatures _and_ `--ignore-abundance`.

