### PR TITLE
[EXP] provide signature file loading function via HTTP

### DIFF
--- a/src/sourmash/sourmash_args.py
+++ b/src/sourmash/sourmash_args.py
@@ -372,10 +372,12 @@ def _load_http_get(filename, **kwargs):
 
         req = requests.get(filename, stream=True)
 
-        # load from req.raw as LinearIndex, then pass into MultiIndex to
-        # generate a manifest.
-        lidx = LinearIndex.load(req.raw, filename=filename)
-        db = MultiIndex.load((lidx,), (None,), parent=None)
+        # CTB: does this follow redirects?
+        if req.status_code == 200:
+            # load from req.raw as LinearIndex, then pass into MultiIndex to
+            # generate a manifest.
+            lidx = LinearIndex.load(req.raw, filename=filename)
+            db = MultiIndex.load((lidx,), (None,), parent=None)
 
     return db
 


### PR DESCRIPTION
This PR adds support for direct loading of signatures via HTTP URLs with `GET`, i.e the normal way of getting files from a Web server.

See discussion here, https://github.com/sourmash-bio/sourmash/issues/2257.

**NEXT STEPS:** Per https://github.com/sourmash-bio/sourmash/issues/2257, I should should look into impementing this more generically using fsspec.

So, for example, this supports:

## Loading JSON sig/sig.gz files directly from Web sites

If you make raw JSON signature files available via an apache download link, you can Do Things With Them:

```
sourmash sig describe https://farm.cse.ucdavis.edu/~ctbrown/wort-data/wort-sra/ERR1040406.sig 
```

## You can build manifests with HTTP URLs in them, too

For example,
```
sourmash sig collect https://farm.cse.ucdavis.edu/~ctbrown/wort-data/wort-sra/ERR1040406.sig -o mf.sqldb
sqlite3 mf.sqldb 'select internal_location from sourmash_sketches'
```
yields
```
https://farm.cse.ucdavis.edu/~ctbrown/wort-data/wort-sra/ERR1040406.sig
https://farm.cse.ucdavis.edu/~ctbrown/wort-data/wort-sra/ERR1040406.sig
https://farm.cse.ucdavis.edu/~ctbrown/wort-data/wort-sra/ERR1040406.sig
```
and then you can do things like
```
sourmash sig summarize mf.sqldb
```
In turn, this allows you to use the full machinery of picklists etc. on non-local signatures.

With the caveat that you might end up asking to download 13 TB of signature files if you make a mistake...

## More on standalone manifests

So for example if you have a manifest containing a bunch of signatures you can use `--include` to get just the signatures containing a keyword in the name, or at a particular ksize, and build a local database just from them:
```
sourmash sig describe --include Sulfito farm.podar-ref.mf.csv
```

## Summary thoughts

Anyway this is some useful mixture of oh-so-wrong and so-very-much-right...

This is _probably_ most useful for things like genomes where the individual signatures are quite small; we could distribute _just_ a manifest CSV file to support certain kinds of things. It's also a good reason to support better encoding formats than JSON per https://github.com/sourmash-bio/sourmash/issues/1262.

NOTE: conflicts, maybe, with https://github.com/sourmash-bio/sourmash/pull/1644, which also takes HTTP URLs.

## Alternative/additional implementation thoughts

Instead of a custom loader fn for signatures only, we could generically support grabbing files and turning them into file handles for signature, pathlist, and manifest loading.