### PR TITLE
[MRG] replace chernoff bounds with exact probabilities

### DIFF
--- a/src/sourmash/minhash.py
+++ b/src/sourmash/minhash.py
@@ -6,7 +6,7 @@ class MinHash - core MinHash class.
 class FrozenMinHash - read-only MinHash class.
 """
 from __future__ import unicode_literals, division
-from .distance_utils import jaccard_to_distance, containment_to_distance, set_size_chernoff
+from .distance_utils import jaccard_to_distance, containment_to_distance, set_size_exact_prob
 from .logging import notify
 
 import numpy as np
@@ -1051,7 +1051,7 @@ class MinHash(RustObject):
         if any([not (0 <= relative_error <= 1), not (0 <= confidence <= 1)]):
             raise ValueError("Error: relative error and confidence values must be between 0 and 1.")
         # to do: replace unique_dataset_hashes with HLL estimation when it gets implemented 
-        probability = set_size_chernoff(self.unique_dataset_hashes, self.scaled, relative_error=relative_error)
+        probability = set_size_exact_prob(self.unique_dataset_hashes, self.scaled, relative_error=relative_error)
         return probability >= confidence
 
 

--- a/tests/test_distance_utils.py
+++ b/tests/test_distance_utils.py
@@ -6,7 +6,7 @@ import numpy as np
 from sourmash.distance_utils import (containment_to_distance, get_exp_probability_nothing_common,
                                     handle_seqlen_nkmers, jaccard_to_distance,
                                     ANIResult, ciANIResult, jaccardANIResult, var_n_mutated,
-                                    set_size_chernoff)
+                                    set_size_chernoff, set_size_exact_prob)
 
 def test_aniresult():
     res = ANIResult(0.4, 0.1)
@@ -416,4 +416,37 @@ def test_set_size_chernoff():
     set_size = 10
     s = 1/.01
     value_from_mathematica = -1
-    assert np.abs(set_size_chernoff(set_size, s,relative_error=rel_error) - value_from_mathematica) < eps
+    assert np.abs(set_size_chernoff(set_size, s, relative_error=rel_error) - value_from_mathematica) < eps
+
+
+def test_set_size_exact_prob():
+    # values obtained from Mathematica
+    # specifically: Probability[Abs[X*s - n]/n <= delta,
+    #   X \[Distributed] BinomialDistribution[n, 1/s]] // N
+    set_size = 100
+    scaled = 2
+    relative_error = 0.05
+    prob = set_size_exact_prob(set_size, scaled, relative_error=relative_error)
+    true_prob = 0.382701
+    np.testing.assert_array_almost_equal(true_prob, prob, decimal=3)
+
+    set_size = 200
+    scaled = 5
+    relative_error = 0.15
+    prob = set_size_exact_prob(set_size, scaled, relative_error=relative_error)
+    true_prob = 0.749858
+    np.testing.assert_array_almost_equal(true_prob, prob, decimal=3)
+
+    set_size = 10
+    scaled = 10
+    relative_error = 0.10
+    prob = set_size_exact_prob(set_size, scaled, relative_error=relative_error)
+    true_prob = 0.38742
+    np.testing.assert_array_almost_equal(true_prob, prob, decimal=3)
+
+    set_size = 1000
+    scaled = 10
+    relative_error = 0.10
+    prob = set_size_exact_prob(set_size, scaled, relative_error=relative_error)
+    true_prob = 0.73182
+    np.testing.assert_array_almost_equal(true_prob, prob, decimal=3)

--- a/tests/test_minhash.py
+++ b/tests/test_minhash.py
@@ -36,6 +36,7 @@
 import itertools
 import pickle
 import math
+import numpy as np
 
 import pytest
 
@@ -3144,9 +3145,9 @@ def test_containment_ani_ci_tiny_testdata():
 
     m2_cani_m1 = mh2.containment_ani(mh1, estimate_ci=True)
     print(m2_cani_m1)
-    assert m2_cani_m1.ani == None
+    # from the formula ANI = c^(1/k) for c=3/4 and k=21
+    np.testing.assert_almost_equal(m2_cani_m1.ani, 0.986394259982259, decimal=3)
     m2_cani_m1.size_is_inaccurate = False
-    assert m2_cani_m1.ani == 0.986394259982259
     assert m2_cani_m1.ani_low == None
     assert m2_cani_m1.ani_high == None
 
@@ -3207,7 +3208,7 @@ def test_minhash_set_size_estimate_is_accurate():
     f2 = utils.get_test_data('2+63.fa.sig')
     mh1 = sourmash.load_one_signature(f1, ksize=31).minhash
     mh2 = sourmash.load_one_signature(f2).minhash
-    mh1_ds = mh1.downsample(scaled=10000)
+    mh1_ds = mh1.downsample(scaled=100000)
     # check accuracy using default thresholds (rel_err= 0.2, confidence=0.95)
     assert mh1.size_is_accurate() == True
     assert mh1_ds.size_is_accurate() == False
@@ -3219,7 +3220,7 @@ def test_minhash_set_size_estimate_is_accurate():
 
     # change prob
     assert mh1.size_is_accurate(confidence=0.5) == True
-    assert mh1.size_is_accurate(confidence=1) == False
+    assert mh1.size_is_accurate(relative_error=0.001, confidence=1) == False
 
     # check that relative error and confidence must be between 0 and 1
     with pytest.raises(ValueError) as exc:
@@ -3236,15 +3237,16 @@ def test_minhash_set_size_estimate_is_accurate():
 
 
 def test_minhash_ani_inaccurate_size_est():
+    # TODO: It's actually really tricky to get the set size to be inaccurate. Eg. For a scale factor of 10000,
+    # you would need
     f1 = utils.get_test_data('2.fa.sig')
     f2 = utils.get_test_data('2+63.fa.sig')
     mh1 = sourmash.load_one_signature(f1, ksize=31).minhash
     mh2 = sourmash.load_one_signature(f2).minhash
     # downsample
-    mh1_ds = mh1.downsample(scaled=10000)
-    mh2_ds = mh2.downsample(scaled=10000)
-
-    assert mh1.size_is_accurate(relative_error=0.05, confidence=0.95) == False
+    mh1_ds = mh1.downsample(scaled=100000)
+    mh2_ds = mh2.downsample(scaled=100000)
+    assert mh1.size_is_accurate(relative_error=0.05, confidence=0.95) == True
     assert mh1.size_is_accurate() == True
     assert mh1_ds.size_is_accurate() == False
     assert mh2.size_is_accurate() == True

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -5946,9 +5946,9 @@ def test_search_ani_containment_fail(runtmp):
         print(row)
         assert search_result_names == list(row.keys())
         assert round(float(row['similarity']), 3) == 0.967
-        assert row['ani'] == ""
-
-    assert "WARNING: size estimation for at least one of these sketches may be inaccurate. ANI values will not be reported for these comparisons." in c.last_result.err
+        assert row['ani'] == "0.998906999319701"
+    # With PR #2268, this error message should not appear
+    #assert "WARNING: size estimation for at least one of these sketches may be inaccurate. ANI values will not be reported for these comparisons." in c.last_result.err
     
 
 def test_search_ani_containment_estimate_ci(runtmp):
@@ -6185,14 +6185,14 @@ def test_gather_ani_csv_estimate_ci(runtmp, linear_gather, prefetch_gather):
         assert row['query_name'] == 'tr1 4'
         assert row['query_md5'] == 'c9d5a795'
         assert row['query_bp'] == '910'
-        assert row['query_containment_ani']== ''
-        assert row['query_containment_ani_low']== ''
-        assert row['query_containment_ani_high']== ''
-        assert row['match_containment_ani'] == ''
-        assert row['match_containment_ani_low'] == ''
-        assert row['match_containment_ani_high'] == ''
-        assert row['average_containment_ani'] == ''
-        assert row['max_containment_ani'] ==''
+        assert row['query_containment_ani'] == '1.0'
+        assert row['query_containment_ani_low'] == '1.0'
+        assert row['query_containment_ani_high'] == '1.0'
+        assert row['match_containment_ani'] == '1.0'
+        assert row['match_containment_ani_low'] == '1.0'
+        assert row['match_containment_ani_high'] == '1.0'
+        assert row['average_containment_ani'] == '1.0'
+        assert row['max_containment_ani'] == '1.0'
         assert row['potential_false_negative'] == 'False'
 
 


### PR DESCRIPTION
Please replace this text with:

* See issue #2267. in brief: Much better to use the exact probabilities, so we don't zero out ANI/AAI estimates when dealing with shorter sequences 
* Fixes #2267 2267

No file format, CLI, or API changes (save for a very small function)
