### PR TITLE
[MRG] clean up zip error handling for bad zip files

### DIFF
--- a/src/sourmash/sbt_storage.py
+++ b/src/sourmash/sbt_storage.py
@@ -323,10 +323,11 @@ class _RwZipStorage(Storage):
     def close(self):
         # TODO: this is not ideal; checking for zipfile.fp is looking at
         # internal implementation details from CPython...
-        if self.zipfile is not None or self.bufferzip is not None:
-            self.flush(keep_closed=True)
-            self.zipfile.close()
-            self.zipfile = None
+        if hasattr(self, 'zipfile'):
+            if self.zipfile is not None or self.bufferzip is not None:
+                self.flush(keep_closed=True)
+                self.zipfile.close()
+                self.zipfile = None
 
     def flush(self, *, keep_closed=False):
         # This is a bit complicated, but we have to deal with new data

--- a/src/sourmash/sbt_storage.py
+++ b/src/sourmash/sbt_storage.py
@@ -323,6 +323,9 @@ class _RwZipStorage(Storage):
     def close(self):
         # TODO: this is not ideal; checking for zipfile.fp is looking at
         # internal implementation details from CPython...
+
+        # might not have self.zipfile if was invalid zipfile and __init__
+        # failed.
         if hasattr(self, 'zipfile'):
             if self.zipfile is not None or self.bufferzip is not None:
                 self.flush(keep_closed=True)

--- a/src/sourmash/sourmash_args.py
+++ b/src/sourmash/sourmash_args.py
@@ -1112,7 +1112,15 @@ class SaveSignatures_ZipFile(_BaseSaveSignaturesToLocation):
         if os.path.exists(self.location):
             do_create = False
 
-        storage = ZipStorage(self.location, mode="w")
+        storage = None
+        try:
+            storage = ZipStorage(self.location, mode="w")
+        except zipfile.BadZipFile:
+            pass
+
+        if storage is None:
+            raise ValueError(f"File '{self.location}' cannot be opened as a zip file.")
+
         if not storage.subdir:
             storage.subdir = 'signatures'
 

--- a/tests/test_sourmash_args.py
+++ b/tests/test_sourmash_args.py
@@ -158,7 +158,6 @@ def test_save_signatures_to_location_1_zip_bad(runtmp):
     assert 'cannot be opened as a zip file' in str(exc)
 
 
-
 def test_save_signatures_to_location_1_zip_dup(runtmp):
     # save to sigfile.zip
     sig2 = utils.get_test_data('2.fa.sig')

--- a/tests/test_sourmash_args.py
+++ b/tests/test_sourmash_args.py
@@ -137,6 +137,28 @@ def test_save_signatures_to_location_1_zip(runtmp):
     assert len(saved) == 2
 
 
+def test_save_signatures_to_location_1_zip_bad(runtmp):
+    # try saving to bad sigfile.zip
+    sig2 = utils.get_test_data('2.fa.sig')
+    ss2 = sourmash.load_one_signature(sig2, ksize=31)
+    sig47 = utils.get_test_data('47.fa.sig')
+    ss47 = sourmash.load_one_signature(sig47, ksize=31)
+
+    outloc = runtmp.output('foo.zip')
+
+    # create bad zip:
+    with open(outloc, 'wt') as fp:
+        pass
+
+    # now check for error
+    with pytest.raises(ValueError) as exc:
+        with sourmash_args.SaveSignaturesToLocation(outloc) as save_sig:
+            pass
+
+    assert 'cannot be opened as a zip file' in str(exc)
+
+
+
 def test_save_signatures_to_location_1_zip_dup(runtmp):
     # save to sigfile.zip
     sig2 = utils.get_test_data('2.fa.sig')


### PR DESCRIPTION
`SaveSignatures_*` and `ZipStorage` have some ugly and slightly broken error handling when trying to open a `.zip` file that is not, in fact, a valid zipfile. This made it hard to figure out what the actual error was!

This PR cleans up the error handling to present the user with a _somewhat_ more useful error message.

Fixes https://github.com/sourmash-bio/sourmash/issues/2269