### PR TITLE
[MRG] remove default ksize of 31 from help message when it's not actually true.

### DIFF
--- a/src/sourmash/cli/categorize.py
+++ b/src/sourmash/cli/categorize.py
@@ -14,7 +14,7 @@ def subparser(subparsers):
         '-q', '--quiet', action='store_true',
         help='suppress non-error output'
     )
-    add_ksize_arg(subparser, 31)
+    add_ksize_arg(subparser)
     subparser.add_argument(
         '--threshold', default=0.08, type=float,
         help='minimum threshold for reporting matches; default=0.08'

--- a/src/sourmash/cli/compare.py
+++ b/src/sourmash/cli/compare.py
@@ -87,7 +87,7 @@ def subparser(subparsers):
     subparser.add_argument(
         '--similarity-matrix', action='store_false',
         dest='distance_matrix',
-        help='output a similiarty matrix; this is the default',
+        help='output a similarity matrix; this is the default',
     )
 
     add_ksize_arg(subparser)

--- a/src/sourmash/cli/gather.py
+++ b/src/sourmash/cli/gather.py
@@ -146,7 +146,7 @@ def subparser(subparsers):
     )
     subparser.set_defaults(fail_on_empty_database=True)
 
-    add_ksize_arg(subparser, 31)
+    add_ksize_arg(subparser)
     add_moltype_args(subparser)
     add_picklist_args(subparser)
     add_pattern_args(subparser)

--- a/src/sourmash/cli/index.py
+++ b/src/sourmash/cli/index.py
@@ -66,7 +66,7 @@ def subparser(subparsers):
         help='What percentage of internal nodes will not be saved; ranges '
         'from 0.0 (save all nodes) to 1.0 (no nodes saved)'
     )
-    add_ksize_arg(subparser, 31)
+    add_ksize_arg(subparser)
     add_moltype_args(subparser)
     add_picklist_args(subparser)
     add_scaled_arg(subparser, 0)

--- a/src/sourmash/cli/lca/index.py
+++ b/src/sourmash/cli/lca/index.py
@@ -66,7 +66,7 @@ def subparser(subparsers):
         choices=['json', 'sql'],
     )
 
-    add_ksize_arg(subparser, 31)
+    add_ksize_arg(subparser, default=31)
     add_moltype_args(subparser)
     add_picklist_args(subparser)
 

--- a/src/sourmash/cli/multigather.py
+++ b/src/sourmash/cli/multigather.py
@@ -83,7 +83,7 @@ def subparser(subparsers):
     )
     subparser.set_defaults(fail_on_empty_database=True)
 
-    add_ksize_arg(subparser, 31)
+    add_ksize_arg(subparser)
     add_moltype_args(subparser)
     add_scaled_arg(subparser, 0)
 

--- a/src/sourmash/cli/prefetch.py
+++ b/src/sourmash/cli/prefetch.py
@@ -62,7 +62,7 @@ def subparser(subparsers):
         '--estimate-ani-ci', action='store_true',
         help='also output confidence intervals for ANI estimates'
     )
-    add_ksize_arg(subparser, 31)
+    add_ksize_arg(subparser)
     add_moltype_args(subparser)
     add_picklist_args(subparser)
     add_pattern_args(subparser)

--- a/src/sourmash/cli/search.py
+++ b/src/sourmash/cli/search.py
@@ -112,7 +112,7 @@ def subparser(subparsers):
     )
     subparser.set_defaults(fail_on_empty_database=True)
 
-    add_ksize_arg(subparser, 31)
+    add_ksize_arg(subparser)
     add_moltype_args(subparser)
     add_picklist_args(subparser)
     add_pattern_args(subparser)

--- a/src/sourmash/cli/sig/cat.py
+++ b/src/sourmash/cli/sig/cat.py
@@ -43,7 +43,7 @@ def subparser(subparsers):
         '-f', '--force', action='store_true',
         help='try to load all files as signatures'
     )
-    add_ksize_arg(subparser, 31)
+    add_ksize_arg(subparser)
     add_moltype_args(subparser)
     add_pattern_args(subparser)
     add_picklist_args(subparser)

--- a/src/sourmash/cli/sig/check.py
+++ b/src/sourmash/cli/sig/check.py
@@ -62,7 +62,7 @@ def subparser(subparsers):
         choices=['csv', 'sql'],
     )
 
-    add_ksize_arg(subparser, 31)
+    add_ksize_arg(subparser)
     add_moltype_args(subparser)
     add_pattern_args(subparser)
     add_picklist_args(subparser)

--- a/src/sourmash/cli/sig/collect.py
+++ b/src/sourmash/cli/sig/collect.py
@@ -53,7 +53,7 @@ def subparser(subparsers):
                            help="convert all locations to absolute paths",
                            action='store_true')
 
-    add_ksize_arg(subparser, 31)
+    add_ksize_arg(subparser)
     add_moltype_args(subparser)
 
 

--- a/src/sourmash/cli/sig/describe.py
+++ b/src/sourmash/cli/sig/describe.py
@@ -49,7 +49,7 @@ def subparser(subparsers):
         '--from-file',
         help='a text file containing a list of files to load signatures from'
     )
-    add_ksize_arg(subparser, 31)
+    add_ksize_arg(subparser)
     add_moltype_args(subparser)
     add_picklist_args(subparser)
     add_pattern_args(subparser)

--- a/src/sourmash/cli/sig/downsample.py
+++ b/src/sourmash/cli/sig/downsample.py
@@ -54,7 +54,7 @@ def subparser(subparsers):
         '-f', '--force', action='store_true',
         help='try to load all files as signatures'
     )
-    add_ksize_arg(subparser, 31)
+    add_ksize_arg(subparser)
     add_moltype_args(subparser)
     add_picklist_args(subparser)
     add_num_arg(subparser, 0)

--- a/src/sourmash/cli/sig/export.py
+++ b/src/sourmash/cli/sig/export.py
@@ -31,7 +31,7 @@ def subparser(subparsers):
         '--md5', default=None,
         help='select the signature with this md5 as query'
     )
-    add_ksize_arg(subparser, 31)
+    add_ksize_arg(subparser)
     add_moltype_args(subparser)
 
 

--- a/src/sourmash/cli/sig/extract.py
+++ b/src/sourmash/cli/sig/extract.py
@@ -69,7 +69,7 @@ def subparser(subparsers):
         '--from-file',
         help='a text file containing a list of files to load signatures from'
     )
-    add_ksize_arg(subparser, 31)
+    add_ksize_arg(subparser)
     add_moltype_args(subparser)
     add_pattern_args(subparser)
     add_picklist_args(subparser)

--- a/src/sourmash/cli/sig/filter.py
+++ b/src/sourmash/cli/sig/filter.py
@@ -52,7 +52,7 @@ def subparser(subparsers):
         '-M', '--max-abundance', type=int, default=None,
         help='keep hashes <= this maximum abundance'
     )
-    add_ksize_arg(subparser, 31)
+    add_ksize_arg(subparser)
     add_moltype_args(subparser)
 
 

--- a/src/sourmash/cli/sig/flatten.py
+++ b/src/sourmash/cli/sig/flatten.py
@@ -50,7 +50,7 @@ def subparser(subparsers):
         '--from-file',
         help='a text file containing a list of files to load signatures from'
     )
-    add_ksize_arg(subparser, 31)
+    add_ksize_arg(subparser)
     add_moltype_args(subparser)
     add_picklist_args(subparser)
 

--- a/src/sourmash/cli/sig/grep.py
+++ b/src/sourmash/cli/sig/grep.py
@@ -84,7 +84,7 @@ def subparser(subparsers):
         help="only output a count of discovered signatures; implies --silent",
         action='store_true'
     )
-    add_ksize_arg(subparser, 31)
+    add_ksize_arg(subparser)
     add_moltype_args(subparser)
     add_picklist_args(subparser)
 

--- a/src/sourmash/cli/sig/inflate.py
+++ b/src/sourmash/cli/sig/inflate.py
@@ -20,7 +20,7 @@ def subparser(subparsers):
         '-f', '--force', action='store_true',
         help='try to load all files as signatures'
     )
-    add_ksize_arg(subparser, 31)
+    add_ksize_arg(subparser)
     add_moltype_args(subparser)
     add_picklist_args(subparser)
 

--- a/src/sourmash/cli/sig/intersect.py
+++ b/src/sourmash/cli/sig/intersect.py
@@ -49,7 +49,7 @@ def subparser(subparsers):
         '--from-file',
         help='a text file containing a list of files to load signatures from'
     )
-    add_ksize_arg(subparser, 31)
+    add_ksize_arg(subparser)
     add_moltype_args(subparser)
     add_picklist_args(subparser)
 

--- a/src/sourmash/cli/sig/kmers.py
+++ b/src/sourmash/cli/sig/kmers.py
@@ -67,7 +67,7 @@ def subparser(subparsers):
         '--from-file',
         help='a text file containing a list of files to load signatures from'
     )
-    add_ksize_arg(subparser, 31)
+    add_ksize_arg(subparser)
     add_moltype_args(subparser)
     add_picklist_args(subparser)
 

--- a/src/sourmash/cli/sig/merge.py
+++ b/src/sourmash/cli/sig/merge.py
@@ -55,7 +55,7 @@ def subparser(subparsers):
         '--from-file',
         help='a text file containing a list of files to load signatures from'
     )
-    add_ksize_arg(subparser, 31)
+    add_ksize_arg(subparser)
     add_moltype_args(subparser)
     add_picklist_args(subparser)
 

--- a/src/sourmash/cli/sig/overlap.py
+++ b/src/sourmash/cli/sig/overlap.py
@@ -35,7 +35,7 @@ def subparser(subparsers):
         '-q', '--quiet', action='store_true',
         help='suppress non-error output'
     )
-    add_ksize_arg(subparser, 31)
+    add_ksize_arg(subparser)
     add_moltype_args(subparser)
 
 

--- a/src/sourmash/cli/sig/rename.py
+++ b/src/sourmash/cli/sig/rename.py
@@ -46,7 +46,7 @@ def subparser(subparsers):
         '--from-file',
         help='a text file containing a list of files to load signatures from'
     )
-    add_ksize_arg(subparser, 31)
+    add_ksize_arg(subparser)
     add_moltype_args(subparser)
     add_pattern_args(subparser)
     add_picklist_args(subparser)

--- a/src/sourmash/cli/sig/split.py
+++ b/src/sourmash/cli/sig/split.py
@@ -59,7 +59,7 @@ def subparser(subparsers):
         '--from-file',
         help='a text file containing a list of files to load signatures from'
     )
-    add_ksize_arg(subparser, 31)
+    add_ksize_arg(subparser)
     add_moltype_args(subparser)
     add_picklist_args(subparser)
 

--- a/src/sourmash/cli/sig/subtract.py
+++ b/src/sourmash/cli/sig/subtract.py
@@ -45,7 +45,7 @@ def subparser(subparsers):
         '-A', '--abundances-from', metavar='FILE',
         help='intersect with & take abundances from this signature'
     )
-    add_ksize_arg(subparser, 31)
+    add_ksize_arg(subparser)
     add_moltype_args(subparser)
 
 

--- a/src/sourmash/cli/utils.py
+++ b/src/sourmash/cli/utils.py
@@ -48,6 +48,7 @@ def add_construct_moltype_args(parser):
 
 
 def add_ksize_arg(parser, default=None):
+    "Add -k/--ksize to argparse parsers, with specified default."
     if default:
         message = f"k-mer size to select; default={default}"
     else:

--- a/src/sourmash/cli/utils.py
+++ b/src/sourmash/cli/utils.py
@@ -47,10 +47,15 @@ def add_construct_moltype_args(parser):
     parser.set_defaults(dna=True)
 
 
-def add_ksize_arg(parser, default=31):
+def add_ksize_arg(parser, default=None):
+    if default:
+        message = f"k-mer size to select; default={default}"
+    else:
+        message = f"k-mer size to select; no default."
+
     parser.add_argument(
-        '-k', '--ksize', metavar='K', default=None, type=int,
-        help='k-mer size; default={d}'.format(d=default)
+        '-k', '--ksize', metavar='K', default=default, type=int,
+        help=message,
     )
 
 #https://stackoverflow.com/questions/55324449/how-to-specify-a-minimum-or-maximum-float-value-with-argparse#55410582

--- a/src/sourmash/cli/utils.py
+++ b/src/sourmash/cli/utils.py
@@ -47,7 +47,7 @@ def add_construct_moltype_args(parser):
     parser.set_defaults(dna=True)
 
 
-def add_ksize_arg(parser, default=None):
+def add_ksize_arg(parser, *, default=None):
     "Add -k/--ksize to argparse parsers, with specified default."
     if default:
         message = f"k-mer size to select; default={default}"

--- a/src/sourmash/cli/watch.py
+++ b/src/sourmash/cli/watch.py
@@ -28,7 +28,7 @@ def subparser(subparsers):
         '--name', type=str, default='stdin',
         help='name to use for generated signature'
     )
-    add_ksize_arg(subparser, 31)
+    add_ksize_arg(subparser)
     add_num_arg(subparser, 500)
 
 def main(args):

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -4499,6 +4499,7 @@ def test_gather_deduce_ksize(runtmp, prefetch_gather, linear_gather):
 
 
 def test_gather_deduce_moltype(runtmp, linear_gather, prefetch_gather):
+    # gather should automatically figure out ksize
     testdata1 = utils.get_test_data('short.fa')
     testdata2 = utils.get_test_data('short2.fa')
 

--- a/tests/test_sourmash_args.py
+++ b/tests/test_sourmash_args.py
@@ -9,11 +9,13 @@ import zipfile
 import io
 import contextlib
 import csv
+import argparse
 
 import sourmash_tst_utils as utils
 import sourmash
 from sourmash import sourmash_args, manifest
 from sourmash.index import LinearIndex
+from sourmash.cli.utils import add_ksize_arg
 
 
 def test_save_signatures_api_none():
@@ -768,3 +770,35 @@ def test_fileoutput_csv_2_stdout():
 
     with sourmash_args.FileOutputCSV(None) as fp:
         assert fp == sys.stdout
+
+
+def test_add_ksize_arg_no_default():
+    # test behavior of cli.utils.add_ksize_arg
+    p = argparse.ArgumentParser()
+    add_ksize_arg(p)
+    args = p.parse_args()
+    assert args.ksize == None
+
+
+def test_add_ksize_arg_no_default_specify():
+    # test behavior of cli.utils.add_ksize_arg
+    p = argparse.ArgumentParser()
+    add_ksize_arg(p)
+    args = p.parse_args(['-k', '21'])
+    assert args.ksize == 21
+
+
+def test_add_ksize_arg_default_31():
+    # test behavior of cli.utils.add_ksize_arg
+    p = argparse.ArgumentParser()
+    add_ksize_arg(p, default=31)
+    args = p.parse_args()
+    assert args.ksize == 31
+
+
+def test_add_ksize_arg_default_31_specify():
+    # test behavior of cli.utils.add_ksize_arg
+    p = argparse.ArgumentParser()
+    add_ksize_arg(p, default=31)
+    args = p.parse_args(['-k', '21'])
+    assert args.ksize == 21


### PR DESCRIPTION
In #2281, @taylorreiter pointed out that our help message for `sourmash sig describe` is inaccurate - it says we default to a ksize of 31 when in fact we do not.

Digging into the code, I found that `add_ksize_arg` was pretty sus - it specified a default of 31, but only used that in the help message, not in the actual argparse setting.
```python
def add_ksize_arg(parser, default=31):
    parser.add_argument(
        '-k', '--ksize', metavar='K', default=None, type=int,
        help='k-mer size; default={d}'.format(d=default)
    )
```

I changed it to this:
```
def add_ksize_arg(parser, default=None):
    if default:
        message = f"k-mer size to select; default={default}"
    else:
        message = f"k-mer size to select; no default."

    parser.add_argument(
        '-k', '--ksize', metavar='K', default=default, type=int,
        help=message,
    )
```
which promptly broke lots of things...

This PR does the following -

* the `default` arg to `add_ksize_arg` now actually sets the default value;
* the help message reflects both the true default _and_ when there is no default;
* changes the CLI code so that only one CLI command in the code (`lca index`) does _not_ set the default, which is in practice what was happening anyway (no tests had to be changed!);
* adds specific tests for `add_ksize_arg` behavior.

Fixes #2281