### PR TITLE
cargo check fixes for beta (1.65)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -64,11 +64,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1662934689,
-        "narHash": "sha256-mXi8hmhiunOVTeHiuouWXb0vTqjzp9v9kshMmI561Us=",
+        "lastModified": 1664028844,
+        "narHash": "sha256-wwGqnvROHW54ma0h4q6GL5toKxTVVKvAypv0CcJkraU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a0b7e70db7a55088d3de0cc370a59f9fbcc906c3",
+        "rev": "72bdd03f0d5696412b25a93218acaad530570d30",
         "type": "github"
       },
       "original": {
@@ -150,11 +150,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1663038100,
-        "narHash": "sha256-DpqF/1FYpUo3Fm54oBaXzdqIG7BuRkHHFOgLM0uVVF0=",
+        "lastModified": 1664074880,
+        "narHash": "sha256-/V1TX4HLADElvi3MuuIbNdvzR/HmNzbYRemKBjX/5YY=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "dbd08f5b5469e1e24f00de45ddc73c26290a2bcb",
+        "rev": "45140fa526b1cb85498f717e355c79a54367cb1d",
         "type": "github"
       },
       "original": {

--- a/src/core/src/index/linear.rs
+++ b/src/core/src/index/linear.rs
@@ -147,7 +147,7 @@ where
         basepath.push(path);
         basepath.canonicalize()?;
 
-        let linear = LinearIndex::<L>::from_reader(&mut reader, &basepath.parent().unwrap())?;
+        let linear = LinearIndex::<L>::from_reader(&mut reader, basepath.parent().unwrap())?;
         Ok(linear)
     }
 

--- a/src/core/src/index/revindex.rs
+++ b/src/core/src/index/revindex.rs
@@ -178,7 +178,7 @@ impl RevIndex {
                 info!("Processed {} reference sigs", i);
             }
 
-            let search_sig = Signature::from_path(&filename)
+            let search_sig = Signature::from_path(filename)
                 .unwrap_or_else(|_| panic!("Error processing {:?}", filename))
                 .swap_remove(0);
 
@@ -215,7 +215,7 @@ impl RevIndex {
             Some(
                 sigs_iter
                     .map(|ref_path| {
-                        Signature::from_path(&ref_path)
+                        Signature::from_path(ref_path)
                             .unwrap_or_else(|_| panic!("Error processing {:?}", ref_path))
                             .swap_remove(0)
                     })
@@ -394,7 +394,7 @@ impl RevIndex {
                 &refsigs[dataset_id as usize]
             } else {
                 // TODO: remove swap_remove
-                ref_match = Signature::from_path(&match_path)?.swap_remove(0);
+                ref_match = Signature::from_path(match_path)?.swap_remove(0);
                 &ref_match
             };
 
@@ -539,7 +539,7 @@ impl RevIndex {
                 &refsigs[dataset_id as usize]
             } else {
                 // TODO: remove swap_remove
-                ref_match = Signature::from_path(&match_path)?.swap_remove(0);
+                ref_match = Signature::from_path(match_path)?.swap_remove(0);
                 &ref_match
             };
 

--- a/src/core/src/index/sbt/mod.rs
+++ b/src/core/src/index/sbt/mod.rs
@@ -287,7 +287,7 @@ where
         // TODO: canonicalize doesn't work on wasm32-wasi
         //basepath.canonicalize()?;
 
-        let sbt = SBT::<Node<U>, T>::from_reader(&mut reader, &basepath.parent().unwrap())?;
+        let sbt = SBT::<Node<U>, T>::from_reader(&mut reader, basepath.parent().unwrap())?;
         Ok(sbt)
     }
 


### PR DESCRIPTION
Nightly Rust checks started failing because next `stable` (1.65, current `beta`) turns more needless borrows into erros (similar to #1636)