### PR TITLE
[MRG] add column 3 to kreport

### DIFF
--- a/doc/command-line.md
+++ b/doc/command-line.md
@@ -625,10 +625,13 @@ To produce multiple output types from the same command, add the types into the
 The `kreport` output reports kraken-style `kreport` output, which may be useful for
 comparison with other taxonomic profiling methods. While this format typically
 records the percent of number of reads assigned to taxa, we create ~comparable
-output by reporting the percent of k-mers (abundance-weighted percent containment)
-and the total number of unique k-mers matched.
+output by reporting the percent of k-mers matched to each taxon and the estimated
+number of base pairs that these k-mers represent. To best represent the percent of all
+reads, we use k-mer abundance information in this output. To generate this properly, query
+FracMinHash sketches should be generated with abundance information (`-p abund`) to allow
+abundance-weighted `gather` results.
 
-standard `kreport` columns:
+standard `kreport` columns (read-based tools):
 - `Percent Reads Contained in Taxon`: The cumulative percentage of reads for this taxon and all descendants.
 - `Number of Reads Contained in Taxon`: The cumulative number of reads for this taxon and all descendants.
 - `Number of Reads Assigned to Taxon`: The number of reads assigned directly to this taxon (not a cumulative count of all descendants).
@@ -649,21 +652,26 @@ Example reads-based `kreport` with all columns:
 ```
 
 sourmash `kreport` columns:
-- `Percent [k-mers] contained in taxon` (abundance-weighted)
-- `Estimated base pairs contained in taxon` (abundance-weighted)
-- [blank column]
+- `Percent [k-mers] contained in taxon`: The cumulative percentage of k-mers for this taxon and all descendants.
+- `Estimated base pairs contained in taxon`: The cumulative estimated base pairs for this taxon and all descendants.
+- `Estimated base pairs "assigned" (species-level)`: The estimated base pairs assigned at species-level (cumulative count of base pairs assigned to individual genomes in this species).
 - `Rank Code`: (U)nclassified, (R)oot, (D)omain, (K)ingdom, (P)hylum, (C)lass, (O)rder, (F)amily, (G)enus, or (S)pecies.
-- [blank column]
+- [blank column]: (`NCBI Taxon ID` is not currently reported).
 - `Scientific Name`: The scientific name of the taxon.
 
 notes:
-- `Number of Reads Assigned to Taxon` and `NCBI Taxon ID` will not be reported (blank entries).
-- Rows are ordered by rank and then ~percent containment.
+- `gather` assigns k-mers to specific genomes. To mimic the output of other
+  tools, we report all results as "assigned" to species-level, which summarizes
+  the k-mers matched to each genome within a given species. Hence, column 3 will
+  show all estimated base pairs at this level, and 0 for all other ranks.
+  Column 2 contains the summarized info at the higher ranks.
 - Since `gather` results are non-overlapping and all assignments are done at the
   genome level, the percent match (first column) will sum to 100% at each rank
   (aside from rounding issues) when including the unclassified (U) percentage.
   Higher-rank assignments are generated using LCA-style summarization of genome
   matches.
+- Rows are ordered by rank and then ~percent containment.
+
 
 example sourmash `{output-name}.kreport.txt`:
 

--- a/doc/command-line.md
+++ b/doc/command-line.md
@@ -631,6 +631,11 @@ reads, we use k-mer abundance information in this output. To generate this prope
 FracMinHash sketches should be generated with abundance information (`-p abund`) to allow
 abundance-weighted `gather` results.
 
+Note: `sourmash gather` makes all assignments to genomes, and then `sourmash tax`
+integrates taxonomy information and uses LCA-style summarization to build assignments.
+For species-level specificity, our current recommendation is to use use our default
+k-mer size of 31.
+
 standard `kreport` columns (read-based tools):
 - `Percent Reads Contained in Taxon`: The cumulative percentage of reads for this taxon and all descendants.
 - `Number of Reads Contained in Taxon`: The cumulative number of reads for this taxon and all descendants.

--- a/src/sourmash/tax/tax_utils.py
+++ b/src/sourmash/tax/tax_utils.py
@@ -496,11 +496,13 @@ def write_kreport(summarized_gather, csv_fp, *, sep='\t'):
                     unclassified_written=True
             else:
                 rank_sciname = res.lineage[-1].name
-            kresD = {"rank_code": rcode, "ncbi_taxid": "", "sci_name": rank_sciname,  "num_bp_assigned": ""}
+            kresD = {"rank_code": rcode, "ncbi_taxid": "", "sci_name": rank_sciname,  "num_bp_assigned": 0}
             # total percent containment, weighted to include abundance info
             kresD['percent_containment'] = f'{res.f_weighted_at_rank:.2f}'
             # weighted bp
             kresD["num_bp_contained"] = int(res.f_weighted_at_rank * res.total_weighted_hashes)
+            if rank == 'species':
+                kresD["num_bp_assigned"] = kresD["num_bp_contained"]
             w.writerow(kresD)
 
 

--- a/src/sourmash/tax/tax_utils.py
+++ b/src/sourmash/tax/tax_utils.py
@@ -501,7 +501,7 @@ def write_kreport(summarized_gather, csv_fp, *, sep='\t'):
             kresD['percent_containment'] = f'{res.f_weighted_at_rank:.2f}'
             # weighted bp
             kresD["num_bp_contained"] = int(res.f_weighted_at_rank * res.total_weighted_hashes)
-            if rank == 'species':
+            if rank == 'species' or rank_sciname == "unclassified":
                 kresD["num_bp_assigned"] = kresD["num_bp_contained"]
             w.writerow(kresD)
 

--- a/tests/test_tax.py
+++ b/tests/test_tax.py
@@ -184,22 +184,22 @@ def test_metagenome_kreport_out(runtmp):
     kreport_results = [x.rstrip().split('\t') for x in open(csvout)]
     assert f"saving 'kreport' output to '{csvout}'" in runtmp.last_result.err
     print(kreport_results)
-    assert ['0.13', '1605999', '', 'D', '', 'd__Bacteria'] == kreport_results[0]
-    assert ['0.87', '10672000', '', 'U', '', 'unclassified'] == kreport_results[1]
-    assert ['0.07', '892000', '', 'P', '', 'p__Bacteroidota'] == kreport_results[2]
-    assert ['0.06', '714000', '', 'P', '', 'p__Proteobacteria'] == kreport_results[3]
-    assert ['0.07', '892000', '', 'C', '', 'c__Bacteroidia'] == kreport_results[4]
-    assert ['0.06', '714000', '', 'C', '', 'c__Gammaproteobacteria'] == kreport_results[5]
-    assert ['0.07', '892000', '', 'O', '', 'o__Bacteroidales'] == kreport_results[6]
-    assert ['0.06', '714000', '', 'O', '', 'o__Enterobacterales'] == kreport_results[7]
-    assert ['0.07', '892000', '', 'F', '', 'f__Bacteroidaceae'] == kreport_results[8]
-    assert ['0.06', '714000', '', 'F', '', 'f__Enterobacteriaceae'] == kreport_results[9]
-    assert ['0.06', '700000', '', 'G', '', 'g__Prevotella']  == kreport_results[10]
-    assert ['0.06', '714000', '', 'G', '', 'g__Escherichia'] == kreport_results[11]
-    assert ['0.02', '192000', '', 'G', '', 'g__Phocaeicola'] == kreport_results[12]
-    assert ['0.06', '700000', '', 'S', '', 's__Prevotella copri'] == kreport_results[13]
-    assert ['0.06', '714000', '', 'S', '', 's__Escherichia coli']== kreport_results[14]
-    assert ['0.02', '192000', '', 'S', '', 's__Phocaeicola vulgatus'] == kreport_results[15]
+    assert ['0.13', '1605999', '0', 'D', '', 'd__Bacteria'] == kreport_results[0]
+    assert ['0.87', '10672000', '0', 'U', '', 'unclassified'] == kreport_results[1]
+    assert ['0.07', '892000', '0', 'P', '', 'p__Bacteroidota'] == kreport_results[2]
+    assert ['0.06', '714000', '0', 'P', '', 'p__Proteobacteria'] == kreport_results[3]
+    assert ['0.07', '892000', '0', 'C', '', 'c__Bacteroidia'] == kreport_results[4]
+    assert ['0.06', '714000', '0', 'C', '', 'c__Gammaproteobacteria'] == kreport_results[5]
+    assert ['0.07', '892000', '0', 'O', '', 'o__Bacteroidales'] == kreport_results[6]
+    assert ['0.06', '714000', '0', 'O', '', 'o__Enterobacterales'] == kreport_results[7]
+    assert ['0.07', '892000', '0', 'F', '', 'f__Bacteroidaceae'] == kreport_results[8]
+    assert ['0.06', '714000', '0', 'F', '', 'f__Enterobacteriaceae'] == kreport_results[9]
+    assert ['0.06', '700000', '0', 'G', '', 'g__Prevotella']  == kreport_results[10]
+    assert ['0.06', '714000', '0', 'G', '', 'g__Escherichia'] == kreport_results[11]
+    assert ['0.02', '192000', '0', 'G', '', 'g__Phocaeicola'] == kreport_results[12]
+    assert ['0.06', '700000', '700000', 'S', '', 's__Prevotella copri'] == kreport_results[13]
+    assert ['0.06', '714000', '714000', 'S', '', 's__Escherichia coli']== kreport_results[14]
+    assert ['0.02', '192000', '192000', 'S', '', 's__Phocaeicola vulgatus'] == kreport_results[15]
 
 
 def test_metagenome_kreport_out_lemonade(runtmp):
@@ -223,14 +223,14 @@ def test_metagenome_kreport_out_lemonade(runtmp):
     kreport_results = [x.rstrip().split('\t') for x in open(csvout)]
     assert f"saving 'kreport' output to '{csvout}'" in runtmp.last_result.err
     print(kreport_results)
-    assert ['0.05', '116000', '', 'D', '', 'd__Bacteria'] == kreport_results[0]
-    assert ['0.95', '2054000', '', 'U', '', 'unclassified'] == kreport_results[1]
-    assert ['0.05', '116000', '', 'P', '', 'p__Bacteroidota'] == kreport_results[2]
-    assert ['0.05', '116000', '', 'C', '', 'c__Chlorobia'] == kreport_results[3]
-    assert ['0.05', '116000', '', 'O', '', 'o__Chlorobiales'] == kreport_results[4]
-    assert ['0.05', '116000', '', 'F', '', 'f__Chlorobiaceae'] == kreport_results[5]
-    assert ['0.05', '116000', '', 'G', '', 'g__Prosthecochloris'] == kreport_results[6]
-    assert ['0.05', '116000', '', 'S', '', 's__Prosthecochloris vibrioformis'] == kreport_results[7]
+    assert ['0.05', '116000', '0', 'D', '', 'd__Bacteria'] == kreport_results[0]
+    assert ['0.95', '2054000', '0', 'U', '', 'unclassified'] == kreport_results[1]
+    assert ['0.05', '116000', '0', 'P', '', 'p__Bacteroidota'] == kreport_results[2]
+    assert ['0.05', '116000', '0', 'C', '', 'c__Chlorobia'] == kreport_results[3]
+    assert ['0.05', '116000', '0', 'O', '', 'o__Chlorobiales'] == kreport_results[4]
+    assert ['0.05', '116000', '0', 'F', '', 'f__Chlorobiaceae'] == kreport_results[5]
+    assert ['0.05', '116000', '0', 'G', '', 'g__Prosthecochloris'] == kreport_results[6]
+    assert ['0.05', '116000', '116000', 'S', '', 's__Prosthecochloris vibrioformis'] == kreport_results[7]
 
 
 def test_metagenome_kreport_out_fail(runtmp):

--- a/tests/test_tax.py
+++ b/tests/test_tax.py
@@ -185,7 +185,7 @@ def test_metagenome_kreport_out(runtmp):
     assert f"saving 'kreport' output to '{csvout}'" in runtmp.last_result.err
     print(kreport_results)
     assert ['0.13', '1605999', '0', 'D', '', 'd__Bacteria'] == kreport_results[0]
-    assert ['0.87', '10672000', '0', 'U', '', 'unclassified'] == kreport_results[1]
+    assert ['0.87', '10672000', '10672000', 'U', '', 'unclassified'] == kreport_results[1]
     assert ['0.07', '892000', '0', 'P', '', 'p__Bacteroidota'] == kreport_results[2]
     assert ['0.06', '714000', '0', 'P', '', 'p__Proteobacteria'] == kreport_results[3]
     assert ['0.07', '892000', '0', 'C', '', 'c__Bacteroidia'] == kreport_results[4]
@@ -224,7 +224,7 @@ def test_metagenome_kreport_out_lemonade(runtmp):
     assert f"saving 'kreport' output to '{csvout}'" in runtmp.last_result.err
     print(kreport_results)
     assert ['0.05', '116000', '0', 'D', '', 'd__Bacteria'] == kreport_results[0]
-    assert ['0.95', '2054000', '0', 'U', '', 'unclassified'] == kreport_results[1]
+    assert ['0.95', '2054000', '2054000', 'U', '', 'unclassified'] == kreport_results[1]
     assert ['0.05', '116000', '0', 'P', '', 'p__Bacteroidota'] == kreport_results[2]
     assert ['0.05', '116000', '0', 'C', '', 'c__Chlorobia'] == kreport_results[3]
     assert ['0.05', '116000', '0', 'O', '', 'o__Chlorobiales'] == kreport_results[4]


### PR DESCRIPTION
Fixes #2305

Updates `kreport` to include information in column 3, which is the bp "assigned" to a particular taxon. Since we make all assignments to the genome level and then apply taxonomy later, this column just contains the species-level assignments from column 2. I think this best mimics the intention of the output format / outputs from other tools.

Updated documentation with this and the recommendation to generate sketches with abundance.

This is basically a bug fix, since this is closer to what the format should have been to begin with.