### PR TITLE
[EXP] Minimal versions for deps and semver checks in Rust

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -255,11 +255,18 @@ jobs:
           toolchain: stable
           override: true
 
+      - name: Check semver
+        uses: obi1kenobi/cargo-semver-checks-action@v1
+        with:
+          crate-name: sourmash
+          version-tag-prefix: r
+
       - name: Make sure we can publish the sourmash crate
         uses: actions-rs/cargo@v1
         with:
           command: publish
           args: --dry-run --manifest-path src/core/Cargo.toml
+
 
   minimum_rust_version:
     runs-on: ubuntu-latest
@@ -274,20 +281,27 @@ jobs:
       - name: check if README matches MSRV defined here
         run: grep '1.48.0' src/core/README.md
 
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.8"
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install -e .
-
       - name: Check if it builds properly
         uses: actions-rs/cargo@v1
         with:
           command: build
+
+  minimal_rust_deps:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: "1.48.0"
+
+      - uses: taiki-e/install-action@cargo-hack
+      - uses: taiki-e/install-action@cargo-minimal-versions
+
+      - run: rustup toolchain add nightly --no-self-update
+      - run: cargo minimal-versions check --workspace --all-features --ignore-private -v
+      - run: cargo minimal-versions build --workspace --all-features --ignore-private -v
+      - run: cargo minimal-versions test --workspace --all-features -v
 
   check_cbindgen:
     name: "Check if cbindgen runs cleanly for generating the C headers"


### PR DESCRIPTION
[Minimal versions](https://github.com/rust-lang/cargo/issues/5657) is more common in [go](https://research.swtch.com/vgo-mvs) but I wanted to check how it fares out in Rust.

Also add an action for [checking semver](https://github.com/obi1kenobi/cargo-semver-checks-action), to see if version bumps are required/respect it.