### PR TITLE
[WIP] add `sourmash tax crosscheck` to validate taxonomies <=> database contents

### DIFF
--- a/src/sourmash/cli/tax/__init__.py
+++ b/src/sourmash/cli/tax/__init__.py
@@ -10,6 +10,7 @@ from . import annotate
 from . import prepare
 from . import grep
 from . import summarize
+from . import crosscheck
 
 from ..utils import command_list
 from argparse import SUPPRESS, RawDescriptionHelpFormatter

--- a/src/sourmash/cli/tax/crosscheck.py
+++ b/src/sourmash/cli/tax/crosscheck.py
@@ -48,6 +48,24 @@ def subparser(subparsers):
         help='continue past errors in file and taxonomy loading',
     )
 
+    subparser.add_argument(
+        '--no-fail', action='store_true',
+        help="do not fail if problems are detected; just output information",
+    )
+    subparser.add_argument(
+        '--no-fail-extra-tax', action='store_true',
+        help="do not fail if databases are missing identifiers from taxonomy",
+    )
+    subparser.add_argument(
+        '--no-fail-missing-ident', action='store_true',
+        help="do not fail if taxonomy is missing for any identifiers",
+    )
+    subparser.add_argument(
+        '--no-fail-duplicate-ident', action='store_true',
+        help="do not fail if there are duplicate identifiers",
+    )
+
+
 def main(args):
     import sourmash
     return sourmash.tax.__main__.crosscheck(args)

--- a/src/sourmash/cli/tax/crosscheck.py
+++ b/src/sourmash/cli/tax/crosscheck.py
@@ -1,0 +1,53 @@
+"""crosscheck taxonomy/lineage information against database contents"""
+
+usage="""
+@CTB
+    sourmash tax summarize <taxonomy_file> [ <more files> ... ]
+
+The 'tax summarize' command reads in one or more taxonomy databases
+or lineage files (produced by 'tax annotate'), combines them,
+and produces a human readable summary.
+
+Please see the 'tax summarize' documentation for more details:
+  https://sourmash.readthedocs.io/en/latest/command-line.html#command-line.html#sourmash-tax-summarize-print-summary-information-for-lineage-spreadsheets-or-taxonomy-databases
+
+"""
+
+import sourmash
+from sourmash.logging import notify, print_results, error
+
+
+def subparser(subparsers):
+    subparser = subparsers.add_parser('crosscheck', usage=usage)
+    subparser.add_argument(
+        '-q', '--quiet', action='store_true',
+        help='suppress non-error output'
+    )
+    subparser.add_argument(
+        '--taxonomy-files', '--taxonomy-csv', '--taxonomy',
+        metavar='FILE',
+        nargs="+", action="extend",
+        help='database lineages'
+    )
+    subparser.add_argument(
+        '--database-files', '--db',
+        metavar='FILE',
+        nargs="+", action="extend",
+        help="sourmash databases",
+    )
+    subparser.add_argument(
+        '--keep-full-identifiers', action='store_true',
+        help='do not split identifiers on whitespace'
+    )
+    subparser.add_argument(
+        '--keep-identifier-versions', action='store_true',
+        help='after splitting identifiers, do not remove accession versions'
+    )
+    subparser.add_argument(
+        '-f', '--force', action = 'store_true',
+        help='continue past errors in file and taxonomy loading',
+    )
+
+def main(args):
+    import sourmash
+    return sourmash.tax.__main__.crosscheck(args)

--- a/src/sourmash/cli/tax/crosscheck.py
+++ b/src/sourmash/cli/tax/crosscheck.py
@@ -64,6 +64,10 @@ def subparser(subparsers):
         '--no-fail-duplicate-ident', action='store_true',
         help="do not fail if there are duplicate identifiers",
     )
+    subparser.add_argument(
+        '-o', '--output-details',
+        help="save details of failed crosscheck to this file",
+    )
 
 
 def main(args):

--- a/src/sourmash/cli/tax/crosscheck.py
+++ b/src/sourmash/cli/tax/crosscheck.py
@@ -68,6 +68,10 @@ def subparser(subparsers):
         '-o', '--output-details',
         help="save details of failed crosscheck to this file",
     )
+    subparser.add_argument(
+        '--ignore-genbank', action='store_true',
+        help="do not invoke special handling for GenBank identifiers (GCA <=> GCF checking)",
+    )
 
 
 def main(args):

--- a/src/sourmash/lca/lca_utils.py
+++ b/src/sourmash/lca/lca_utils.py
@@ -144,7 +144,7 @@ def build_tree(assignments, initial=None):
 
 def find_lca(tree):
     """
-    Given a tree produced by 'find_tree', find the first node with multiple
+    Given a tree produced by 'build_tree', find the first node with multiple
     children, OR the only leaf in the tree.  Return (lineage_tup, reason),
     where 'reason' is the number of children of the returned node, i.e.
     0 if it's a leaf and > 1 if it's an internal node.

--- a/src/sourmash/tax/__main__.py
+++ b/src/sourmash/tax/__main__.py
@@ -563,7 +563,7 @@ def crosscheck(args):
             idents.add(ident)
 
     # hackity hack hack
-    if missing_idents:
+    if missing_idents and not args.ignore_genbank:
         notify("Missing identifiers; checking GenBank to see if we need to demux")
         notify("GCA_ and GCF_ identifiers.")
 
@@ -596,6 +596,9 @@ def crosscheck(args):
             if len(missing_idents_2) != len(missing_idents):
                 notify(f"Resolved all but {len(missing_idents_2)} missing identifiers with GenBank demuxification.")
                 missing_idents = missing_idents_2
+    elif missing_idents and args.ignore_genbank:
+        notify("** NOTE: missing identifiers, but --ignore-genbank is set;")
+        notify("** we are NOT checking to see if GCF <=> GCA conversion would resolve.")
 
     fail = False
 

--- a/src/sourmash/tax/tax_utils.py
+++ b/src/sourmash/tax/tax_utils.py
@@ -1103,7 +1103,7 @@ class MultiLineageDB(abc.Mapping):
         """)
             did_create = True
         except sqlite3.OperationalError:
-            # already exists?
+            # already exists? ...OR database is read only...
             raise ValueError(f"taxonomy table already exists in '{filename}'")
 
         # follow up and create index


### PR DESCRIPTION
Fixes https://github.com/sourmash-bio/sourmash/issues/2361

This PR adds `sourmash tax crosscheck`, which validates taxonomies against databases and databases against taxonomies (every identifier has a lineage, every lineage has at least one identifier).

This also adds some of the remaining lingering useful functionality in `lca index` to the tax submodule, in pursuit of the eventual consolidation of lca utility/parsing functionality into tax per https://github.com/sourmash-bio/sourmash/issues/2198 

`tax crosscheck` currently verifies:
* every identifier has a taxonomic lineage
* every taxonomic lineage is present at least once in database
* there are no duplicate identifiers in the database

TODO:
- [ ] add tests
- [ ] add output of bad or missing identifiers to CSV file

## Example usage

### all is well

```
% sourmash tax crosscheck --taxonomy gtdb-rs207.taxonomy.sqldb --db gtdb-rs207.genomic.k31.zip
...
loading taxonomies...
...loaded 317542 entries.
loading sourmash databases...
...found 317542 sketches across 1 files

no duplicate identifiers found!
all identifiers have a taxonomic lineage associated with them!
all taxonomy entries have a matching sketch in the databases!
```

### missing identifiers in databases

```
% sourmash tax crosscheck --taxonomy gtdb-rs207.taxonomy.sqldb --db gtdb-rs207.genomic-reps.dna.k31.zip
...
loading taxonomies...
...loaded 317542 entries.
loading sourmash databases...
...found 65703 sketches across 1 files

no duplicate identifiers found!
all identifiers have a taxonomic lineage associated with them!
found 251839 identifiers in the taxonomy that are NOT in any database.
```
