### PR TITLE
[MRG] fix manifest load function to properly catch `gzip.BadGzipFile`

### DIFF
--- a/src/sourmash/manifest.py
+++ b/src/sourmash/manifest.py
@@ -41,7 +41,7 @@ class BaseCollectionManifest:
         if db is not None:
             return db
 
-        # not a SQLite db?
+        # not a SQLite db? CTB: fix this to actually try loading this as .gz...
         if filename.endswith('.gz'):
             xopen = gzip.open
         else:

--- a/src/sourmash/sourmash_args.py
+++ b/src/sourmash/sourmash_args.py
@@ -366,7 +366,12 @@ def _load_stdin(filename, **kwargs):
 
 def _load_standalone_manifest(filename, **kwargs):
     from sourmash.index import StandaloneManifestIndex
-    idx = StandaloneManifestIndex.load(filename)
+
+    try:
+        idx = StandaloneManifestIndex.load(filename)
+    except gzip.BadGzipFile as exc:
+        raise ValueError(exc)
+
     return idx
 
 

--- a/tests/test_sourmash_args.py
+++ b/tests/test_sourmash_args.py
@@ -10,6 +10,7 @@ import io
 import contextlib
 import csv
 import argparse
+import shutil
 
 import sourmash_tst_utils as utils
 import sourmash
@@ -802,3 +803,15 @@ def test_add_ksize_arg_default_31_specify():
     add_ksize_arg(p, default=31)
     args = p.parse_args(['-k', '21'])
     assert args.ksize == 21
+
+
+def test_bug_2370(runtmp):
+    # bug - manifest loading code does not catch gzip.BadGzipFile
+    sigfile = utils.get_test_data('63.fa.sig')
+
+    # copy sigfile over to a .gz file without compressing it -
+    shutil.copyfile(sigfile, runtmp.output('not_really_gzipped.gz'))
+
+    # try running sourmash_args.load_file_as_index
+    #runtmp.sourmash('sig', 'describe', runtmp.output('not_really_gzipped.gz'))
+    sourmash_args.load_file_as_index(runtmp.output('not_really_gzipped.gz'))


### PR DESCRIPTION
The code in `sourmash_args` for manifest loading wasn't properly catching the `gzip.BadGzipFile` exception.

Fixes https://github.com/sourmash-bio/sourmash/issues/2370