### PR TITLE
[MRG] fixing cross-platform cibuildwheel action for release

### DIFF
--- a/.ci/install_cargo.sh
+++ b/.ci/install_cargo.sh
@@ -5,5 +5,5 @@ export PATH="$HOME/.cargo/bin:$PATH"
 rustc -V
 rustup target add aarch64-apple-darwin
 
+export CARGO_NET_GIT_FETCH_WITH_CLI=true
 cargo update
-

--- a/.ci/install_cargo.sh
+++ b/.ci/install_cargo.sh
@@ -4,6 +4,3 @@ rustup show
 export PATH="$HOME/.cargo/bin:$PATH"
 rustc -V
 rustup target add aarch64-apple-darwin
-
-export CARGO_NET_GIT_FETCH_WITH_CLI=true
-cargo update

--- a/.ci/install_cargo.sh
+++ b/.ci/install_cargo.sh
@@ -4,3 +4,6 @@ rustup show
 export PATH="$HOME/.cargo/bin:$PATH"
 rustc -V
 rustup target add aarch64-apple-darwin
+
+cargo update
+

--- a/.ci/install_cargo.sh
+++ b/.ci/install_cargo.sh
@@ -1,5 +1,6 @@
 #! /bin/sh
-curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable
+curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain=stable --profile=minimal
+rustup show
 export PATH="$HOME/.cargo/bin:$PATH"
 rustc -V
 rustup target add aarch64-apple-darwin

--- a/.ci/install_cargo.sh
+++ b/.ci/install_cargo.sh
@@ -4,3 +4,6 @@ rustup show
 export PATH="$HOME/.cargo/bin:$PATH"
 rustc -V
 rustup target add aarch64-apple-darwin
+
+export CARGO_NET_GIT_FETCH_WITH_CLI=true
+cargo update

--- a/.ci/install_cargo.sh
+++ b/.ci/install_cargo.sh
@@ -1,5 +1,5 @@
 #! /bin/sh
-curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain=stable --profile=minimal
+curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain=stable
 rustup show
 export PATH="$HOME/.cargo/bin:$PATH"
 rustc -V

--- a/.github/workflows/build_wheel_all_archs.yml
+++ b/.github/workflows/build_wheel_all_archs.yml
@@ -79,7 +79,7 @@ jobs:
   release:
     name: Publish wheels
     runs-on: ubuntu-20.04
-    if: startsWith(github.ref, 'refs/tags/v')
+#    if: startsWith(github.ref, 'refs/tags/v')
     needs: build_wheels
 
     steps:

--- a/.github/workflows/build_wheel_all_archs.yml
+++ b/.github/workflows/build_wheel_all_archs.yml
@@ -71,6 +71,7 @@ jobs:
           CIBW_ENVIRONMENT_MACOS: ${{ matrix.macos_target }}
           CIBW_ARCHS_LINUX: ${{ matrix.arch }}
           CIBW_ARCHS_MACOS: ${{ matrix.arch }}
+          CARGO_NET_GIT_FETCH_WITH_CLI: true
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build_wheel_all_archs.yml
+++ b/.github/workflows/build_wheel_all_archs.yml
@@ -16,22 +16,22 @@ jobs:
       matrix:
         build: [
           linux-aarch64,
-          linux-ppc64le,
-          linux-s390x,
+#          linux-ppc64le,
+#          linux-s390x,
         ]
         include:
           - build: linux-aarch64
             os: ubuntu-20.04
             arch: aarch64
             macos_target: ''
-          - build: linux-ppc64le
-            os: ubuntu-20.04
-            arch: ppc64le
-            macos_target: ''
-          - build: linux-s390x
-            os: ubuntu-20.04
-            arch: s390x
-            macos_target: ''
+#          - build: linux-ppc64le
+#            os: ubuntu-20.04
+#            arch: ppc64le
+#            macos_target: ''
+#          - build: linux-s390x
+#            os: ubuntu-20.04
+#            arch: s390x
+#            macos_target: ''
       fail-fast: false
 
     steps:

--- a/.github/workflows/build_wheel_all_archs.yml
+++ b/.github/workflows/build_wheel_all_archs.yml
@@ -1,4 +1,4 @@
-name: cibuildwheel
+name: cibuildwheel_ubuntu
 
 on:
   push:

--- a/.github/workflows/build_wheel_all_archs.yml
+++ b/.github/workflows/build_wheel_all_archs.yml
@@ -80,7 +80,7 @@ jobs:
   release:
     name: Publish wheels
     runs-on: ubuntu-20.04
-#    if: startsWith(github.ref, 'refs/tags/v')
+    if: startsWith(github.ref, 'refs/tags/v')
     needs: build_wheels
 
     steps:

--- a/.github/workflows/build_wheel_all_archs.yml
+++ b/.github/workflows/build_wheel_all_archs.yml
@@ -16,22 +16,22 @@ jobs:
       matrix:
         build: [
           linux-aarch64,
-#          linux-ppc64le,
-#          linux-s390x,
+          linux-ppc64le,
+          linux-s390x,
         ]
         include:
           - build: linux-aarch64
             os: ubuntu-20.04
             arch: aarch64
             macos_target: ''
-#          - build: linux-ppc64le
-#            os: ubuntu-20.04
-#            arch: ppc64le
-#            macos_target: ''
-#          - build: linux-s390x
-#            os: ubuntu-20.04
-#            arch: s390x
-#            macos_target: ''
+          - build: linux-ppc64le
+            os: ubuntu-20.04
+            arch: ppc64le
+            macos_target: ''
+          - build: linux-s390x
+            os: ubuntu-20.04
+            arch: s390x
+            macos_target: ''
       fail-fast: false
 
     steps:

--- a/.github/workflows/build_wheel_all_archs.yml
+++ b/.github/workflows/build_wheel_all_archs.yml
@@ -1,7 +1,7 @@
 name: cibuildwheel_ubuntu
 
 on:
-  pull request:        # CTB remove before merge!
+  pull_request:        # CTB remove before merge!
   push:
     branches: [latest]
     tags: v*

--- a/.github/workflows/build_wheel_all_archs.yml
+++ b/.github/workflows/build_wheel_all_archs.yml
@@ -1,6 +1,7 @@
 name: cibuildwheel_ubuntu
 
 on:
+  pull request:        # CTB remove before merge!
   push:
     branches: [latest]
     tags: v*


### PR DESCRIPTION
The QEMU/cibuildwheel based wheel-builds were exiting on `cargo update`:
```
2022-12-01T17:46:44.0138993Z   copying src/sourmash/cli/sketch/translate.py -> build/lib/sourmash/cli/sketch
2022-12-01T17:46:47.2377148Z       Updating crates.io index
2022-12-01T17:48:47.6753837Z   error: subprocess-exited-with-error
2022-12-01T17:48:47.6779277Z   
2022-12-01T17:48:47.6796452Z   × Building wheel for sourmash (pyproject.toml) did not run successfully.
2022-12-01T17:48:47.6834234Z   │ exit code: 247
2022-12-01T17:48:47.6839824Z   ╰─> See above for output.
2022-12-01T17:48:47.6851498Z   
```
which seems to have been caused by an out-of-memory error; see https://users.rust-lang.org/t/cargo-uses-too-much-memory-being-run-in-qemu/76531 for what looks like the same problem.

This PR fixes the problem using the same fix as in https://users.rust-lang.org/t/cargo-uses-too-much-memory-being-run-in-qemu/76531.