### PR TITLE
[MRG] remove cibuildwheel action from PRs

### DIFF
--- a/.github/workflows/build_wheel_all_archs.yml
+++ b/.github/workflows/build_wheel_all_archs.yml
@@ -1,7 +1,7 @@
 name: cibuildwheel_ubuntu
 
 on:
-  pull_request:        # CTB remove before merge!
+  #pull_request:        # use for testing modifications to this action
   push:
     branches: [latest]
     tags: v*


### PR DESCRIPTION
While testing https://github.com/sourmash-bio/sourmash/pull/2384, I enabled cibuildwheel on PRs and then when I merged, I left it in by mistake.  This removes it again!