### PR TITLE
[MRG] update release procedure after v4.6.0 and v4.6.1

### DIFF
--- a/doc/release.md
+++ b/doc/release.md
@@ -3,6 +3,33 @@
 These are adapted from the khmer release docs, originally written by
 Michael Crusoe.
 
+## Checklist
+
+Here's a checklist to copy/paste into an issue:
+
+```
+
+Release candidate testing:
+- [ ] Command line tests pass for a release candidate
+- [ ] All eight release candidate wheels are built
+
+Releasing to PyPI:
+
+- [ ] RC tag(s)s deleted on github
+- [ ] Release tag cut
+- [ ] Release notes written
+- [ ] All eight release wheels built
+- [ ] Release wheels uploaded to pypi
+- [ ] tar.gz distribution uploaded to pypi
+
+After release to PyPI and conda-forge/bioconda packages built:
+
+- [ ] [PyPI page](https://pypi.org/project/sourmash/) updated
+- [ ] Zenodo DOI successfully minted upon new github release - [see search results](https://zenodo.org/search?page=1&size=20&q=sourmash)
+- [ ] `pip install sourmash` installs the correct version
+- [ ] `mamba create -n smash-release -y sourmash` installs the correct version
+```
+
 ## Creating the build environment with conda
 
 You can most easily set up your build environment with conda.
@@ -221,7 +248,9 @@ merge it and wait for the `sourmash-minimal` package to show up in conda-forge:
 conda search sourmash-minimal={new_version}
 ```
 
-An example PR for [`3.4.0`](https://github.com/conda-forge/sourmash-minimal-feedstock/pull/7).
+[An example conda-forge PR for `4.6.0`](https://github.com/conda-forge/sourmash-minimal-feedstock/pull/37).
+
+[An example bioconda PR for `4.6.0`](https://github.com/bioconda/bioconda-recipes/pull/38205).
 
 ## Bioconda
 
@@ -234,15 +263,6 @@ prepared in the previous section to be available for installation,
 and tests are going to fail in Bioconda before that.
 
 An example PR for [`3.4.0`](https://github.com/bioconda/bioconda-recipes/pull/23171).
-
-## Double check everything:
-
-```
-- [ ] [PyPI page](https://pypi.org/project/sourmash/) updated
-- [ ] Zenodo DOI successfully minted upon new github release - [see search results](https://zenodo.org/search?page=1&size=20&q=sourmash)
-- [ ] `pip install sourmash` installs the correct version
-- [ ] `mamba create -n smash-release -y sourmash` installs the correct version
-```
 
 ## Announce it!
 

--- a/doc/release.md
+++ b/doc/release.md
@@ -61,6 +61,7 @@ git push --tags origin
 
 3\. Test the release candidate. Bonus: repeat on macOS:
 ```
+python -m pip install -U pip
 python -m pip install -U virtualenv wheel tox-setuptools-version build
 
 cd ..
@@ -73,6 +74,7 @@ python -m venv testenv4
 
 cd testenv1
 source bin/activate
+python -m pip install wheel
 git clone --depth 1 --branch v${new_version}${rc} https://github.com/sourmash-bio/sourmash.git
 cd sourmash
 python -m pip install -r requirements.txt
@@ -83,7 +85,7 @@ pytest && cargo test
 cd ../../testenv2
 deactivate
 source bin/activate
-python -m pip install setuptools_scm build
+python -m pip install setuptools_scm build wheel
 python -m pip install -e git+https://github.com/sourmash-bio/sourmash.git@v${new_version}${rc}#egg=sourmash[test]
 cd src/sourmash
 pytest && cargo test

--- a/doc/release.md
+++ b/doc/release.md
@@ -195,9 +195,11 @@ Minor new features:
 
 Bug fixes:
 
-Cleanup and documentation fixes:
+Cleanup and documentation updates:
 
 Developer updates:
+
+Dependabot updates:
 ```
 
 ## Conda-forge

--- a/doc/release.md
+++ b/doc/release.md
@@ -28,6 +28,28 @@ latest version with `rustup update`:
 rustup update
 ```
 
+## Writing release notes
+
+Draft release notes can be created with `git log --oneline
+v4.4.1..latest`, but should then be edited manually. We suggest
+putting PRs in the following categories:
+
+```
+Major new features:
+
+Minor new features:
+
+Bug fixes:
+
+Cleanup and documentation updates:
+
+Developer updates:
+
+Dependabot updates:
+```
+
+A convenient way to edit release notes is to put them in a [hackmd.io](https://hackmd.io) document and edit/display them there; then, create a "draft release notes for v..." issue and paste the markdown into the issue.
+
 ## Testing a release
 
 0\. First things first: check if Read the Docs is building properly for `latest`.
@@ -183,24 +205,6 @@ with the tag you pushed. Copy and paste in the release notes.
 Note that there will also be releases associated with the Rust `core`
 package, which is versioned differently than `sourmash`.  These will
 be of the form `rXX.YY.ZZ`, e.g. `r0.9.0`. Please just ignore them :)
-
-Draft release notes can be created with `git log --oneline
-v4.4.1..latest`, but should then be edited manually. We suggest
-putting PRs in the following categories:
-
-```
-Major new features:
-
-Minor new features:
-
-Bug fixes:
-
-Cleanup and documentation updates:
-
-Developer updates:
-
-Dependabot updates:
-```
 
 ## Conda-forge
 

--- a/doc/release.md
+++ b/doc/release.md
@@ -96,10 +96,11 @@ Next create a new branch to work on release candidates and the version bump:
 ```
 git checkout -b release/v${new_version}
 ```
-and update the version number in `pyproject.toml`:
+and update the version number in `pyproject.toml` and `flake.nix`:
 ```
-sed -i -e "s|version = .*$|version = \"${new_version}${rc}\"|g" pyproject.toml
+sed -i -e "s|version = .*$|version = \"${new_version}${rc}\"|g" pyproject.toml flake.nix
 ```
+
 Commit the changes and push the branch:
 ```
 git add pyproject.toml

--- a/doc/release.md
+++ b/doc/release.md
@@ -160,7 +160,7 @@ cut a release like so:
 1\. Create the final tag and push to GitHub:
 
 ```
-git tag -a v${new_version}
+git tag -a v${new_version} -m "${new_version} release"
 git push --tags origin
 ```
 


### PR DESCRIPTION
Fixes https://github.com/sourmash-bio/sourmash/issues/2273

This PR:
- [x] adjusts tag commands to avoid wheels getting uploaded to the github release candidate;
- [x] switches `make test` for `pytest && cargo test`
- [x] eliminates the pypi test server section because of [this issue](https://github.com/pypa/pip/issues/9242), which has been a longstanding problem with our releases
- [x] explicit installs `wheel` wherever possible
- [x] does a `pip install -U` in the release/build conda environment
- [x] makes `rustup update` an explicit part of the release docs
- [x] updates release note guide with dependabot category
- [x] fixes release tag command to use `-m` so that we don't have to open up an editor.