### PR TITLE
[MRG] change `cargo update` to do a dry-run only

### DIFF
--- a/.ci/install_cargo.sh
+++ b/.ci/install_cargo.sh
@@ -5,5 +5,6 @@ export PATH="$HOME/.cargo/bin:$PATH"
 rustc -V
 rustup target add aarch64-apple-darwin
 
+# update crates.io index without updating Cargo.lock
 export CARGO_NET_GIT_FETCH_WITH_CLI=true
-cargo update
+cargo update --dry-run

--- a/.github/workflows/build_wheel_all_archs.yml
+++ b/.github/workflows/build_wheel_all_archs.yml
@@ -1,7 +1,7 @@
 name: cibuildwheel_ubuntu
 
 on:
-  #pull_request:        # use for testing modifications to this action
+  pull_request:        # use for testing modifications to this action
   push:
     branches: [latest]
     tags: v*


### PR DESCRIPTION
This PR continues the cibuildwheel exploration that started with a fix for building the wheels (https://github.com/sourmash-bio/sourmash/pull/2384 and #2385).

The saga continues like so:

When building the release candidates, we don't get "clean" rcN wheels. I think this is because when I run `cargo update` in the cibuildwheel action it's actually updating the Rust packages and we're getting a version bump from that. Yay? (See screenshot of releases page with 'dev' yada in wheel names.)

<img width="1025" alt="Screen Shot 2022-12-02 at 7 15 52 AM" src="https://user-images.githubusercontent.com/51016/205325234-9ec0c6c2-7cbc-42c7-9727-fd700ef59320.png">

This PR changes `cargo update` to `cargo update --dry-run` which should update the crates.io index without actually changing `Cargo.lock` and pushing a version bump.

We Shall See!