### PR TITLE
[MRG] fix `sourmash sketch ... -o <file>.zip` bug introduced in #2329 and released in v4.6.0

### DIFF
--- a/src/sourmash/sourmash_args.py
+++ b/src/sourmash/sourmash_args.py
@@ -926,19 +926,14 @@ def get_manifest(idx, *, require=True, rebuild=False):
 #
 
 def _get_signatures_from_rust(siglist):
-    for ss in siglist:
-        try:
-            ss.md5sum()
-            yield ss
-        except sourmash.exceptions.Panic:
-            # this deals with a disconnect between the way Rust
-            # and Python handle signatures; Python expects one
-            # minhash (and hence one md5sum) per signature, while
-            # Rust supports multiple. For now, go through serializing
-            # and deserializing the signature! See issue #1167 for more.
-            json_str = sourmash.save_signatures([ss])
-            for ss in sourmash.load_signatures(json_str):
-                yield ss
+    # this deals with a disconnect between the way Rust
+    # and Python handle signatures; Python expects one
+    # minhash (and hence one md5sum) per signature, while
+    # Rust supports multiple. For now, go through serializing
+    # and deserializing the signature! See issue #1167 for more.
+    json_str = sourmash.save_signatures(siglist)
+    for ss in sourmash.load_signatures(json_str):
+        yield ss
 
 
 class _BaseSaveSignaturesToLocation:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -75,6 +75,10 @@ def lca_db_format(request):
 def manifest_db_format(request):
     return request.param
 
+@pytest.fixture(params=['sig', 'sig.gz', 'zip', '.d/', '.sqldb'])
+def sig_save_extension(request):
+    return request.param
+
 
 # --- BEGIN - Only run tests using a particular fixture --- #
 # Cribbed from: http://pythontesting.net/framework/pytest/pytest-run-tests-using-particular-fixture/


### PR DESCRIPTION
This PR fixes a bug introduced in #2329 and released in v4.6.0. It also adds tests so that this bug does not trouble us again...

The easiest fix involves serializing _every_ signature into JSON format, and then deserializing it. This may add a slight performance regression that I will work to fix in a different PR, once I get v4.6.1 out.

Fixes #2390.