### PR TITLE
[MRG] fix python tests by bumping tox and pip cache versions

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -36,9 +36,9 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
-          key: ${{ runner.os }}-pip-v3-${{ hashFiles('**/setup.cfg') }}
+          key: ${{ runner.os }}-pip-v4-${{ hashFiles('**/setup.cfg') }}
           restore-keys: |
-            ${{ runner.os }}-pip-v3-
+            ${{ runner.os }}-pip-v4-
 
       - name: Install dependencies
         run: |
@@ -65,9 +65,9 @@ jobs:
         uses: actions/cache@v3
         with:
           path: .tox/
-          key: ${{ runner.os }}-tox-v3-${{ hashFiles('**/setup.cfg') }}
+          key: ${{ runner.os }}-tox-v4-${{ hashFiles('**/setup.cfg') }}
           restore-keys: |
-            ${{ runner.os }}-tox-v3-
+            ${{ runner.os }}-tox-v4-
 
       - name: Test with tox
         run: tox


### PR DESCRIPTION
This PR appears to fix recent test failures in the Python tests, which I had guessed were due to tox caching too many files; I bumped the cache numbers to attempt to start from a clean reinstall.
