### PR TITLE
Update makefile and docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,10 +21,8 @@ sourmash.egg-info
 src/sourmash/version.py
 *.DS_Store
 .tox
-src/sourmash/_lowlevel*.py
+src/sourmash/_lowlevel/*
 .env
-Pipfile
-Pipfile.lock
 target/
 .eggs
 .asv

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,3 +3,6 @@ members = [
   "src/core",
 ]
 default-members = ["src/core"]
+
+[profile.test]
+opt-level = 1

--- a/Makefile
+++ b/Makefile
@@ -5,21 +5,20 @@ all: build
 .PHONY:
 
 build: .PHONY
-	$(PYTHON) setup.py build_ext -i
+	$(PYTHON) -m pip install -e .
 
 clean:
-	$(PYTHON) setup.py clean --all
-	rm -f src/sourmash/*.so
+	$(PYTHON) -m pip uninstall -y sourmash
+	rm -rf src/sourmash/_lowlevel
 	cd doc && make clean
 
-install: all
-	$(PYTHON) setup.py install
+install: build
 
 dist: FORCE
 	$(PYTHON) -m build --sdist
 
 test: .PHONY
-	tox -e py38
+	tox -e py39
 	cargo test
 
 doc: .PHONY

--- a/doc/developer.md
+++ b/doc/developer.md
@@ -43,7 +43,7 @@ for setting up Nix in your system (Linux or macOS).
 
 Once Nix is installed, run
 ```
-nix-shell
+nix develop
 ```
 to start an environment ready for [running tests and checks](#running-tests-and-checks).
 
@@ -121,11 +121,17 @@ There are three main components in the sourmash repo:
 - The command-line interface (in `src/sourmash/cli`)
 - The Rust core library  (in `src/core`)
 
-`setup.py` has all the configuration to prepare a Python package containing these three components.
+`pyproject.toml` has all the configuration to prepare a Python package containing these
+three components.
 First it compiles the Rust core component into a shared library,
-which is wrapped by [CFFI] and exposed to the Python module.
+which is wrapped by [cffi] and exposed to the Python module.
+These steps are executed by [maturin],
+a modern [PEP 517]-compatible build backend for Python projects containing Rust
+extensions.
 
-[CFFI]: https://cffi.readthedocs.io/
+[cffi]: https://cffi.readthedocs.io/
+[maturin]: https://www.maturin.rs/
+[PEP 517]: https://peps.python.org/pep-0517/
 
 A short description of the high-level files and dirs in the sourmash repo:
 ```
@@ -150,14 +156,13 @@ A short description of the high-level files and dirs in the sourmash repo:
 ├── Makefile            | Entry point for most development tasks
 ├── MANIFEST.in         | Describes what files to add to the Python package
 ├── matplotlibrc        | Configuration for matplotlib
-├── shell.nix           | Nix configuration for creating a dev environment
+├── flake.nix           | Nix definitions (package, dev env)
+├── shell.nix           | Nix config  for creating a dev env (backward-compatible)
 ├── paper.bib           | References in the JOSS paper
 ├── paper.md            | JOSS paper content
 ├── pyproject.toml      | Python project definitions (build system and tooling)
 ├── README.md           | Info to get started
 ├── requirements.txt    | Python dependencies for development
-├── setup.py            | Entry point for Python package setup
-├── setup.cfg           | Python package definitions
 └── tox.ini             | Configuration for test automation
 ```
 
@@ -253,7 +258,6 @@ including some tools for evaluating performance changes.
 
 ## Versioning
 
-We use [`setuptools_scm`] to generate versions based on git tags.
 Versions are tagged in a `vMAJOR.MINOR.PATH` format,
 following the [Semantic Versioning] convention.
 From their definition:
@@ -264,11 +268,14 @@ From their definition:
 > MINOR version when you add functionality in a backwards compatible manner, and
 > PATCH version when you make backwards compatible bug fixes.
 
-[`setuptools_scm`]: https://github.com/pypa/setuptools_scm
 [Semantic Versioning]: https://semver.org/
+
+The Python version is not automated,
+and must be bumped in `pyproject.toml` and `flake.nix`.
 
 For the Rust core library we use `rMAJOR.MINOR.PATCH`
 (note it starts with `r`, and not `v`).
+
 The Rust version is not automated,
 and must be bumped in `src/core/Cargo.toml`.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "maturin>=0.14.7,<0.15",
+    "maturin>=0.14.13,<0.15",
     "cffi",
 ]
 build-backend = 'maturin'
@@ -134,6 +134,9 @@ manifest-path = "src/core/Cargo.toml"
 bindings = "cffi"
 include = [
   { path = "include/sourmash.h", format = ["sdist","wheel"] },
+  { path = "requirements.txt", format = ["sdist"] },
+  { path = "tests/*.py", format = ["sdist"] },
+  { path = "citation.cff", format = ["sdist", "wheel"] },
 ]
 features = ["maturin"]
 locked = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,7 @@ test = [
   "pyyaml>=6,<7",
   "recommonmark",
   "hypothesis",
+  "build",
 ]
 demo = [
   "jupyter",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,6 +135,7 @@ bindings = "cffi"
 include = [
   { path = "include/sourmash.h", format = ["sdist","wheel"] },
   { path = "requirements.txt", format = ["sdist"] },
+  { path = "Cargo.*", format = ["sdist"] },
   { path = "tests/*.py", format = ["sdist"] },
   { path = "citation.cff", format = ["sdist", "wheel"] },
 ]


### PR DESCRIPTION
Closes #2431

Relevant to #2425 because it removes `setuptools_scm` from docs =P

Also brings in the `pyproject.toml` changes needed for #2386 (and will remove them from there)