### PR TITLE
ReadTheDocs updates

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,14 +7,12 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: miniconda3-4.7
+    python: "3.10"
+    rust: "1.64"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: doc/conf.py
-
-conda:
-  environment: doc/environment.yml
 
 python:
   install:

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -1,7 +1,0 @@
-channels:
-  - conda-forge
-  - defaults
-dependencies:
-  - rust
-  - python=3.10
-  - pip


### PR DESCRIPTION
- Use Rust provided by RTD
- Remove conda env

Looking at https://readthedocs.org/projects/sourmash/builds/ it shaves from 40-100s in build time, which... yay?