### PR TITLE
importlib_metadata is a dependency on old Python versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ dependencies = [
   "deprecation>=2.0.6",
   "cachetools>=4,<6",
   "bitstring>=3.1.9,<5",
+  "importlib_metadata;python_version<'3.10'"
 ]
 
 requires-python = ">=3.8"


### PR DESCRIPTION
Fixing a related error on https://github.com/conda-forge/sourmash-minimal-feedstock/pull/40, where `importlib_metadata` is missing due to not being declared as dependency for old Python versions (pre-3.10)