### PR TITLE
MRG: bump version number to v4.8.1-dev

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = 'maturin'
 name = "sourmash"
 description = "tools for comparing biological sequences with k-mer sketches"
 readme = "README.md"
-version = "4.8.0"
+version = "4.8.1-dev"
 
 authors = [
   { name="Luiz Irber", orcid="0000-0003-4371-9659" },


### PR DESCRIPTION
This PR bumps the version number in the development branch to v4.8.1-dev. This will make it clear(er) when we are working with an install of an unreleased version.

ref https://github.com/sourmash-bio/sourmash/issues/2517