### PR TITLE
MRG: fix exception error when no arguments are provided to `sig intersect`

### DIFF
--- a/src/sourmash/sig/__main__.py
+++ b/src/sourmash/sig/__main__.py
@@ -488,6 +488,10 @@ def intersect(args):
 
         mins.intersection_update(sigobj.minhash.hashes)
 
+    if first_sig is None:
+        notify("no signatures provided to intersect!?")
+        sys.exit(-1)
+
     # forcibly turn off track_abundance, unless --abundances-from set.
     intersect_mh = first_sig.minhash.copy_and_clear().flatten()
     intersect_mh.add_many(mins)

--- a/tests/test_cmd_signature.py
+++ b/tests/test_cmd_signature.py
@@ -396,6 +396,17 @@ def test_sig_merge_flatten_2(c):
     assert actual_merge_sig.minhash == test_merge_sig.minhash
 
 
+def test_sig_intersect_0(runtmp):
+    # should print usage when no arguments
+    c = runtmp
+
+    with pytest.raises(SourmashCommandFailed):
+        c.run_sourmash('sig', 'intersect')
+
+    err = c.last_result.err
+    assert "no signatures provided to intersect!?" in err
+
+
 def test_sig_intersect_1(runtmp):
     c = runtmp
 


### PR DESCRIPTION
Fixes https://github.com/sourmash-bio/sourmash/issues/2547