### PR TITLE
MRG: add --create-empty-results option to gather

### DIFF
--- a/src/sourmash/cli/gather.py
+++ b/src/sourmash/cli/gather.py
@@ -145,6 +145,10 @@ def subparser(subparsers):
         help='continue past databases that contain no compatible signatures'
     )
     subparser.set_defaults(fail_on_empty_database=True)
+    subparser.add_argument(
+        '--create-empty-results', action='store_true',
+        help='create an empty results file even if no matches.'
+    )
 
     add_ksize_arg(subparser)
     add_moltype_args(subparser)

--- a/src/sourmash/commands.py
+++ b/src/sourmash/commands.py
@@ -888,9 +888,9 @@ def gather(args):
         print_results(f'WARNING: final scaled was {gather_iter.scaled}, vs query scaled of {query.minhash.scaled}')
 
     # save CSV?
-    w = None
-    if found and args.output:
+    if (found and args.output) or args.create_empty_results:
         with FileOutputCSV(args.output) as fp:
+            w = None
             for result in found:
                 if w is None:
                     w = result.init_dictwriter(fp)

--- a/src/sourmash/sourmash_args.py
+++ b/src/sourmash/sourmash_args.py
@@ -32,6 +32,9 @@ signature and file output functionality:
 
 * class FileOutput - file output context manager that deals w/stdout well
 * class FileOutputCSV - file output context manager for CSV files
+
+misc support:
+* FileInputCSV - context manager for reading CSVs
 """
 import sys
 import os

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -3533,13 +3533,39 @@ def test_gather_nomatch(runtmp, linear_gather, prefetch_gather):
         'gather/GCF_000006945.2_ASM694v2_genomic.fna.gz.sig')
     testdata_match = utils.get_test_data('lca/TARA_ASE_MAG_00031.sig')
 
+    out_csv = runtmp.output('results.csv')
+
     runtmp.sourmash('gather', testdata_query, testdata_match,
+                    '-o', out_csv,
                     linear_gather, prefetch_gather)
 
     print(runtmp.last_result.out)
     print(runtmp.last_result.err)
 
     assert "No matches found for --threshold-bp at 50.0 kbp." in runtmp.last_result.err
+    assert not os.path.exists(out_csv)
+
+
+def test_gather_nomatch_create_empty(runtmp, linear_gather, prefetch_gather):
+    testdata_query = utils.get_test_data(
+        'gather/GCF_000006945.2_ASM694v2_genomic.fna.gz.sig')
+    testdata_match = utils.get_test_data('lca/TARA_ASE_MAG_00031.sig')
+
+    out_csv = runtmp.output('results.csv')
+
+    runtmp.sourmash('gather', testdata_query, testdata_match,
+                    '-o', out_csv, '--create-empty-results',
+                    linear_gather, prefetch_gather)
+
+    print(runtmp.last_result.out)
+    print(runtmp.last_result.err)
+
+    assert "No matches found for --threshold-bp at 50.0 kbp." in runtmp.last_result.err
+    assert os.path.exists(out_csv)
+
+    with open(out_csv, 'rt') as fp:
+        data = fp.read()
+        assert not data
 
 
 def test_gather_abund_nomatch(runtmp, linear_gather, prefetch_gather):


### PR DESCRIPTION
Fixes https://github.com/sourmash-bio/sourmash/issues/2357

Questions for reviewers:
* currently it is created as an empty file if no results. Should we add CSV headers? (This is difficult with current code, I think.)
* Is the option name good? here's the relevant code:

```python
    subparser.add_argument(
        '--create-empty-results', action='store_true',
        help='create an empty results file even if no matches.'
    )
```