### PR TITLE
MRG: update `sourmash sketch` docs for building merged sketches

### DIFF
--- a/doc/command-line.md
+++ b/doc/command-line.md
@@ -720,8 +720,8 @@ When using LIN taxonomic information, you can optionally also provide a `lingrou
 
 This output format consists of four columns:
 - `name`, `lin` columns are taken directly from the `--lingroup` file
-- `percent_containment`, the total percent of the dataset contained in this lingroup and all descendents
-- `num_bp_contained`, the estimated number of base pairs contained in this lingroup and all descendents.
+- `percent_containment`, the total percent of the dataset contained in this lingroup and all descendants
+- `num_bp_contained`, the estimated number of base pairs contained in this lingroup and all descendants.
 
 Similar to `kreport` above, we use the wording "contained" rather than "assigned," because `sourmash` assigns matches at the genome level, and the `tax` functions summarize this information.
 
@@ -791,8 +791,8 @@ When using LIN taxonomic information, you can optionally also provide a `lingrou
 
 This output format consists of four columns:
 - `name`, `lin` columns are taken directly from the `--lingroup` file
-- `percent_containment`, the total percent of the dataset contained in this lingroup and all descendents
-- `num_bp_contained`, the estimated number of base pairs contained in this lingroup and all descendents.
+- `percent_containment`, the total percent of the dataset contained in this lingroup and all descendants
+- `num_bp_contained`, the estimated number of base pairs contained in this lingroup and all descendants.
 
 Similar to `kreport` above, we use the wording "contained" rather than "assigned," because `sourmash` assigns matches at the genome level, and the `tax` functions summarize this information.
 

--- a/doc/sourmash-sketch.md
+++ b/doc/sourmash-sketch.md
@@ -52,9 +52,41 @@ By default, `sketch dna` ignores bad k-mers (e.g. non-ACGT characters
 in DNA). If `--check-sequence` is provided, `sketch dna` will error
 exit on the first bad k-mer.
 
+### Building a combined sketch from two or more files
+
+If you have multiple files, sourmash will by default create one sketch
+for _each_ file.  For situations such as paired-end read files from
+Illumina sequencing, you may instead want to build a combined sketch.
+
+You can build a combined sketch in two ways.
+
+First, you can use `--name/--merge` to build
+a single (named) sketch out of multiple input files:
+```
+sourmash sketch dna -p k=31 sample_R1.fq.gz sample_R2.fq.gz \
+    --name "sample" -o sample.sig
+```
+Here you need to specify a name because sourmash does not pick a default
+name when given multiple files; you also need to provide an output file
+name because sourmash doesn't pick a default output name in this situation.
+
+Second, you can stream the input files into `sourmash sketch` via stdin:
+```
+gunzip -c sample_R?.fq.gz | sourmash sketch dna -p k=31 - \
+    -o sample.sig
+```
+As above, you need to specify an output filename because sourmash
+can't guess a good default for streaming input.  The `--name` option
+can still be specified if you want to name the output sketch something
+other than `-`.
+
+Note that the order of sequences or sequence files does not affect
+the output of `sourmash sketch` at all: you do not need to
+interleave reads or provide the input files in a consistent order.
+
 ### Protein sketches for genomes and proteomes
 
-Likewise,
+The command:
 ```
 sourmash sketch translate genome.fna
 ```

--- a/doc/sourmash-sketch.md
+++ b/doc/sourmash-sketch.md
@@ -258,11 +258,24 @@ and then `sourmash sig rename`.
 
 ### Locations for output files
 
-Signature files can contain multiple signatures and sketches. Use `sourmash sig describe` to get details on the contents of a file.
+Signature files can contain multiple signatures and sketches. Use
+`sourmash sig fileinfo` to summarize the contents of a signature file,
+and `sourmash sig describe` to get details on the contents of a file.
 
 You can use `-o <filename>` to specify a file output location for all the output signatures; `-o -` means stdout. This does not merge signatures unless `--merge` is provided.
 
 Specify `--outdir` to put all the signatures in a specific directory.
+
+### Output file formats
+
+Sourmash can read and write signatures in many different formats, and
+`sourmash sketch ... -o <filename>` supports all of the standard
+output formats. Our recommendation is to output to zip files -
+e.g. `filename.zip` - as this is the smallest and most flexible
+signature storage format.
+
+Please see
+[Choosing signature output formats](command-line.md#choosing-signature-output-formats) for more details.
 
 ### Downsampling and flattening signatures
 

--- a/doc/sourmash-sketch.md
+++ b/doc/sourmash-sketch.md
@@ -64,7 +64,7 @@ First, you can use `--name/--merge` to build
 a single (named) sketch out of multiple input files:
 ```
 sourmash sketch dna -p k=31 sample_R1.fq.gz sample_R2.fq.gz \
-    --name "sample" -o sample.sig
+    --name "sample" -o sample.zip
 ```
 Here you need to specify a name because sourmash does not pick a default
 name when given multiple files; you also need to provide an output file
@@ -73,7 +73,7 @@ name because sourmash doesn't pick a default output name in this situation.
 Second, you can stream the input files into `sourmash sketch` via stdin:
 ```
 gunzip -c sample_R?.fq.gz | sourmash sketch dna -p k=31 - \
-    -o sample.sig
+    -o sample.zip
 ```
 As above, you need to specify an output filename because sourmash
 can't guess a good default for streaming input.  The `--name` option

--- a/doc/using-sourmash-a-guide.md
+++ b/doc/using-sourmash-a-guide.md
@@ -127,6 +127,17 @@ reads; the second takes all the trimmed read files, subsamples k-mers
 from them at 1000:1, and outputs a single merged signature named
 'SOMENAME' into the file `SOMENAME-reads.sig`.
 
+### Calculating a combined signature for multiple read files
+
+```
+sourmash sketch dna -p scaled=1000,k=21,k=31,k=51 sample_*.fq.gz \
+    --name "combined sketch for sample" -o sample.zip
+```
+
+This will build combined sketches of all `*.fq.gz` files
+in the directory for three ksizes, k=21, k=31, and k=51. The three sketches
+will be named `combined sketch for sample` and be saved to `sample.zip`.
+
 ### Creating signatures for individual genome files:
 
 ```


### PR DESCRIPTION
Fixes https://github.com/sourmash-bio/sourmash/issues/2532
Fixes https://github.com/sourmash-bio/sourmash/issues/567

This PR updates the docs to provide commands for calculating a single merged sketch from multiple input files.

In [the sourmash sketch quickstart](https://sourmash.readthedocs.io/en/latest/sourmash-sketch.html#quickstart), it adds:

> ### Building a combined sketch from two or more files
> 
> If you have multiple files, sourmash will by default create one sketch
> for _each_ file.  For situations such as paired-end read files from
> Illumina sequencing, you may instead want to build a combined sketch.
> 
> You can build a combined sketch in two ways.
> 
> First, you can use `--name/--merge` to build
> a single (named) sketch out of multiple input files:
> ```
> sourmash sketch dna -p k=31 sample_R1.fq.gz sample_R2.fq.gz \
>     --name "sample" -o sample.zip
> ```
> Here you need to specify a name because sourmash does not pick a default
> name when given multiple files; you also need to provide an output file
> name because sourmash doesn't pick a default output name in this situation.
> 
> Second, you can stream the input files into `sourmash sketch` via stdin:
> ```
> gunzip -c sample_R?.fq.gz | sourmash sketch dna -p k=31 - \
>     -o sample.zip
> ```
> As above, you need to specify an output filename because sourmash
> can't guess a good default for streaming input.  The `--name` option
> can still be specified if you want to name the output sketch something
> other than `-`.
> 
> Note that the order of sequences or sequence files does not affect
> the output of `sourmash sketch` at all: you do not need to
> interleave reads or provide the input files in a consistent order.
> 

In the [practical guide](https://sourmash.readthedocs.io/en/latest/using-sourmash-a-guide.html#could-you-just-give-us-the-command-line) it adds:

> ### Calculating a combined signature for multiple read files
> 
> ```
> sourmash sketch dna -p scaled=1000,k=21,k=31,k=51 sample_*.fq.gz \
>     --name "combined sketch for sample" -o sample.zip
> ```
> 
> This will build combined sketches of all `*.fq.gz` files
> in the directory for three ksizes, k=21, k=31, and k=51. The three sketches
> will be named `combined sketch for sample` and be saved to `sample.zip`.
