### PR TITLE
Remove codecov from tox, use GH action instead

### DIFF
--- a/.github/workflows/hypothesis.yml
+++ b/.github/workflows/hypothesis.yml
@@ -27,3 +27,9 @@ jobs:
 
       - name: Run Hypothesis tests
         run: tox -e hypothesis,coverage
+
+      - name: Upload Python coverage to codecov
+        uses: codecov/codecov-action@v3
+        with:
+          flags: hypothesis-py
+          fail_ci_if_error: true

--- a/.github/workflows/hypothesis.yml
+++ b/.github/workflows/hypothesis.yml
@@ -33,3 +33,4 @@ jobs:
         with:
           flags: hypothesis-py
           fail_ci_if_error: true
+          files: .tox/coverage.xml

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -79,3 +79,4 @@ jobs:
         with:
           flags: python
           fail_ci_if_error: true
+          files: .tox/coverage.xml

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -73,3 +73,9 @@ jobs:
         run: tox
         env:
           PYTHONDEVMODE: 1
+
+      - name: Upload Python coverage to codecov
+        uses: codecov/codecov-action@v3
+        with:
+          flags: python
+          fail_ci_if_error: true

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,6 @@ envlist =
   py311,
   py39,
   coverage,
-  codecov,
   docs,
   package_description
   py38,
@@ -161,22 +160,6 @@ commands = coverage combine
 depends = py39, py38, py37, pypy3
 parallel_show_output = True
 
-[testenv:codecov]
-description = [only run on CI]: upload coverage data to codecov (depends on coverage running first)
-passenv = {[testenv]passenv}
-          CODECOV_*
-          GITHUB_ACTION
-          GITHUB_REF
-          GITHUB_HEAD_REF
-          GITHUB_RUN_ID
-          GITHUB_SHA
-          GITHUB_REPOSITORY
-deps = codecov
-skip_install = True
-changedir = {toxinidir}
-depends = coverage
-commands = codecov -e $TOXENV --file "{toxworkdir}/coverage.xml" -F python {posargs}
-
 [testenv:X]
 description = print the positional arguments passed in with echo
 commands = echo {posargs}
@@ -209,10 +192,10 @@ source = src/sourmash/
 
 [gh-actions]
 python =
-  3.10: py310, docs, package_description, coverage, codecov
-  3.11: py311, coverage, codecov
-  3.9: py39, coverage, codecov
-  3.8: py38, coverage, codecov
+  3.10: py310, docs, package_description, coverage
+  3.11: py311, coverage
+  3.9: py39, coverage
+  3.8: py38, coverage
 
 [flake8]
 max-complexity = 22


### PR DESCRIPTION
Fixes #2567

Remove codecov from `tox`, and use the GitHub Action for uploading coverage for Python tests (and hypothesis too, I don't think they were being uploaded...)