### PR TITLE
MRG: 4.8.1 release

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -57,7 +57,7 @@
 
           sourmash = python.buildPythonPackage rec {
             pname = "sourmash";
-            version = "4.8.0";
+            version = "4.8.1";
             format = "pyproject";
 
             src = ./.;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = 'maturin'
 name = "sourmash"
 description = "tools for comparing biological sequences with k-mer sketches"
 readme = "README.md"
-version = "4.8.1-dev"
+version = "4.8.1"
 
 authors = [
   { name="Luiz Irber", orcid="0000-0003-4371-9659" },


### PR DESCRIPTION
## release checklist

Release candidate testing:
- [x] Command line tests pass for a release candidate
- [x] All eight release candidate wheels are built

Releasing to PyPI:

- [x] RC tag(s)s deleted on github
- [x] Release tag cut
- [x] Release notes written
- [x] All eight release wheels built
- [x] Release wheels uploaded to pypi
- [x] tar.gz distribution uploaded to pypi

After release to PyPI and conda-forge/bioconda packages built:

- [x] [PyPI page](https://pypi.org/project/sourmash/) updated
- [x] Zenodo DOI successfully minted upon new github release - [see search results](https://zenodo.org/search?page=1&size=20&q=sourmash&sort=mostrecent)
- [x] `pip install sourmash` installs the correct version
- [ ] `mamba create -n smash-release -y sourmash` installs the correct version

## release docs

Minor new features:

* add --create-empty-results option to gather (#2557)

Bug fixes:

* fix exception error when no arguments are provided to `sig intersect` (#2555)

Cleanup and documentation updates:

* update `sourmash sketch` docs for building merged sketches (#2563)
* fix broken crates.io badge (#2556)
* add --csv to command-line docs for `compare` (#2565)

Developer updates:

* Remove codecov from tox, use GH action instead (#2568)

Dependabot updates:

* Update pytest requirement from <7.3.0,>=6.2.4 to >=6.2.4,<7.4.0 (#2558)
* Bump tempfile from 3.4.0 to 3.5.0 (#2561)
* Bump serde from 1.0.158 to 1.0.159 (#2560)
* Bump getrandom from 0.2.8 to 0.2.9 (#2559)