### PR TITLE
MRG: bump version number to 4.8.2-dev

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = 'maturin'
 name = "sourmash"
 description = "tools for comparing biological sequences with k-mer sketches"
 readme = "README.md"
-version = "4.8.1"
+version = "4.8.2-dev"
 
 authors = [
   { name="Luiz Irber", orcid="0000-0003-4371-9659" },


### PR DESCRIPTION
This PR bumps the version number in the development branch to v4.8.2-dev. This makes it clear that we are working on unreleased code.

ref https://github.com/sourmash-bio/sourmash/issues/2517