### PR TITLE
[MRG] fix lineage_summary tax bug

### DIFF
--- a/src/sourmash/tax/__main__.py
+++ b/src/sourmash/tax/__main__.py
@@ -104,7 +104,7 @@ def metagenome(args):
         notify('No gather results loaded. Exiting.')
         sys.exit(-1)
 
-    single_query_output_formats =  ['csv_summary', 'kreport', "lineage_summary"]
+    single_query_output_formats =  ['csv_summary', 'kreport']
     desired_single_outputs = []
     if len(query_gather_results) > 1: # working with multiple queries
         desired_single_outputs = [x for x in args.output_format if x in single_query_output_formats]


### PR DESCRIPTION
This fixes a human error bug, where lineage_summary was erroneously included as a single-query output format. Fixes https://github.com/sourmash-bio/sourmash/issues/2578

Looking back, this bug was introduced in #2443, which means it went into v4.7.0.