### PR TITLE
[MRG] add optional reporting for duplicated names in sketch fromfile

### DIFF
--- a/src/sourmash/cli/sketch/fromfile.py
+++ b/src/sourmash/cli/sketch/fromfile.py
@@ -72,8 +72,8 @@ def subparser(subparsers):
         help='output a manifest file of already-existing signatures'
     )
     file_args.add_argument(
-        '--report-errors', action='store_true',
-        help='report missing or duplicated names'
+        '--report-duplicated', action='store_true',
+        help='report duplicated names'
     )
 
 

--- a/src/sourmash/cli/sketch/fromfile.py
+++ b/src/sourmash/cli/sketch/fromfile.py
@@ -71,6 +71,10 @@ def subparser(subparsers):
         '--output-manifest-matching',
         help='output a manifest file of already-existing signatures'
     )
+    file_args.add_argument(
+        '--report-errors', action='store_true',
+        help='report missing or duplicated names'
+    )
 
 
 def main(args):

--- a/src/sourmash/command_sketch.py
+++ b/src/sourmash/command_sketch.py
@@ -424,6 +424,8 @@ def fromfile(args):
     skipped_sigs = 0
     n_missing_name = 0
     n_duplicate_name = 0
+    missing_names = set()
+    duplicate_names=set()
 
     for csvfile in args.csvs:
         with sourmash_args.FileInputCSV(csvfile) as r:
@@ -431,6 +433,7 @@ def fromfile(args):
                 name = row['name']
                 if not name:
                     n_missing_name += 1
+                    missing_names.add(name)
                     continue
 
                 genome = row['genome_filename']
@@ -439,15 +442,20 @@ def fromfile(args):
 
                 if name in all_names:
                     n_duplicate_name += 1
+                    duplicate_names.add(name)
                 else:
                     all_names[name] = (genome, proteome)
 
     fail_exit = False
     if n_duplicate_name:
+        if args.report_errors:
+            notify("duplicated:\n" + '\n'.join(sorted(duplicate_names)))
         error(f"** ERROR: {n_duplicate_name} entries have duplicate 'name' records. Exiting!")
         fail_exit = True
 
     if n_missing_name:
+        if args.report_errors:
+            notify("missing:\n" + '\n'.join(sorted(missing_names)))
         error(f"** ERROR: {n_missing_name} entries have blank 'name's? Exiting!")
         fail_exit = True
 

--- a/src/sourmash/command_sketch.py
+++ b/src/sourmash/command_sketch.py
@@ -446,7 +446,7 @@ def fromfile(args):
 
     fail_exit = False
     if n_duplicate_name:
-        if args.report_errors:
+        if args.report_duplicated:
             notify("duplicated:\n" + '\n'.join(sorted(duplicate_names)))
         error(f"** ERROR: {n_duplicate_name} entries have duplicate 'name' records. Exiting!")
         fail_exit = True

--- a/src/sourmash/command_sketch.py
+++ b/src/sourmash/command_sketch.py
@@ -424,8 +424,7 @@ def fromfile(args):
     skipped_sigs = 0
     n_missing_name = 0
     n_duplicate_name = 0
-    missing_names = set()
-    duplicate_names=set()
+    duplicate_names = set()
 
     for csvfile in args.csvs:
         with sourmash_args.FileInputCSV(csvfile) as r:
@@ -433,7 +432,6 @@ def fromfile(args):
                 name = row['name']
                 if not name:
                     n_missing_name += 1
-                    missing_names.add(name)
                     continue
 
                 genome = row['genome_filename']
@@ -454,8 +452,6 @@ def fromfile(args):
         fail_exit = True
 
     if n_missing_name:
-        if args.report_errors:
-            notify("missing:\n" + '\n'.join(sorted(missing_names)))
         error(f"** ERROR: {n_missing_name} entries have blank 'name's? Exiting!")
         fail_exit = True
 

--- a/tests/test_sourmash_sketch.py
+++ b/tests/test_sourmash_sketch.py
@@ -1808,7 +1808,7 @@ def test_fromfile_dna_and_protein_dup_name_report(runtmp):
         runtmp.sourmash('sketch', 'fromfile',
                         'sketch_fromfile/salmonella.csv',
                         'sketch_fromfile/salmonella.csv',
-                        '--report-errors',
+                        '--report-duplicated',
                         '-o', 'out.zip', '-p', 'dna', '-p', 'protein')
 
     out = runtmp.last_result.out

--- a/tests/test_sourmash_sketch.py
+++ b/tests/test_sourmash_sketch.py
@@ -1799,6 +1799,27 @@ def test_fromfile_dna_and_protein_dup_name(runtmp):
     assert "ERROR: 1 entries have duplicate 'name' records. Exiting!" in err
 
 
+def test_fromfile_dna_and_protein_dup_name_report(runtmp):
+    # duplicate names
+    test_inp = utils.get_test_data('sketch_fromfile')
+    shutil.copytree(test_inp, runtmp.output('sketch_fromfile'))
+
+    with pytest.raises(SourmashCommandFailed):
+        runtmp.sourmash('sketch', 'fromfile',
+                        'sketch_fromfile/salmonella.csv',
+                        'sketch_fromfile/salmonella.csv',
+                        '--report-errors',
+                        '-o', 'out.zip', '-p', 'dna', '-p', 'protein')
+
+    out = runtmp.last_result.out
+    err = runtmp.last_result.err
+
+    print(out)
+    print(err)
+    assert "GCA_903797575 Salmonella enterica" in err
+    assert "ERROR: 1 entries have duplicate 'name' records. Exiting!" in err
+
+
 def test_fromfile_dna_and_protein_missing(runtmp):
     # test what happens when missing protein.
     test_inp = utils.get_test_data('sketch_fromfile')

--- a/tests/test_sourmash_sketch.py
+++ b/tests/test_sourmash_sketch.py
@@ -1796,6 +1796,7 @@ def test_fromfile_dna_and_protein_dup_name(runtmp):
 
     print(out)
     print(err)
+    assert "GCA_903797575 Salmonella enterica" not in err
     assert "ERROR: 1 entries have duplicate 'name' records. Exiting!" in err
 
 


### PR DESCRIPTION
When `sketch fromfile` encounters duplicated names, it exits with an error. This PR introduces an option, `--report-duplicated`, to report those names for faster/easier debugging.

We could instead do this by default, if we want.