### PR TITLE
Update URL for sourmash/fig.py

### DIFF
--- a/doc/plotting-compare.ipynb
+++ b/doc/plotting-compare.ipynb
@@ -215,7 +215,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you want to customize the plots, please see the code for `plot_composite_matrix` in [sourmash/fig.py](https://github.com/dib-lab/sourmash/blob/latest/sourmash/fig.py), which is reproduced below; you can modify the code in place to (for example) [use custom dendrogram colors](https://stackoverflow.com/questions/38153829/custom-cluster-colors-of-scipy-dendrogram-in-python-link-color-func)."
+    "If you want to customize the plots, please see the code for `plot_composite_matrix` in [sourmash/fig.py](https://github.com/sourmash-bio/sourmash/blob/latest/src/sourmash/fig.py), which is reproduced below; you can modify the code in place to (for example) [use custom dendrogram colors](https://stackoverflow.com/questions/38153829/custom-cluster-colors-of-scipy-dendrogram-in-python-link-color-func)."
    ]
   },
   {


### PR DESCRIPTION
Documentation fix for URL in https://sourmash.readthedocs.io/en/latest/plotting-compare.html#Customizing-plots where repository changed, and now has ``src/`` in path.

Note: I have not checked for other URLs still using https://github.com/dib-lab/sourmash/