### PR TITLE
MRG: switch dib-lab links to sourmash-bio links in .md files

### DIFF
--- a/doc/other-languages.md
+++ b/doc/other-languages.md
@@ -32,7 +32,7 @@ sourmash_comp_matrix <- as.matrix(sourmash_comp_matrix)
 
 ```
 
-See the output of plotting and clustering this matrix by downloading and opening [this html](https://raw.githubusercontent.com/dib-lab/sourmash/latest/doc/_static/ecoli-cmp.html), produced by [this RMarkdown file](https://raw.githubusercontent.com/dib-lab/sourmash/latest/doc/_static/ecoli-cmp.Rmd).
+See the output of plotting and clustering this matrix by downloading and opening [this html](https://raw.githubusercontent.com/sourmash-bio/sourmash/latest/doc/_static/ecoli-cmp.html), produced by [this RMarkdown file](https://raw.githubusercontent.com/sourmash-bio/sourmash/latest/doc/_static/ecoli-cmp.Rmd).
 
-You can download the `ecoli.cmp.csv` file itself [here](https://raw.githubusercontent.com/dib-lab/sourmash/latest/doc/_static/ecoli.cmp.csv).
+You can download the `ecoli.cmp.csv` file itself [here](https://raw.githubusercontent.com/sourmash-bio/sourmash/latest/doc/_static/ecoli.cmp.csv).
 

--- a/doc/release-notes/releases.md
+++ b/doc/release-notes/releases.md
@@ -1,7 +1,7 @@
 # sourmash release notes
 
 Please see the
-[github releases page](https://github.com/dib-lab/sourmash/releases)
+[github releases page](https://github.com/sourmash-bio/sourmash/releases)
 for detailed release notes for each version!
 
 ```{toctree}

--- a/doc/release-notes/sourmash-2.0.md
+++ b/doc/release-notes/sourmash-2.0.md
@@ -12,7 +12,7 @@ released version is at http://sourmash.readthedocs.io/en/stable/.
 Python API, command-line, and signature file formats have all changed
 substantially.** Please post questions about migrating to sourmash 2.0
 in the
-[sourmash issue tracker](https://github.com/dib-lab/sourmash/issues/new).
+[sourmash issue tracker](https://github.com/sourmash-bio/sourmash/issues/new).
 
 ## Major new features since 1.0
 

--- a/doc/release-notes/sourmash-3.0.md
+++ b/doc/release-notes/sourmash-3.0.md
@@ -10,25 +10,25 @@ released version is at http://sourmash.readthedocs.io/en/stable/.
 Python API, command-line, signature and databases file formats are all the same.** We are releasing 3.0 to indicate the build system and internal implementation changed.
 
 Please post questions about migrating to sourmash 3.0
-in the [sourmash issue tracker](https://github.com/dib-lab/sourmash/issues/new).
+in the [sourmash issue tracker](https://github.com/sourmash-bio/sourmash/issues/new).
 
 ## Highlighted changes since 2.0
 
-This is a list of substantial new features and functionality since sourmash 2.0. For more details check the [releases page on GitHub](https://github.com/dib-lab/sourmash/releases).
+This is a list of substantial new features and functionality since sourmash 2.0. For more details check the [releases page on GitHub](https://github.com/sourmash-bio/sourmash/releases).
 
 Features:
 
-- Replacing C++ with Rust ([#424](https://github.com/dib-lab/sourmash/pull/424))
-- Create an `Index` abstract base class ([#556](https://github.com/dib-lab/sourmash/pull/556))
-- Dayhoff and HP encoding for proteins ([#689](https://github.com/dib-lab/sourmash/pull/689)) ([#758](https://github.com/dib-lab/sourmash/pull/758))
-- Add `sourmash signature filter` to do abundance filtering. ([#748](https://github.com/dib-lab/sourmash/pull/748))
-- Parallelized compare function with multiprocessing ([#709](https://github.com/dib-lab/sourmash/pull/709))
-- add compute signatures for 10x bam file ([#713](https://github.com/dib-lab/sourmash/pull/713))
+- Replacing C++ with Rust ([#424](https://github.com/sourmash-bio/sourmash/pull/424))
+- Create an `Index` abstract base class ([#556](https://github.com/sourmash-bio/sourmash/pull/556))
+- Dayhoff and HP encoding for proteins ([#689](https://github.com/sourmash-bio/sourmash/pull/689)) ([#758](https://github.com/sourmash-bio/sourmash/pull/758))
+- Add `sourmash signature filter` to do abundance filtering. ([#748](https://github.com/sourmash-bio/sourmash/pull/748))
+- Parallelized compare function with multiprocessing ([#709](https://github.com/sourmash-bio/sourmash/pull/709))
+- add compute signatures for 10x bam file ([#713](https://github.com/sourmash-bio/sourmash/pull/713))
 
 Improvements:
 
-- improve error handling in `sourmash lca index`. ([#798](https://github.com/dib-lab/sourmash/pull/798))
-- Include more base deps: numpy, scipy and matplotlib ([#770](https://github.com/dib-lab/sourmash/pull/770))
-- use `bam2fasta` package to simplify `sourmash compute` ([#768](https://github.com/dib-lab/sourmash/pull/768))
-- add a `--abundances-from` flag to sourmash signature intersect, to preserve abundances ([#747](https://github.com/dib-lab/sourmash/pull/747))
-- Compare outputs can be saved to an output dir ([#715](https://github.com/dib-lab/sourmash/pull/715))
+- improve error handling in `sourmash lca index`. ([#798](https://github.com/sourmash-bio/sourmash/pull/798))
+- Include more base deps: numpy, scipy and matplotlib ([#770](https://github.com/sourmash-bio/sourmash/pull/770))
+- use `bam2fasta` package to simplify `sourmash compute` ([#768](https://github.com/sourmash-bio/sourmash/pull/768))
+- add a `--abundances-from` flag to sourmash signature intersect, to preserve abundances ([#747](https://github.com/sourmash-bio/sourmash/pull/747))
+- Compare outputs can be saved to an output dir ([#715](https://github.com/sourmash-bio/sourmash/pull/715))

--- a/doc/release-notes/sourmash-4.0.md
+++ b/doc/release-notes/sourmash-4.0.md
@@ -12,7 +12,7 @@ Please see
 [our migration guide](../support.md#migrating-from-sourmash-v3x-to-sourmash-v4x)
 for guidance on updating to sourmash v4, and post questions about
 migrating to sourmash 4.0 in the
-[sourmash issue tracker](https://github.com/dib-lab/sourmash/issues/new).
+[sourmash issue tracker](https://github.com/sourmash-bio/sourmash/issues/new).
 
 ## Major changes for 4.0
 
@@ -23,7 +23,7 @@ release; you should get the same results with v4 as you get with v3,
 except where command-line parameters need to be adjusted as noted
 below (see: protein ksize #1277, lca summarize changes #1175, sourmash
 gather on signatures without abundance #1328). Please
-[file an issue](https://github.com/dib-lab/sourmash/issues) if your
+[file an issue](https://github.com/sourmash-bio/sourmash/issues) if your
 results change!
 
 ### New or changed behavior

--- a/doc/tutorial-long.md
+++ b/doc/tutorial-long.md
@@ -82,7 +82,7 @@ About two years ago, [Ondov et al. (2016)](https://genomebiology.biomedcentral.c
 
 The basic idea behind MinHash is that you pick a small subset of k-mers to look at, and you use those as a proxy for *all* the k-mers.  The trick is that you pick the k-mers randomly but consistently: so if a chosen k-mer is present in two data sets of interest, it will be picked in both. This is done using a clever trick that we can try to explain to you in class - but either way, trust us, it works!
 
-We have implemented a MinHash approach in our [sourmash software](https://github.com/dib-lab/sourmash/), which can do some nice things with samples.  We'll show you some of these things next!
+We have implemented a MinHash approach in our [sourmash software](https://github.com/sourmash-bio/sourmash/), which can do some nice things with samples.  We'll show you some of these things next!
 
 ## Installing sourmash
 
@@ -357,7 +357,7 @@ Let's grab a sample collection of 50 E. coli genomes and unpack it --
 mkdir ecoli_many_sigs
 cd ecoli_many_sigs
 
-curl -O -L https://github.com/dib-lab/sourmash/raw/master/data/eschericia-sigs.tar.gz
+curl -O -L https://github.com/sourmash-bio/sourmash/raw/master/data/eschericia-sigs.tar.gz
 
 tar xzf eschericia-sigs.tar.gz
 rm eschericia-sigs.tar.gz
@@ -472,7 +472,7 @@ from the
 [Shakya et al. 2013 mock metagenome paper](https://www.ncbi.nlm.nih.gov/pubmed/23387867).
 
 ```
-wget https://github.com/dib-lab/sourmash/raw/master/doc/_static/shakya-unaligned-contigs.sig
+wget https://github.com/sourmash-bio/sourmash/raw/master/doc/_static/shakya-unaligned-contigs.sig
 sourmash lca gather shakya-unaligned-contigs.sig genbank-k31.lca.json
 ```
 

--- a/tests/test_minhash.py
+++ b/tests/test_minhash.py
@@ -1,4 +1,4 @@
-# This file is part of sourmash, https://github.com/dib-lab/sourmash/, and is
+# This file is part of sourmash, https://github.com/sourmash-bio/sourmash/, and is
 # Copyright (C) 2016, The Regents of the University of California.
 #
 # Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
Builds off of https://github.com/sourmash-bio/sourmash/pull/2586 to fix links that were going to `github.com/dib-lab/sourmash` and change them to `github.com/sourmash-bio/sourmash`.