### PR TITLE
maturin: move deprecated definition from Cargo.toml to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,6 +146,7 @@ exclude = [
 ]
 features = ["maturin"]
 locked = true
+module-name = "sourmash._lowlevel"
 
 [tool.isort]
 known_third_party = ["deprecation", "hypothesis", "mmh3", "numpy", "pytest", "screed", "sourmash_tst_utils"]

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -95,6 +95,3 @@ wasm-bindgen-test = "0.3.34"
 
 ### These crates don't compile on wasm
 [target.'cfg(not(all(target_arch = "wasm32", target_os="unknown")))'.dependencies]
-
-[package.metadata.maturin]
-name = "sourmash._lowlevel"


### PR DESCRIPTION
Fix #2552 