### PR TITLE
EXP: work with RankLineageInfo and sourmash tax

### DIFF
--- a/doc/taxonomic-lineages-examples.md
+++ b/doc/taxonomic-lineages-examples.md
@@ -201,6 +201,9 @@ The taxonomy ranks themselves can be displayed with `taxlist` and
 
 ~~~
 
+An empty lineage, representing a "root" lineage only, can be created
+with an empty `lineage_str` like so:
+
 ~~~
 >>> obj = RankLineageInfo(lineage_str='')
 >>> type(obj)

--- a/doc/taxonomic-lineages-examples.md
+++ b/doc/taxonomic-lineages-examples.md
@@ -1,0 +1,133 @@
+# Using sourmash's built-in taxonomy handling from Python
+
+sourmash works with taxonomies by connecting **identifiers** (typically
+Genbank accessions or private identifiers) to **lineages** in lineage
+databases.
+
+Lineage databases can be loaded from CSV files or SQL databases; see
+`sourmash tax prepare` to convert between the two.
+
+For example,
+
+~~~
+>>> import pprint
+>>> from sourmash.tax.tax_utils import MultiLineageDB, RankLineageInfo, LineagePair
+
+>>> taxdb = MultiLineageDB.load(['doc/taxtax.csv'])
+>>> print(f"Loaded {len(taxdb)} taxonomic identifiers.")
+Loaded 3 taxonomic identifiers.
+
+~~~
+
+Accessions or identifiers are keys in the database:
+
+~~~
+>>> accession = 'GCF_014075335.1'
+>>> accession in taxdb
+True
+
+~~~
+
+Lineage database values are **tuples of `LineagePairs`**, or lineages -
+
+~~~
+>>> lineage = taxdb[accession]
+>>> for linpair in lineage:
+...    print(linpair.rank, linpair.name)
+superkingdom d__Bacteria
+phylum p__Proteobacteria
+class c__Gammaproteobacteria
+order o__Enterobacterales
+family f__Enterobacteriaceae
+genus g__Escherichia
+species s__Escherichia coli
+
+~~~
+
+@CTB: why does `taxdb[accession]` not return a `RankLineageInfo` object?
+
+These lineages can be displayed, queried, and manipulated in a variety
+of convenient ways by using `RankLineageInfo`:
+
+~~~
+>>> lineage = RankLineageInfo(lineage=lineage)
+>>> lineage.display_lineage()
+'d__Bacteria;p__Proteobacteria;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Escherichia;s__Escherichia coli'
+>>> lineage.rank_is_filled('species')
+True
+>>> lineage.rank_is_filled('strain')
+False
+>>> lin2 = lineage.pop_to_rank('class')
+>>> lin2.display_lineage()
+'d__Bacteria;p__Proteobacteria;c__Gammaproteobacteria'
+
+~~~
+
+If you have multiple accessions, you can also find the lowest common
+ancestor of their lineages; this functionality is used extensively in
+both the `lca` and `tax` submodules of sourmash.
+
+First, load the lineages:
+~~~
+>>> acclist = ['GCF_014075335.1', 'GCF_900013275.1', 'GCF_900698905.1']
+>>> lineages = [ taxdb[acc] for acc in acclist ]
+>>> lineages = [ RankLineageInfo(lineage=lin) for lin in lineages]
+>>> for lin in lineages:
+...    print(lin.display_lineage())
+d__Bacteria;p__Proteobacteria;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Escherichia;s__Escherichia coli
+d__Bacteria;p__Proteobacteria;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Escherichia;s__Escherichia coli
+d__Bacteria;p__Proteobacteria;c__Gammaproteobacteria;o__Enterobacterales_A;f__Enterobacteriaceae_A;g__Buchnera;s__Buchnera aphidicola_W
+
+~~~
+
+Then, calculate the LCA. Here, the LCA is just another `RankLineageInfo`
+object that we update each time. Note that the LCA here is at class
+`c__Gammaproteobacteria`, the lowest rank shared by all three lineages
+(above `o__Enterobacterales` and `o__Enterobacterales_A`).
+
+~~~
+>>> lca = lineages.pop()
+>>> while lineages:
+...    lin = lineages.pop()
+...    lca = lca.find_lca(lin)
+>>> lca.display_lineage()
+'d__Bacteria;p__Proteobacteria;c__Gammaproteobacteria'
+
+~~~
+
+## Creating/initializing "traditional" lineages with `RankLineageInfo`
+
+NCBI and GTDB taxonomies both use the seven ranks - superkingdom
+(or domain), phylum, class, order, family, genus, and species - along
+with an (optional) strain. Lineages from both taxonomies can be
+loaded into and manipulated using `RankLineageInfo`.
+
+You can load from a lineage string with semicolon separators,
+
+~~~
+>>> lin1 = RankLineageInfo(lineage_str='d__Bacteria;p__Proteobacteria;c__Gammaproteobacteria')
+>>> lin1
+d__Bacteria;p__Proteobacteria;c__Gammaproteobacteria
+
+~~~
+
+or build your own `LineagePair` tuples and supply them via `lineage`:
+~~~
+>>> lintup = (LineagePair(rank='superkingdom', name='d__Bacteria'),
+...           LineagePair(rank='phylum', name='p__Proteobacteria'),
+...           LineagePair(rank='class', name='c__Gammaproteobacteria'))
+>>> lin2 = RankLineageInfo(lineage=lintup)
+>>> lin2
+d__Bacteria;p__Proteobacteria;c__Gammaproteobacteria
+
+~~~
+
+And lineages initialized either way are equivalent:
+
+~~~
+>>> lin1 == lin2
+True
+
+~~~
+
+## foo

--- a/doc/taxonomic-lineages-examples.md
+++ b/doc/taxonomic-lineages-examples.md
@@ -1,7 +1,5 @@
 # Using sourmash's built-in taxonomy handling from Python
 
-@CTB zip_lineage
-
 sourmash works with taxonomies by connecting **identifiers** (typically
 Genbank accessions or private identifiers) to **lineages** in lineage
 databases.
@@ -45,13 +43,13 @@ species s__Escherichia coli
 
 ~~~
 
-@CTB: why does `taxdb[accession]` not return a `RankLineageInfo` object?
-
 These lineages can be displayed, queried, and manipulated in a variety
 of convenient ways by using `RankLineageInfo`:
 
 ~~~
 >>> lineage = RankLineageInfo(lineage=lineage)
+>>> lineage
+RankLineageInfo(lineage_str='d__Bacteria;p__Proteobacteria;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Escherichia;s__Escherichia coli')
 
 ~~~
 
@@ -98,8 +96,6 @@ and you can get get the lineage tuple at a specific rank with
 
 ~~~
 
-@CTB what's the difference in use case for `lineage_at_rank` and `pop_to_rank`? How does this differ from pop_to_rank? It appears that it just gives you the tuple of LineagePairs rather htan giving you a new RankLineageInfo object.
-
 ## Calculating the lowest common ancestor of two or more lineages.
 
 If you have multiple accessions, you can also find the lowest common
@@ -142,8 +138,9 @@ lowest rank in a lineage with `lowest_rank`,
 
 ~~~
 
-You can check if a rank is missing with `check_rank_availability`,
-and check if it's filled with `rank_is_filled`:
+You can check if a rank is available in the taxonomy with
+`check_rank_availability`, and check if that rank is filled with
+`rank_is_filled`:
 
 ~~~
 >>> lca.check_rank_availability('class')
@@ -157,9 +154,6 @@ False
 
 ~~~
 
-@CTB why is check_rank_availability True for family?
-
-
 ## Creating/initializing "traditional" lineages with `RankLineageInfo`
 
 NCBI and GTDB taxonomies both use the seven ranks - superkingdom
@@ -172,7 +166,7 @@ You can load from a lineage string with semicolon separators,
 ~~~
 >>> lin1 = RankLineageInfo(lineage_str='d__Bacteria;p__Proteobacteria;c__Gammaproteobacteria')
 >>> lin1
-RankLineageInfo('d__Bacteria;p__Proteobacteria;c__Gammaproteobacteria')
+RankLineageInfo(lineage_str='d__Bacteria;p__Proteobacteria;c__Gammaproteobacteria')
 
 ~~~
 
@@ -183,7 +177,7 @@ or build your own `LineagePair` tuples and supply them via `lineage`:
 ...           LineagePair(rank='class', name='c__Gammaproteobacteria'))
 >>> lin2 = RankLineageInfo(lineage=lintup)
 >>> lin2
-RankLineageInfo('d__Bacteria;p__Proteobacteria;c__Gammaproteobacteria')
+RankLineageInfo(lineage_str='d__Bacteria;p__Proteobacteria;c__Gammaproteobacteria')
 
 ~~~
 
@@ -207,14 +201,44 @@ The taxonomy ranks themselves can be displayed with `taxlist` and
 
 ~~~
 
-@CTB NCBI taxids, zip_taxid, display_taxid
-@CTB is_compatible, is_lineage_match, 
-
 ~~~
 >>> obj = RankLineageInfo(lineage_str='')
 >>> type(obj)
 <class 'sourmash.tax.tax_utils.RankLineageInfo'>
 >>> obj
-RankLineageInfo('')
+RankLineageInfo(lineage_str='')
 
 ~~~
+
+## To discuss with Tessa:
+
+1. Why does `taxdb[accession]` not return a `RankLineageInfo` object?
+(And/or should it?)
+
+2. what's the difference in use case for `lineage_at_rank` and `pop_to_rank`? How does this differ from pop_to_rank? It appears that it just gives you the tuple of LineagePairs rather than giving you a new RankLineageInfo object.
+
+~~~
+>>> lineage = RankLineageInfo(lineage_str='d__Bacteria;p__Proteobacteria;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Escherichia;s__Escherichia coli')
+>>> lineage.pop_to_rank('class')
+RankLineageInfo(lineage_str='d__Bacteria;p__Proteobacteria;c__Gammaproteobacteria')
+>>> lineage.lineage_at_rank('class')
+(LineagePair(rank='superkingdom', name='d__Bacteria'), LineagePair(rank='phylum', name='p__Proteobacteria'), LineagePair(rank='class', name='c__Gammaproteobacteria'))
+
+~~~
+
+`pop_to_rank` is used twice in the code base, `lineage_at_rank` is
+used once.  Suggest picking one, or making a new method and using
+that - maybe `lineage_to_rank`, which returns a RankLineageInfo
+object?
+
+3. suggest changing `check_rank_availability`
+
+`check_rank_availability` is all about raising an exception, it seems -
+no caller checks its return value. Is it OK to remove the return value?
+
+## TODO items @CTB:
+
+- [ ] discuss/describe NCBI taxids, zip_taxid, display_taxid
+- [ ] describe zip_lineage
+- [ ] document/test is_compatible, is_lineage_match
+

--- a/doc/taxonomic-lineages-examples.md
+++ b/doc/taxonomic-lineages-examples.md
@@ -71,10 +71,10 @@ False
 
 ~~~
 
-Remove ranks below a particular rank with `pop_to_rank`:
+Remove ranks below a particular rank with `lineage_to_rank`:
 
 ~~~
->>> lin2 = lineage.pop_to_rank('class')
+>>> lin2 = lineage.lineage_to_rank('class')
 >>> lin2.display_lineage()
 'd__Bacteria;p__Proteobacteria;c__Gammaproteobacteria'
 
@@ -84,15 +84,6 @@ If you want to get the name at a given rank, use `name_at_rank`:
 ~~~
 >>> lin2.name_at_rank('phylum')
 'p__Proteobacteria'
-
-~~~
-
-and you can get get the lineage tuple at a specific rank with
-`lineage_at_rank`:
-
-~~~
->>> lin2.lineage_at_rank('phylum')
-(LineagePair(rank='superkingdom', name='d__Bacteria'), LineagePair(rank='phylum', name='p__Proteobacteria'))
 
 ~~~
 
@@ -138,15 +129,10 @@ lowest rank in a lineage with `lowest_rank`,
 
 ~~~
 
-You can check if a rank is available in the taxonomy with
-`check_rank_availability`, and check if that rank is filled with
+You can check if a rank is filled with
 `rank_is_filled`:
 
 ~~~
->>> lca.check_rank_availability('class')
-True
->>> lca.check_rank_availability('family')
-True
 >>> lca.rank_is_filled('class')
 True
 >>> lca.rank_is_filled('family')
@@ -218,30 +204,11 @@ RankLineageInfo(lineage_str='')
 1. Why does `taxdb[accession]` not return a `RankLineageInfo` object?
 (And/or should it?)
 
-2. what's the difference in use case for `lineage_at_rank` and `pop_to_rank`? How does this differ from pop_to_rank? It appears that it just gives you the tuple of LineagePairs rather than giving you a new RankLineageInfo object.
-
 ~~~
->>> lineage = RankLineageInfo(lineage_str='d__Bacteria;p__Proteobacteria;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Escherichia;s__Escherichia coli')
->>> lineage.pop_to_rank('class')
-RankLineageInfo(lineage_str='d__Bacteria;p__Proteobacteria;c__Gammaproteobacteria')
->>> lineage.lineage_at_rank('class')
-(LineagePair(rank='superkingdom', name='d__Bacteria'), LineagePair(rank='phylum', name='p__Proteobacteria'), LineagePair(rank='class', name='c__Gammaproteobacteria'))
-
-~~~
-
-`pop_to_rank` is used twice in the code base, `lineage_at_rank` is
-used once.  Suggest picking one, or making a new method and using
-that - maybe `lineage_to_rank`, which returns a RankLineageInfo
-object?
-
-3. suggest changing `check_rank_availability`
-
-`check_rank_availability` is all about raising an exception, it seems -
-no caller checks its return value. Is it OK to remove the return value?
 
 ## TODO items @CTB:
 
 - [ ] discuss/describe NCBI taxids, zip_taxid, display_taxid
 - [ ] describe zip_lineage
 - [ ] document/test is_compatible, is_lineage_match
-
+- [ ] add stuff about different tax, `check_rank_availability`

--- a/doc/taxonomic-lineages-examples.md
+++ b/doc/taxonomic-lineages-examples.md
@@ -172,7 +172,7 @@ You can load from a lineage string with semicolon separators,
 ~~~
 >>> lin1 = RankLineageInfo(lineage_str='d__Bacteria;p__Proteobacteria;c__Gammaproteobacteria')
 >>> lin1
-d__Bacteria;p__Proteobacteria;c__Gammaproteobacteria
+RankLineageInfo('d__Bacteria;p__Proteobacteria;c__Gammaproteobacteria')
 
 ~~~
 
@@ -183,7 +183,7 @@ or build your own `LineagePair` tuples and supply them via `lineage`:
 ...           LineagePair(rank='class', name='c__Gammaproteobacteria'))
 >>> lin2 = RankLineageInfo(lineage=lintup)
 >>> lin2
-d__Bacteria;p__Proteobacteria;c__Gammaproteobacteria
+RankLineageInfo('d__Bacteria;p__Proteobacteria;c__Gammaproteobacteria')
 
 ~~~
 
@@ -215,6 +215,6 @@ The taxonomy ranks themselves can be displayed with `taxlist` and
 >>> type(obj)
 <class 'sourmash.tax.tax_utils.RankLineageInfo'>
 >>> obj
-<BLANKLINE>
+RankLineageInfo('')
 
 ~~~

--- a/doc/taxonomic-lineages-examples.md
+++ b/doc/taxonomic-lineages-examples.md
@@ -82,13 +82,23 @@ Remove ranks below a particular rank with `pop_to_rank`:
 
 ~~~
 
-Get the lineage tuple at a specific rank with `lineage_at_rank`:
+If you want to get the name at a given rank, use `name_at_rank`:
+~~~
+>>> lin2.name_at_rank('phylum')
+'p__Proteobacteria'
 
 ~~~
->> lin2.lineage_at_rank('class')
-c__Gammaproteobacteria
+
+and you can get get the lineage tuple at a specific rank with
+`lineage_at_rank`:
 
 ~~~
+>>> lin2.lineage_at_rank('phylum')
+(LineagePair(rank='superkingdom', name='d__Bacteria'), LineagePair(rank='phylum', name='p__Proteobacteria'))
+
+~~~
+
+@CTB what's the difference in use case for `lineage_at_rank` and `pop_to_rank`? How does this differ from pop_to_rank? It appears that it just gives you the tuple of LineagePairs rather htan giving you a new RankLineageInfo object.
 
 ## Calculating the lowest common ancestor of two or more lineages.
 
@@ -124,12 +134,30 @@ object that we update each time. Note that the LCA here is at class
 
 ~~~
 
-Lineages can contain some or all of the ranks - you can use
+Lineages can contain some or all of the ranks - you can get the
+lowest rank in a lineage with `lowest_rank`,
+~~~
+>>> lca.lowest_rank
+'class'
 
-name_at_rank
-rank_index
-filled_lineage
-lowest_lineage_name
+~~~
+
+You can check if a rank is missing with `check_rank_availability`,
+and check if it's filled with `rank_is_filled`:
+
+~~~
+>>> lca.check_rank_availability('class')
+True
+>>> lca.check_rank_availability('family')
+True
+>>> lca.rank_is_filled('class')
+True
+>>> lca.rank_is_filled('family')
+False
+
+~~~
+
+@CTB why is check_rank_availability True for family?
 
 
 ## Creating/initializing "traditional" lineages with `RankLineageInfo`
@@ -159,7 +187,7 @@ d__Bacteria;p__Proteobacteria;c__Gammaproteobacteria
 
 ~~~
 
-And lineages initialized either way are equivalent:
+Of course, lineages initialized either way are equivalent:
 
 ~~~
 >>> lin1 == lin2
@@ -179,5 +207,5 @@ The taxonomy ranks themselves can be displayed with `taxlist` and
 
 ~~~
 
-@CTB NCBI taxids, zip_taxid, display_taxid, check_rank_availability, 
+@CTB NCBI taxids, zip_taxid, display_taxid
 @CTB is_compatible, is_lineage_match, 

--- a/doc/taxonomic-lineages-examples.md
+++ b/doc/taxonomic-lineages-examples.md
@@ -209,3 +209,12 @@ The taxonomy ranks themselves can be displayed with `taxlist` and
 
 @CTB NCBI taxids, zip_taxid, display_taxid
 @CTB is_compatible, is_lineage_match, 
+
+~~~
+>>> obj = RankLineageInfo(lineage_str='')
+>>> type(obj)
+<class 'sourmash.tax.tax_utils.RankLineageInfo'>
+>>> obj
+<BLANKLINE>
+
+~~~

--- a/doc/taxonomic-lineages-examples.md
+++ b/doc/taxonomic-lineages-examples.md
@@ -1,5 +1,7 @@
 # Using sourmash's built-in taxonomy handling from Python
 
+@CTB zip_lineage
+
 sourmash works with taxonomies by connecting **identifiers** (typically
 Genbank accessions or private identifiers) to **lineages** in lineage
 databases.
@@ -10,7 +12,6 @@ Lineage databases can be loaded from CSV files or SQL databases; see
 For example,
 
 ~~~
->>> import pprint
 >>> from sourmash.tax.tax_utils import MultiLineageDB, RankLineageInfo, LineagePair
 
 >>> taxdb = MultiLineageDB.load(['doc/taxtax.csv'])
@@ -51,17 +52,45 @@ of convenient ways by using `RankLineageInfo`:
 
 ~~~
 >>> lineage = RankLineageInfo(lineage=lineage)
+
+~~~
+
+Format the lineage for display with `display_lineage`:
+
+~~~
 >>> lineage.display_lineage()
 'd__Bacteria;p__Proteobacteria;c__Gammaproteobacteria;o__Enterobacterales;f__Enterobacteriaceae;g__Escherichia;s__Escherichia coli'
+
+~~~
+
+Confirm the presence (or absence) of specific ranks:
+
+~~~
 >>> lineage.rank_is_filled('species')
 True
 >>> lineage.rank_is_filled('strain')
 False
+
+~~~
+
+Remove ranks below a particular rank with `pop_to_rank`:
+
+~~~
 >>> lin2 = lineage.pop_to_rank('class')
 >>> lin2.display_lineage()
 'd__Bacteria;p__Proteobacteria;c__Gammaproteobacteria'
 
 ~~~
+
+Get the lineage tuple at a specific rank with `lineage_at_rank`:
+
+~~~
+>> lin2.lineage_at_rank('class')
+c__Gammaproteobacteria
+
+~~~
+
+## Calculating the lowest common ancestor of two or more lineages.
 
 If you have multiple accessions, you can also find the lowest common
 ancestor of their lineages; this functionality is used extensively in
@@ -94,6 +123,14 @@ object that we update each time. Note that the LCA here is at class
 'd__Bacteria;p__Proteobacteria;c__Gammaproteobacteria'
 
 ~~~
+
+Lineages can contain some or all of the ranks - you can use
+
+name_at_rank
+rank_index
+filled_lineage
+lowest_lineage_name
+
 
 ## Creating/initializing "traditional" lineages with `RankLineageInfo`
 
@@ -130,4 +167,17 @@ True
 
 ~~~
 
-## foo
+The taxonomy ranks themselves can be displayed with `taxlist` and
+`ascending_taxlist` -
+
+~~~
+>>> lin1.taxlist
+('superkingdom', 'phylum', 'class', 'order', 'family', 'genus', 'species', 'strain')
+
+>>> lin1.ascending_taxlist
+('strain', 'species', 'genus', 'family', 'order', 'class', 'phylum', 'superkingdom')
+
+~~~
+
+@CTB NCBI taxids, zip_taxid, display_taxid, check_rank_availability, 
+@CTB is_compatible, is_lineage_match, 

--- a/doc/taxtax.csv
+++ b/doc/taxtax.csv
@@ -1,0 +1,4 @@
+ident,superkingdom,phylum,class,order,family,genus,species
+GCF_900013275.1,d__Bacteria,p__Proteobacteria,c__Gammaproteobacteria,o__Enterobacterales,f__Enterobacteriaceae,g__Escherichia,s__Escherichia coli
+GCF_014075335.1,d__Bacteria,p__Proteobacteria,c__Gammaproteobacteria,o__Enterobacterales,f__Enterobacteriaceae,g__Escherichia,s__Escherichia coli
+GCF_900698905.1,d__Bacteria,p__Proteobacteria,c__Gammaproteobacteria,o__Enterobacterales_A,f__Enterobacteriaceae_A,g__Buchnera,s__Buchnera aphidicola_W

--- a/src/sourmash/tax/tax_utils.py
+++ b/src/sourmash/tax/tax_utils.py
@@ -88,7 +88,7 @@ class BaseLineageInfo:
         return self.lineage_str
 
     def __repr__(self):
-        return f"BaseLineageInfo('{self.lineage_str}')"
+        return f"BaseLineageInfo(lineage_str='{self.lineage_str}')"
 
     @property
     def taxlist(self):
@@ -389,7 +389,7 @@ class RankLineageInfo(BaseLineageInfo):
         return self.lineage_str
 
     def __repr__(self):
-        return f"RankLineageInfo('{self.lineage_str}')"
+        return f"RankLineageInfo(lineage_str='{self.lineage_str}')"
         
 require_kwargs_on_init(RankLineageInfo)
 
@@ -523,7 +523,7 @@ class LINLineageInfo(BaseLineageInfo):
         return self.lineage_str
 
     def __repr__(self):
-        return f"LINLineageInfo('{self.lineage_str}')"
+        return f"LINLineageInfo(lineage_str='{self.lineage_str}')"
         
 require_kwargs_on_init(LINLineageInfo)
 

--- a/src/sourmash/tax/tax_utils.py
+++ b/src/sourmash/tax/tax_utils.py
@@ -88,7 +88,7 @@ class BaseLineageInfo:
         return self.lineage_str
 
     def __repr__(self):
-        return self.lineage_str
+        return f"BaseLineageInfo('{self.lineage_str}')"
 
     @property
     def taxlist(self):
@@ -389,7 +389,7 @@ class RankLineageInfo(BaseLineageInfo):
         return self.lineage_str
 
     def __repr__(self):
-        return self.lineage_str
+        return f"RankLineageInfo('{self.lineage_str}')"
         
 require_kwargs_on_init(RankLineageInfo)
 
@@ -523,7 +523,7 @@ class LINLineageInfo(BaseLineageInfo):
         return self.lineage_str
 
     def __repr__(self):
-        return self.lineage_str
+        return f"LINLineageInfo('{self.lineage_str}')"
         
 require_kwargs_on_init(LINLineageInfo)
 

--- a/src/sourmash/utils.py
+++ b/src/sourmash/utils.py
@@ -76,3 +76,79 @@ def rustcall(func, *args):
     if backtrace:
         exc.rust_info = backtrace
     raise exc
+
+###
+### data class utils - from https://gist.github.com/mikeholler/4be180627d3f8fceb55704b729464adb
+###
+
+
+from dataclasses import is_dataclass
+from typing import TypeVar, Type, Callable, List, Dict, Any
+
+_T = TypeVar("_T")
+_Self = TypeVar("_Self")
+_VarArgs = List[Any]
+_KWArgs = Dict[str, Any]
+
+
+def _kwarg_only_init_wrapper(
+        self: _Self,
+        init: Callable[..., None],
+        *args: _VarArgs,
+        **kwargs: _KWArgs
+) -> None:
+    if len(args) > 0:
+        raise TypeError(
+            f"{type(self).__name__}.__init__(self, ...) only allows keyword arguments. Found the "
+            f"following positional arguments: {args}"
+        )
+    init(self, **kwargs)
+
+
+def _positional_arg_only_init_wrapper(
+        self: _Self,
+        init: Callable[..., None],
+        *args: _VarArgs,
+        **kwargs: _KWArgs
+) -> None:
+    if len(kwargs) > 0:
+        raise TypeError(
+            f"{type(self).__name__}.__init__(self, ...) only allows positional arguments. Found "
+            f"the following keyword arguments: {kwargs}"
+        )
+    init(self, *args)
+
+
+def require_kwargs_on_init(cls: Type[_T]) -> Type[_T]:
+    """
+    Force a dataclass's init function to only work if called with keyword arguments.
+    If parameters are not positional-only, a TypeError is thrown with a helpful message.
+    This function may only be used on dataclasses.
+    This works by wrapping the __init__ function and dynamically replacing it. Therefore,
+    stacktraces for calls to the new __init__ might look a bit strange. Fear not though,
+    all is well.
+    Note: although this may be used as a decorator, this is not advised as IDEs will no longer
+    suggest parameters in the constructor. Instead, this is the recommended usage::
+        from dataclasses import dataclass
+        @dataclass
+        class Foo:
+            bar: str
+        require_kwargs_on_init(Foo)
+    """
+    if cls is None:
+        raise TypeError("Cannot call with cls=None")
+    if not is_dataclass(cls):
+        raise TypeError(
+            f"This decorator only works on dataclasses. {cls.__name__} is not a dataclass."
+        )
+
+    original_init = cls.__init__
+
+    def new_init(self: _Self, *args: _VarArgs, **kwargs: _KWArgs) -> None:
+        _kwarg_only_init_wrapper(self, original_init, *args, **kwargs)
+
+    # noinspection PyTypeHints
+    cls.__init__ = new_init  # type: ignore
+
+    return cls
+

--- a/tests/test_tax_utils.py
+++ b/tests/test_tax_utils.py
@@ -1232,6 +1232,7 @@ def test_BaseLineageInfo_init_lineage_tups():
     print(taxinf.lineage)
     print(taxinf.lineage_str)
     assert taxinf.zip_lineage()== ['a', '', 'b']
+    assert taxinf.lineage_str == 'a;;b'
 
 
 def test_BaseLineageInfo_init_lca_lineage_tups():
@@ -1274,6 +1275,39 @@ def test_BaseLineageInfo_init_not_lineagepair():
         BaseLineageInfo(lineage=lin_tups, ranks=ranks)
     print(str(exc))
     assert "is not tax_utils LineagePair" in str(exc)
+
+
+def test_BaseLineageInfo_init_not_lineagepair_no_kw():
+    # test what happens when no keyword argument is used to construct
+    # BaseLineageInfo - should be TypeError
+    ranks=["A", "B", "C"]
+    lin_tups = (("rank1", "name1"),)
+    with pytest.raises(TypeError) as exc:
+        BaseLineageInfo(lin_tups)
+    print(str(exc))
+    assert "only allows keyword arguments" in str(exc)
+
+
+def test_RankLineageInfo_init_not_lineagepair_no_kw():
+    # test what happens when no keyword argument is used to construct
+    # RankLineageInfo - should be TypeError
+    ranks=["A", "B", "C"]
+    lin_tups = (("rank1", "name1"),)
+    with pytest.raises(TypeError) as exc:
+        RankLineageInfo(lin_tups)
+    print(str(exc))
+    assert "only allows keyword arguments" in str(exc)
+
+
+def test_LINLineageInfo_init_not_lineagepair_no_kw():
+    # test what happens when no keyword argument is used to construct
+    # LINLineageInfo - should be TypeError
+    ranks=["A", "B", "C"]
+    lin_tups = (("rank1", "name1"),)
+    with pytest.raises(TypeError) as exc:
+        LINLineageInfo(lin_tups)
+    print(str(exc))
+    assert "only allows keyword arguments" in str(exc)
 
 
 def test_RankLineageInfo_taxlist():

--- a/tests/test_tax_utils.py
+++ b/tests/test_tax_utils.py
@@ -1768,70 +1768,72 @@ def test_is_lineage_match_improper_rank():
     assert "Desired Rank 'NotARank' not available for this lineage" in str(exc)
 
 
-def test_pop_to_rank_1():
+def test_lineage_to_rank_1():
     # basic behavior - pop to order?
     lin1 = RankLineageInfo(lineage_str='d__a;p__b;c__c;o__d')
     lin2 = RankLineageInfo(lineage_str='d__a;p__b;c__c;o__d;f__f')
 
     print(lin1)
-    popped = lin2.pop_to_rank('order')
+    popped = lin2.lineage_to_rank('order')
     print(popped)
     assert popped == lin1
 
 
-def test_pop_to_rank_2():
+def test_lineage_to_rank_2():
     # what if we're already above rank?
     lin2 = RankLineageInfo(lineage_str='d__a;p__b;c__c;o__d;f__f')
-    print(lin2.pop_to_rank('species'))
-    assert lin2.pop_to_rank('species') == lin2
+    print(lin2.lineage_to_rank('species'))
+    assert lin2.lineage_to_rank('species') == lin2
 
 
-def test_pop_to_rank_rank_not_avail():
+def test_lineage_to_rank_rank_not_avail():
     lin1 = RankLineageInfo(lineage_str = 'd__a;p__b;c__c;o__d;f__f')
     with pytest.raises(ValueError) as exc:
-        lin1.pop_to_rank("NotARank")
+        lin1.lineage_to_rank("NotARank")
     print(str(exc))
     assert "Desired Rank 'NotARank' not available for this lineage" in str(exc)
 
 
-def test_lineage_at_rank_norank():
+def test_lineage_to_rank_norank():
     lin1 = RankLineageInfo(lineage_str = 'd__a;p__b;c__c;o__d;f__f')
     with pytest.raises(TypeError) as exc:
-        lin1.lineage_at_rank()
+        lin1.lineage_to_rank()
     print(str(exc))
-    assert "lineage_at_rank() missing 1 required positional argument: 'rank'" in str(exc)
+    assert "lineage_to_rank() missing 1 required positional argument: 'rank'" in str(exc)
 
 
-def test_lineage_at_rank_rank_not_avail():
+def test_lineage_to_rank_rank_not_avail():
     lin1 = RankLineageInfo(lineage_str = 'd__a;p__b;c__c;o__d;f__f')
     with pytest.raises(ValueError) as exc:
-        lin1.lineage_at_rank("NotARank")
+        lin1.lineage_to_rank("NotARank")
     print(str(exc))
     assert "Desired Rank 'NotARank' not available for this lineage" in str(exc)
 
 
-def test_lineage_at_rank_1():
+def test_lineage_to_rank_1():
+    # @CTB
     lin1 = RankLineageInfo(lineage_str = 'd__a;p__b;c__c;o__d;f__f')
-    print(lin1.lineage_at_rank('superkingdom'))
+    print(lin1.lineage_to_rank('superkingdom'))
     
-    assert lin1.lineage_at_rank('superkingdom') == (LineagePair(rank='superkingdom', name='d__a', taxid=None),)
-    print(lin1.lineage_at_rank('class'))
-    assert lin1.lineage_at_rank('class') == (LineagePair(rank='superkingdom', name='d__a', taxid=None),
+    assert lin1.lineage_to_rank('superkingdom') == RankLineageInfo(lineage=(LineagePair(rank='superkingdom', name='d__a', taxid=None),))
+    print(lin1.lineage_to_rank('class'))
+    assert lin1.lineage_to_rank('class') == RankLineageInfo(lineage=(LineagePair(rank='superkingdom', name='d__a', taxid=None),
                                              LineagePair(rank='phylum', name='p__b', taxid=None),
-                                             LineagePair(rank='class', name='c__c', taxid=None))
+                                             LineagePair(rank='class', name='c__c', taxid=None)))
 
 
-def test_lineage_at_rank_below_rank():
+def test_lineage_to_rank_below_rank():
+    # @CTB
     lin1 = RankLineageInfo(lineage_str = 'd__a;p__b;c__c;o__d;f__f')
-    print(lin1.lineage_at_rank('superkingdom'))
+    print(lin1.lineage_to_rank('superkingdom'))
     # if rank is not provided, we only return the filled lineage, to follow original pop_to_rank behavior.
 
-    print(lin1.lineage_at_rank('genus'))
-    assert lin1.lineage_at_rank('genus') == (LineagePair(rank='superkingdom', name='d__a', taxid=None),
+    print(lin1.lineage_to_rank('genus'))
+    assert lin1.lineage_to_rank('genus') == RankLineageInfo(lineage=(LineagePair(rank='superkingdom', name='d__a', taxid=None),
                                              LineagePair(rank='phylum', name='p__b', taxid=None),
                                              LineagePair(rank='class', name='c__c', taxid=None),
                                              LineagePair(rank='order', name='o__d', taxid=None),
-                                             LineagePair(rank='family', name='f__f', taxid=None))
+                                             LineagePair(rank='family', name='f__f', taxid=None)))
 
 
 def test_TaxResult_get_match_lineage_1():


### PR DESCRIPTION
I got interested in the refactoring of tuples of `LineagePair` that happened in #2437 and #2443 and thought I'd write some docs!

See [taxonomic-lineages-examples.md on this branch](https://github.com/sourmash-bio/sourmash/blob/play_with_tax/doc/taxonomic-lineages-examples.md) for the potential new docs page.

In the process, I found a few things that didn't make sense to me, so I tried filling them in. Specifically,

* the `str` and `repr` for `BaseLineageInfo` etc now show `lineage_str`;
* `lineage_str` is now filled in by the init code for all initializers;
* `BaseLineageInfo`, `RankLineageInfo`, and `LINLineageInfo` no longer take positional arguments. This prevents certain kinds of bad things happening, like `lin = RankLineageInfo(tuple_of_lineage_info)` from working and assigning tuples to `ranks`, for one not-so-hypothetical situation!

TODO/to test;
- [x] `lineage_str` being empty <=> `RankLineageInfo(lineage_str='')` works.
- [ ] discuss/describe NCBI taxids, zip_taxid, display_taxid
- [ ] describe zip_lineage
- [ ] document/test is_compatible, is_lineage_match


