### PR TITLE
Fix clippy lint introduced in 1.71 beta

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1682716666,
-        "narHash": "sha256-RGKVQ6pt12VWzJ0vPTLTdsmsyTfsfL4WYgLztE2ZACg=",
+        "lastModified": 1685399834,
+        "narHash": "sha256-Lt7//5snriXSdJo5hlVcDkpERL1piiih0UXIz1RUcC4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "358a179550508bf2dafdf1657a94b7f65d91c4bf",
+        "rev": "58c85835512b0db938600b6fe13cc3e3dc4b364e",
         "type": "github"
       },
       "original": {
@@ -54,11 +54,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1682734733,
-        "narHash": "sha256-oAoNMgWQveSF1Vv16OJ2GVU+BGGdzazTHpPu/VKy/BQ=",
+        "lastModified": 1685413459,
+        "narHash": "sha256-+ELexqS2yN0wj1WnmWdF24OfjRBIgTN6Ltcpjvp2dEo=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "0bb45c519ebd64f6b4223e1bb6b4e08df80834ca",
+        "rev": "9b3284e2412f76bd68ff46f8cf1c7af44d7ffac0",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -98,7 +98,7 @@
           ];
 
           buildInputs = [
-            rustPlatform.rust.cargo
+            rustVersion
             openssl
             pkgconfig
 
@@ -114,7 +114,7 @@
 
             wasmtime
             wasm-pack
-            nodejs-16_x
+            nodejs_20
 
             #py-spy
             heaptrack

--- a/src/core/src/index/sbt/mod.rs
+++ b/src/core/src/index/sbt/mod.rs
@@ -391,9 +391,7 @@ where
         let mut visited = HashSet::new();
         let mut queue = vec![0u64];
 
-        while !queue.is_empty() {
-            let pos = queue.pop().unwrap();
-
+        while let Some(pos) = queue.pop() {
             if !visited.contains(&pos) {
                 visited.insert(pos);
 
@@ -708,9 +706,7 @@ where
     // - datasets
     // - first level of internal nodes
     info!("Start processing leaves");
-    while !datasets.is_empty() {
-        let next_leaf = datasets.pop().unwrap();
-
+    while let Some(next_leaf) = datasets.pop() {
         let (simleaf_tree, in_common) = if datasets.is_empty() {
             (BinaryTree::Empty, next_leaf.mins().into_iter().collect())
         } else {
@@ -773,8 +769,7 @@ where
     let mut visited = HashSet::new();
     let mut queue = vec![(0u64, root)];
 
-    while !queue.is_empty() {
-        let (pos, cnode) = queue.pop().unwrap();
+    while let Some((pos, cnode)) = queue.pop() {
         if !visited.contains(&pos) {
             visited.insert(pos);
 
@@ -804,9 +799,7 @@ impl BinaryTree {
     fn process_internal_level(mut current_round: Vec<BinaryTree>) -> Vec<BinaryTree> {
         let mut next_round = Vec::with_capacity(current_round.len() + 1);
 
-        while !current_round.is_empty() {
-            let next_node = current_round.pop().unwrap();
-
+        while let Some(next_node) = current_round.pop() {
             let similar_node = if current_round.is_empty() {
                 BinaryTree::Empty
             } else {

--- a/src/core/src/sketch/minhash.rs
+++ b/src/core/src/sketch/minhash.rs
@@ -1057,7 +1057,7 @@ impl<'de> Deserialize<'de> for KmerMinHashBTree {
             values.sort();
             let mins: BTreeSet<_> = values.iter().map(|(v, _)| **v).collect();
             let abunds = values.into_iter().map(|(v, x)| (*v, *x)).collect();
-            current_max = *mins.iter().rev().next().unwrap_or(&0);
+            current_max = *mins.iter().next_back().unwrap_or(&0);
             (mins, Some(abunds))
         } else {
             current_max = 0;
@@ -1244,13 +1244,13 @@ impl KmerMinHashBTree {
 
             // is it too big now?
             if self.num != 0 && self.mins.len() > (self.num as usize) {
-                let last = *self.mins.iter().rev().next().unwrap();
+                let last = *self.mins.iter().next_back().unwrap();
                 self.mins.remove(&last);
                 self.reset_md5sum();
                 if let Some(ref mut abunds) = self.abunds {
                     abunds.remove(&last);
                 }
-                self.current_max = *self.mins.iter().rev().next().unwrap();
+                self.current_max = *self.mins.iter().next_back().unwrap();
             }
         }
     }
@@ -1268,7 +1268,7 @@ impl KmerMinHashBTree {
             }
         }
         if hash == self.current_max {
-            self.current_max = *self.mins.iter().rev().next().unwrap_or(&0);
+            self.current_max = *self.mins.iter().next_back().unwrap_or(&0);
         }
     }
 


### PR DESCRIPTION
Rust checks [failed](https://github.com/sourmash-bio/sourmash/actions/runs/5127480236/jobs/9223152688) due to new clippy lints introduced in `1.71` (currently beta).

Fixing it, and also updating nix.