### PR TITLE
MRG: add upload token for codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -6,3 +6,6 @@ fixes:
 - "sourmash::src/sourmash"
 ignores:
 - "src/core/src/ffi"
+
+codecov: 
+ token: 66273971-681c-44a5-b93a-f60249a2a70c


### PR DESCRIPTION
Fixes https://github.com/sourmash-bio/sourmash/issues/2631

This PR adds the codecov upload token per [instructions](https://github.com/codecov/feedback/issues/126); this should make our CI break less frequently.