### PR TITLE
Build: bump maturin to 1.x

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,10 +28,10 @@ repos:
 # format using black
 # when the full codebase is black, use it directly;
 #  while it isn't, let's use darker to format new/changed code
--   repo: https://github.com/akaihola/darker
-    rev: 1.2.1
-    hooks:
-    -   id: darker
+- repo: https://github.com/akaihola/darker
+  rev: 1.7.1
+  hooks:
+    - id: darker
 #- repo: https://github.com/psf/black
 #  rev: 20.8b1
 #  hooks:

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1679567394,
-        "narHash": "sha256-ZvLuzPeARDLiQUt6zSZFGOs+HZmE+3g4QURc8mkBsfM=",
+        "lastModified": 1686572087,
+        "narHash": "sha256-jXTut7ZSYqLEgm/nTk7TuVL2ExahTip605bLINklAnQ=",
         "owner": "nix-community",
         "repo": "naersk",
-        "rev": "88cd22380154a2c36799fe8098888f0f59861a15",
+        "rev": "8507af04eb40c5520bd35d9ce6f9d2342cea5ad1",
         "type": "github"
       },
       "original": {
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1685399834,
-        "narHash": "sha256-Lt7//5snriXSdJo5hlVcDkpERL1piiih0UXIz1RUcC4=",
+        "lastModified": 1687103638,
+        "narHash": "sha256-dwy/TK6Db5W7ivcgmcxUykhFwodIg0jrRzOFt7H5NUc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "58c85835512b0db938600b6fe13cc3e3dc4b364e",
+        "rev": "91430887645a0953568da2f3e9a3a3bb0a0378ac",
         "type": "github"
       },
       "original": {
@@ -54,11 +54,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1685413459,
-        "narHash": "sha256-+ELexqS2yN0wj1WnmWdF24OfjRBIgTN6Ltcpjvp2dEo=",
+        "lastModified": 1687141659,
+        "narHash": "sha256-ckvEuxejYmFTyFF0u9CWV8h5u+ubuxA7vYrOw/GXRXg=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "9b3284e2412f76bd68ff46f8cf1c7af44d7ffac0",
+        "rev": "86302751ef371597d48951983e1a2f04fe78d4ff",
         "type": "github"
       },
       "original": {
@@ -87,11 +87,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1681202837,
-        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
+        "lastModified": 1685518550,
+        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -117,7 +117,7 @@
             nodejs_20
 
             #py-spy
-            heaptrack
+            #heaptrack
             cargo-watch
             cargo-limit
             cargo-outdated

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "maturin>=0.14.13,<0.15",
+    "maturin>=1,<2",
     "cffi",
 ]
 build-backend = 'maturin'

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,8 @@ isolated_build = true
 skip_missing_interpreters = true
 
 [testenv]
+package = wheel
+wheel_build_env = .pkg
 description = run the tests with pytest under {basepython}
 setenv =
     PIP_DISABLE_VERSION_CHECK = 1


### PR DESCRIPTION
Maturin reached 1.x, and we were ready for the transition, so bumping the minimum required version.

Other fixes:
- darker pre-commit check updated to most recent version
- use `package = wheel` and `wheel_build_env = .pkg` to `tox.ini`, which greatly speed up local testing since we only build the package once and reuse the wheel for all tox envs.