### PR TITLE
Update commands.py

### DIFF
--- a/src/sourmash/commands.py
+++ b/src/sourmash/commands.py
@@ -314,6 +314,8 @@ def plot(args):
 
     ### do clustering
     Y = sch.linkage(D, method='single')
+    if not args.labels:
+        labeltext = [str(i) for i in range(len(labeltext))]
     sch.dendrogram(Y, orientation='right', labels=labeltext)
     fig.savefig(dendrogram_out)
     notify(f'wrote dendrogram to: {dendrogram_out}')


### PR DESCRIPTION

I have implemented a simple check for the `--labels` command for the dendrogram plot without heat map. This wasn't previously implemented which resulted in an asymmetric handling of labels for the dendrogram and dendrogram+heatmap plot for the `sourmash plot` command. 
Fixes #2667

