### PR TITLE
Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ authors = [
   { name="Ivan Ogasawara", orcid="0000-0001-5049-4289" },
   { name="N. Tessa Pierce", orcid="0000-0002-2942-5331" },
   { name="Taylor Reiter", orcid="0000-0002-7388-421X" },
+  { name="Gillian Reynolds", orcid="0000-0001-6233-6915" }
   { name="Camille Scott", orcid="0000-0001-8822-8779" },
   { name="Andreas Sjödin", orcid="0000-0001-5350-4219" },
   { name="Connor T. Skennerton", orcid="0000-0003-1320-4873" },


### PR DESCRIPTION
I have implemented a simple check for the `--labels `command for the dendrogram plot without heat map. This wasn't previously implemented which resulted in an asymmetric handling of labels for the dendrogram and dendrogram+heatmap plot for the sourmash plot command.
Fixes #2667