### PR TITLE
build: fix clippy lints and MSRV check

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Start Redis
         if: startsWith(runner.os, 'Linux') && (matrix.py == '3.9')
-        uses: supercharge/redis-github-action@f63fe516254d0af5df91755a4488274c2e71e38c
+        uses: supercharge/redis-github-action@1.5.0
         with:
           redis-version: 6
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -268,17 +268,17 @@ jobs:
 
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: "1.60.0"
+          toolchain: "1.64.0"
           override: true
 
       - name: check if README matches MSRV defined here
-        run: grep '1.60.0' src/core/README.md
+        run: grep '1.64.0' src/core/README.md
 
       - name: Check if it builds properly
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --all-features
+          args: --all-features --tests
 
   check_cbindgen:
     name: "Check if cbindgen runs cleanly for generating the C headers"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
   "src/core",
 ]
 default-members = ["src/core"]
+resolver = "2"
 
 [profile.test]
 opt-level = 1

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1686572087,
-        "narHash": "sha256-jXTut7ZSYqLEgm/nTk7TuVL2ExahTip605bLINklAnQ=",
+        "lastModified": 1688534083,
+        "narHash": "sha256-/bI5vsioXscQTsx+Hk9X5HfweeNZz/6kVKsbdqfwW7g=",
         "owner": "nix-community",
         "repo": "naersk",
-        "rev": "8507af04eb40c5520bd35d9ce6f9d2342cea5ad1",
+        "rev": "abca1fb7a6cfdd355231fc220c3d0302dbb4369a",
         "type": "github"
       },
       "original": {
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1687103638,
-        "narHash": "sha256-dwy/TK6Db5W7ivcgmcxUykhFwodIg0jrRzOFt7H5NUc=",
+        "lastModified": 1689449371,
+        "narHash": "sha256-sK3Oi8uEFrFPL83wKPV6w0+96NrmwqIpw9YFffMifVg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "91430887645a0953568da2f3e9a3a3bb0a0378ac",
+        "rev": "29bcead8405cfe4c00085843eb372cc43837bb9d",
         "type": "github"
       },
       "original": {
@@ -54,11 +54,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1687141659,
-        "narHash": "sha256-ckvEuxejYmFTyFF0u9CWV8h5u+ubuxA7vYrOw/GXRXg=",
+        "lastModified": 1689475081,
+        "narHash": "sha256-lAyG+KKKjOAG1YxYnji1g1pV39WxzQQBHI3ZwoRzweM=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "86302751ef371597d48951983e1a2f04fe78d4ff",
+        "rev": "6e28f20574595b01e14f2bbb57d62b84393fdcc1",
         "type": "github"
       },
       "original": {
@@ -87,11 +87,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1685518550,
-        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
+        "lastModified": 1689068808,
+        "narHash": "sha256-6ixXo3wt24N/melDWjq70UuHQLxGV8jZvooRanIHXw0=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
+        "rev": "919d646de7be200f3bf08cb76ae1f09402b6f9b4",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -37,11 +37,11 @@
           rustc = rustVersion;
         };
         naersk-lib = naersk.lib."${system}".override {
-          cargo = rustPlatform.rust.cargo;
-          rustc = rustPlatform.rust.rustc;
+          cargo = rustVersion;
+          rustc = rustVersion;
         };
 
-        python = pkgs.python310Packages;
+        python = pkgs.python311Packages;
 
       in
 
@@ -104,8 +104,8 @@
 
             git
             stdenv.cc.cc.lib
-            (python310.withPackages (ps: with ps; [ virtualenv tox cffi ]))
-            (python311.withPackages (ps: with ps; [ virtualenv ]))
+            (python311.withPackages (ps: with ps; [ virtualenv tox cffi ]))
+            (python310.withPackages (ps: with ps; [ virtualenv ]))
             (python39.withPackages (ps: with ps; [ virtualenv ]))
             (python38.withPackages (ps: with ps; [ virtualenv ]))
 

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 readme = "README.md"
 autoexamples = false
 autobins = false
-rust-version = "1.60.0"
+rust-version = "1.64.0"
 
 [lib]
 name = "sourmash"

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -31,6 +31,7 @@ cfg-if = "1.0"
 counter = "0.5.7"
 finch = { version = "0.5.0", optional = true }
 fixedbitset = "0.4.0"
+getrandom = { version = "0.2", features = ["js"] }
 getset = "0.1.1"
 log = "0.4.19"
 md5 = "0.7.0"
@@ -57,7 +58,6 @@ criterion = "0.5.1"
 needletail = { version = "0.5.1", default-features = false }
 proptest = { version = "1.2.0", default-features = false, features = ["std"]}
 rand = "0.8.2"
-getrandom = { version = "0.2", features = ["js"] }
 tempfile = "3.6.0"
 
 [[bench]]

--- a/src/core/README.md
+++ b/src/core/README.md
@@ -38,4 +38,4 @@ Development happens on github at
 
 ## Minimum supported Rust version
 
-Currently the minimum supported Rust version is 1.60.0.
+Currently the minimum supported Rust version is 1.64.0.

--- a/src/core/src/ffi/cmd/compute.rs
+++ b/src/core/src/ffi/cmd/compute.rs
@@ -52,7 +52,7 @@ pub unsafe extern "C" fn computeparams_ksizes_free(ptr: *mut u32, insize: usize)
     if ptr.is_null() {
         return;
     }
-    Vec::from_raw_parts(ptr as *mut u32, insize, insize);
+    Vec::from_raw_parts(ptr, insize, insize);
 }
 
 ffi_fn! {
@@ -65,7 +65,7 @@ unsafe fn computeparams_set_ksizes(
 
     let ksizes = {
         assert!(!ksizes_ptr.is_null());
-        slice::from_raw_parts(ksizes_ptr as *const u32, insize)
+        slice::from_raw_parts(ksizes_ptr, insize)
     };
 
     cp.set_ksizes(ksizes.into());

--- a/src/core/src/ffi/minhash.rs
+++ b/src/core/src/ffi/minhash.rs
@@ -39,7 +39,7 @@ pub unsafe extern "C" fn kmerminhash_slice_free(ptr: *mut u64, insize: usize) {
     if ptr.is_null() {
         return;
     }
-    Vec::from_raw_parts(ptr as *mut u64, insize, insize);
+    Vec::from_raw_parts(ptr, insize, insize);
 }
 
 ffi_fn! {
@@ -232,7 +232,7 @@ unsafe fn kmerminhash_add_many(
     // FIXME: make a SourmashSlice_u64 type?
     let hashes = {
         assert!(!hashes_ptr.is_null());
-        slice::from_raw_parts(hashes_ptr as *const u64, insize)
+        slice::from_raw_parts(hashes_ptr, insize)
     };
 
     for hash in hashes {
@@ -277,13 +277,13 @@ unsafe fn kmerminhash_set_abundances(
     // FIXME: make a SourmashSlice_u64 type?
     let hashes = {
         assert!(!hashes_ptr.is_null());
-        slice::from_raw_parts(hashes_ptr as *const u64, insize)
+        slice::from_raw_parts(hashes_ptr, insize)
     };
 
     // FIXME: make a SourmashSlice_u64 type?
     let abunds = {
         assert!(!abunds_ptr.is_null());
-        slice::from_raw_parts(abunds_ptr as *const u64, insize)
+        slice::from_raw_parts(abunds_ptr, insize)
     };
 
     let mut pairs: Vec<_> = hashes.iter().cloned().zip(abunds.iter().cloned()).collect();

--- a/src/core/src/ffi/nodegraph.rs
+++ b/src/core/src/ffi/nodegraph.rs
@@ -29,7 +29,7 @@ pub unsafe extern "C" fn nodegraph_buffer_free(ptr: *mut u8, insize: usize) {
     if ptr.is_null() {
         return;
     }
-    Vec::from_raw_parts(ptr as *mut u8, insize, insize);
+    Vec::from_raw_parts(ptr, insize, insize);
 }
 
 #[no_mangle]

--- a/src/core/src/ffi/storage.rs
+++ b/src/core/src/ffi/storage.rs
@@ -64,7 +64,7 @@ unsafe fn zipstorage_list_sbts(
     // FIXME: use the ForeignObject trait, maybe define new method there...
     let ptr_sigs: Vec<*mut SourmashStr> = sbts
         .into_iter()
-        .map(|x| Box::into_raw(Box::new(SourmashStr::from_string(x))) as *mut SourmashStr)
+        .map(|x| Box::into_raw(Box::new(SourmashStr::from_string(x))))
         .collect();
 
     let b = ptr_sigs.into_boxed_slice();
@@ -86,7 +86,7 @@ unsafe fn zipstorage_filenames(
     // FIXME: use the ForeignObject trait, maybe define new method there...
     let ptr_sigs: Vec<*mut SourmashStr> = files
         .into_iter()
-        .map(|x| Box::into_raw(Box::new(SourmashStr::from_string(x))) as *mut SourmashStr)
+        .map(|x| Box::into_raw(Box::new(SourmashStr::from_string(x))))
         .collect();
 
     let b = ptr_sigs.into_boxed_slice();

--- a/src/core/src/sketch/minhash.rs
+++ b/src/core/src/sketch/minhash.rs
@@ -1655,7 +1655,7 @@ impl From<KmerMinHash> for KmerMinHashBTree {
         let mins: BTreeSet<u64> = other.mins.into_iter().collect();
         let abunds = other
             .abunds
-            .map(|abunds| mins.iter().cloned().zip(abunds.into_iter()).collect());
+            .map(|abunds| mins.iter().cloned().zip(abunds).collect());
 
         new_mh.mins = mins;
         new_mh.abunds = abunds;

--- a/tox.ini
+++ b/tox.ini
@@ -79,7 +79,7 @@ commands = pytest \
 [testenv:khmer_master]
 basepython = python3.8
 deps =
-  -e git+https://github.com/dib-lab/khmer.git#egg=khmer
+  -e git+https://github.com/dib-lab/khmer.git\#egg=khmer
 commands = pytest \
            --cov "{envsitepackagesdir}/sourmash" \
            --cov-config "{toxinidir}/tox.ini" \


### PR DESCRIPTION
Rust 1.72 beta introduced new clippy lints that are failing on CI, most of them are easy to fix (remove ` as` conversion), but [the one changing](https://rust-lang.github.io/rust-clippy/master/index.html#/arc_with_non_send_sync)
```
pub struct InnerStorage(Arc<Mutex<dyn Storage>>);
```
to
```
pub struct InnerStorage(Rc<RwLock<dyn Storage>>);
```
is a bit more involved. Still need to better evaluate how this will go with threads, but since it is an opaque type we can also change the internal representation without breaking semver.

https://github.com/sourmash-bio/sourmash/pull/2629 introduced an MSRV bump to 1.64 on the test dependencies, added an extra argument `--tests`  in the CI checks to verify test deps too.