### PR TITLE
MRG: update a manifest test to use temp directory

### DIFF
--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -1947,13 +1947,15 @@ def test_standalone_manifest_signatures_prefix_fail(runtmp):
         row['internal_location'] = os.path.basename(row['internal_location'])
 
     ## got a manifest! ok, now test out StandaloneManifestIndex
-    mm = StandaloneManifestIndex(mi.manifest, None, prefix='foo')
+    mm = StandaloneManifestIndex(mi.manifest, None,
+                                 prefix=runtmp.output('foo'))
 
     # should fail
     with pytest.raises(ValueError) as exc:
         list(mm.signatures())
 
-    assert "Error while reading signatures from 'foo/47.fa.sig'" in str(exc)
+    assert "Error while reading signatures from " in str(exc)
+    assert "foo/47.fa.sig'" in str(exc)
 
 
 def test_standalone_manifest_load_from_dir(runtmp):


### PR DESCRIPTION
This PR updates `test_standalone_manifest_signatures_prefix_fail` to use `runtmp.out(...)` for a directory that's not supposed to exist; the test was failing on my laptop because the directory used in the test _did_ exist on my laptop 😄 
