### PR TITLE
MRG: add a `sourmash.cli.parse_args([...])` function

### DIFF
--- a/src/sourmash/__main__.py
+++ b/src/sourmash/__main__.py
@@ -7,7 +7,7 @@ Can also be executed as 'python -m sourmash'.
 
 def main(arglist=None):
     import sourmash
-    args = sourmash.cli.get_parser().parse_args(arglist)
+    args = sourmash.cli.parse_args(arglist)
     if hasattr(args, 'subcmd'):
         mod = getattr(sourmash.cli, args.cmd)
         submod = getattr(mod, args.subcmd)

--- a/src/sourmash/cli/__init__.py
+++ b/src/sourmash/cli/__init__.py
@@ -141,3 +141,20 @@ def get_parser():
         getattr(sys.modules[__name__], op).subparser(sub)
     parser._action_groups.reverse()
     return parser
+
+
+def parse_args(arglist=None):
+    """
+    Return an argparse 'args' object from parsing arglist.
+
+    By default pulls arguments from sys.argv.
+
+    Example usage:
+
+    ```
+    args = parse_args(['sig', 'filter', '-m', '10'])
+
+    sourmash.sig.filter.__main__.filter(args)
+    ```
+    """
+    return get_parser().parse_args(arglist)

--- a/src/sourmash/sig/__init__.py
+++ b/src/sourmash/sig/__init__.py
@@ -1,2 +1,2 @@
-from .__main__ import main
+from .__main__ import *         # bring all functions into top-level
 from . import grep

--- a/tests/test_cmd_signature.py
+++ b/tests/test_cmd_signature.py
@@ -45,6 +45,15 @@ def test_run_sourmash_sig_cmd():
     assert status != 0                    # no args provided, ok ;)
 
 
+def test_run_cat_via_parse_args():
+    # run a command ('sourmash.sig.cat') with args constructed via parse_args
+    import sourmash.sig, sourmash.cli
+    sig47 = utils.get_test_data('47.fa.sig')
+
+    args = sourmash.cli.parse_args(['sig', 'cat', sig47])
+    sourmash.sig.cat(args)
+
+
 def test_sig_merge_1_use_full_signature_in_cmd(runtmp):
     c = runtmp
 

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -332,6 +332,15 @@ def test_compare_quiet(runtmp):
     assert not c.last_result.err
 
 
+def test_compare_do_traverse_directory_parse_args(runtmp):
+    # test 'compare' on a directory, using sourmash.cli.parse_args.
+    import sourmash.commands, sourmash.cli
+    args = sourmash.cli.parse_args(['compare', '-k', '21', '--dna',
+                                    utils.get_test_data('compare')])
+
+    sourmash.commands.compare(args)
+
+
 def test_compare_do_traverse_directory(runtmp):
     # test 'compare' on a directory
     c = runtmp


### PR DESCRIPTION
Fixes #2684

This PR adds a function that creates an `args` object for a particular sourmash command - so that you can do something like this:
```python
import sourmash.commands, sourmash.cli

# create args object:
args = sourmash.cli.parse_args(['plot', 'cmp'])

# run 'sourmash plot'
sourmash.commands.plot(args)
```

For convenience, this PR also makes all of the `sourmash sig` functions available in Python via `sourmash.sig.<fn>`.