### PR TITLE
MRG: update plugin support for argparse usage/description/epilog

### DIFF
--- a/src/sourmash/plugins.py
+++ b/src/sourmash/plugins.py
@@ -16,6 +16,7 @@ DEFAULT_LOAD_FROM_PRIORITY = 99
 DEFAULT_SAVE_TO_PRIORITY = 99
 
 import itertools
+import argparse
 
 from .logging import (debug_literal, error, notify, set_quiet)
 
@@ -150,7 +151,17 @@ def add_cli_scripts(parser):
         name = plugin.name
         script_cls = plugin.load()
 
-        subparser = parser.add_parser(script_cls.command)
+        usage = getattr(script_cls, 'usage', None)
+        description = getattr(script_cls, 'description', None)
+        epilog = getattr(script_cls, 'epilog', None)
+        formatter_class = getattr(script_cls, 'formatter_class',
+                                  argparse.HelpFormatter)
+
+        subparser = parser.add_parser(script_cls.command,
+                                      usage=usage,
+                                      description=description,
+                                      epilog=epilog,
+                                      formatter_class=formatter_class)
         debug_literal(f"cls_script plugin '{name}' adding command '{script_cls.command}'")
         obj = script_cls(subparser)
         d[script_cls.command] = obj

--- a/src/sourmash/plugins.py
+++ b/src/sourmash/plugins.py
@@ -139,7 +139,8 @@ def get_cli_scripts_descriptions():
 
         command = getattr(script_cls, 'command')
         description = getattr(script_cls, 'description', "")
-        description = description.splitlines()[0]
+        if description:
+            description = description.splitlines()[0]
         if not description:
             description = f"(no description provided by plugin '{name}')"
 

--- a/src/sourmash/plugins.py
+++ b/src/sourmash/plugins.py
@@ -138,8 +138,11 @@ def get_cli_scripts_descriptions():
         script_cls = plugin.load()
 
         command = getattr(script_cls, 'command')
-        description = getattr(script_cls, 'description',
-                              f"(no description provided by plugin '{name}')")
+        description = getattr(script_cls, 'description', "")
+        description = description.splitlines()[0]
+        if not description:
+            description = f"(no description provided by plugin '{name}')"
+
         yield f"sourmash scripts {command:16s} - {description}"
 
 


### PR DESCRIPTION
This PR adds support for argparse `usage` and `epilog` strings, as well as `formatter_class`, per [argparse docs](https://docs.python.org/3/library/argparse.html#argparse.ArgumentParser).

See https://github.com/sourmash-bio/sourmash_plugin_template/commit/cb5d45439c23e3ea5b1c650322d30faf433902f2 for general use in plugins, and https://github.com/ctb/sourmash_plugin_commonhash/commit/3fbb4d21e41eb1af2c027e81bc4e4d076dd50883 for an example use in commonhash.

This means that e.g. commonhash now supports pleasing output for both bad usage and `-h` flag -
```
sourmash scripts commonhash    
usage: 
   sourmash scripts commonhash [ -m 2 ] *.sig.gz -o filtered.zip
 commonhash: error: the following arguments are required: sigfiles, -o/--output
```

and
```
== This is sourmash version 4.8.3.dev0. ==
== Please cite Brown and Irber (2016), doi:10.21105/joss.00027. ==

usage: 
   sourmash scripts commonhash [ -m 2 ] *.sig.gz -o filtered.zip

filter hashes by min occurrence across sketches

Reduce 'noise' in Jaccard comparisons of sequencing data by removing
hashes that are present in only a few sketches.

'commonhash' supports the full range of sourmash sketch output formats [1].

[1] https://sourmash.readthedocs.io/en/latest/command-line.html#choosing-signature-output-formats

---

positional arguments:
  sigfiles              input signatures

options:
  -h, --help            show this help message and exit
  -q, --quiet           suppress non-error output
  -d, --debug           provide debugging output
  -k KSIZE, --ksize KSIZE
                        select this k-mer size
  -o OUTPUT, --output OUTPUT
                        save sketches to this location; e.g. output.zip or ./output/
  -m MIN_SAMPLES, --min-samples MIN_SAMPLES
                        a hash must be in this many samples to be retained

See https://github.com/ctb/sourmash_plugin_commonhash for more examples.

Need help? Have questions? Ask at http://github.com/sourmash/issues!
```