### PR TITLE
Feature: implement FFI for manifest, picklist and selection in Rust

### DIFF
--- a/include/sourmash.h
+++ b/include/sourmash.h
@@ -16,6 +16,12 @@ enum HashFunctions {
 };
 typedef uint32_t HashFunctions;
 
+enum PickStyle {
+  PICK_STYLE_INCLUDE = 1,
+  PICK_STYLE_EXCLUDE = 2,
+};
+typedef uint32_t PickStyle;
+
 enum SourmashErrorCode {
   SOURMASH_ERROR_CODE_NO_ERROR = 0,
   SOURMASH_ERROR_CODE_PANIC = 1,
@@ -53,13 +59,23 @@ typedef struct SourmashHyperLogLog SourmashHyperLogLog;
 
 typedef struct SourmashKmerMinHash SourmashKmerMinHash;
 
+typedef struct SourmashManifest SourmashManifest;
+
+typedef struct SourmashManifestRowIter SourmashManifestRowIter;
+
 typedef struct SourmashNodegraph SourmashNodegraph;
+
+typedef struct SourmashPicklist SourmashPicklist;
 
 typedef struct SourmashRevIndex SourmashRevIndex;
 
 typedef struct SourmashSearchResult SourmashSearchResult;
 
+typedef struct SourmashSelection SourmashSelection;
+
 typedef struct SourmashSignature SourmashSignature;
+
+typedef struct SourmashSignatureIter SourmashSignatureIter;
 
 typedef struct SourmashZipStorage SourmashZipStorage;
 
@@ -80,6 +96,15 @@ typedef struct {
    */
   bool owned;
 } SourmashStr;
+
+typedef struct {
+  uint32_t ksize;
+  bool with_abundance;
+  SourmashStr md5;
+  SourmashStr internal_location;
+  SourmashStr name;
+  SourmashStr moltype;
+} SourmashManifestRow;
 
 bool computeparams_dayhoff(const SourmashComputeParameters *ptr);
 
@@ -267,6 +292,10 @@ void kmerminhash_slice_free(uint64_t *ptr, uintptr_t insize);
 
 bool kmerminhash_track_abundance(const SourmashKmerMinHash *ptr);
 
+SourmashManifestRowIter *manifest_rows(const SourmashManifest *ptr);
+
+const SourmashManifestRow *manifest_rows_iter_next(SourmashManifestRowIter *ptr);
+
 void nodegraph_buffer_free(uint8_t *ptr, uintptr_t insize);
 
 bool nodegraph_count(SourmashNodegraph *ptr, uint64_t h);
@@ -310,6 +339,18 @@ void nodegraph_update_mh(SourmashNodegraph *ptr, const SourmashKmerMinHash *optr
 SourmashNodegraph *nodegraph_with_tables(uintptr_t ksize,
                                          uintptr_t starting_size,
                                          uintptr_t n_tables);
+
+void picklist_free(SourmashPicklist *ptr);
+
+SourmashPicklist *picklist_new(void);
+
+void picklist_set_coltype(SourmashPicklist *ptr, const char *coltype_ptr, uintptr_t insize);
+
+void picklist_set_column_name(SourmashPicklist *ptr, const char *prop_ptr, uintptr_t insize);
+
+void picklist_set_pickfile(SourmashPicklist *ptr, const char *prop_ptr, uintptr_t insize);
+
+void picklist_set_pickstyle(SourmashPicklist *ptr, PickStyle pickstyle);
 
 void revindex_free(SourmashRevIndex *ptr);
 
@@ -356,6 +397,36 @@ double searchresult_score(const SourmashSearchResult *ptr);
 
 SourmashSignature *searchresult_signature(const SourmashSearchResult *ptr);
 
+bool selection_abund(const SourmashSelection *ptr);
+
+bool selection_containment(const SourmashSelection *ptr);
+
+uint32_t selection_ksize(const SourmashSelection *ptr);
+
+HashFunctions selection_moltype(const SourmashSelection *ptr);
+
+SourmashSelection *selection_new(void);
+
+uint32_t selection_num(const SourmashSelection *ptr);
+
+const SourmashPicklist *selection_picklist(const SourmashSelection *ptr);
+
+uint32_t selection_scaled(const SourmashSelection *ptr);
+
+void selection_set_abund(SourmashSelection *ptr, bool new_abund);
+
+void selection_set_containment(SourmashSelection *ptr, bool new_containment);
+
+void selection_set_ksize(SourmashSelection *ptr, uint32_t new_ksize);
+
+void selection_set_moltype(SourmashSelection *ptr, HashFunctions new_moltype);
+
+void selection_set_num(SourmashSelection *ptr, uint32_t new_num);
+
+void selection_set_picklist(SourmashSelection *ptr, SourmashPicklist *new_picklist);
+
+void selection_set_scaled(SourmashSelection *ptr, uint32_t new_scaled);
+
 void signature_add_protein(SourmashSignature *ptr, const char *sequence);
 
 void signature_add_sequence(SourmashSignature *ptr, const char *sequence, bool force);
@@ -389,6 +460,8 @@ void signature_set_filename(SourmashSignature *ptr, const char *name);
 void signature_set_mh(SourmashSignature *ptr, const SourmashKmerMinHash *other);
 
 void signature_set_name(SourmashSignature *ptr, const char *name);
+
+const SourmashSignature *signatures_iter_next(SourmashSignatureIter *ptr);
 
 SourmashSignature **signatures_load_buffer(const char *ptr,
                                            uintptr_t insize,

--- a/src/core/src/ffi/index/mod.rs
+++ b/src/core/src/ffi/index/mod.rs
@@ -2,8 +2,13 @@
 #[cfg(feature = "branchwater")]
 pub mod revindex;
 
+use crate::ffi::HashFunctions;
+use crate::selection::Selection;
+use crate::storage::SigStore;
+
 use crate::signature::Signature;
 
+use crate::ffi::picklist::SourmashPicklist;
 use crate::ffi::signature::SourmashSignature;
 use crate::ffi::utils::{ForeignObject, SourmashStr};
 
@@ -36,4 +41,165 @@ pub unsafe extern "C" fn searchresult_signature(
 ) -> *mut SourmashSignature {
     let result = SourmashSearchResult::as_rust(ptr);
     SourmashSignature::from_rust((result.1).clone())
+}
+
+//================================================================
+
+pub struct SourmashSelection;
+
+impl ForeignObject for SourmashSelection {
+    type RustObject = Selection;
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn selection_new() -> *mut SourmashSelection {
+    SourmashSelection::from_rust(Selection::default())
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn selection_ksize(ptr: *const SourmashSelection) -> u32 {
+    let sel = SourmashSelection::as_rust(ptr);
+    if let Some(ksize) = sel.ksize() {
+        ksize
+    } else {
+        todo!("empty ksize case not supported yet")
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn selection_set_ksize(ptr: *mut SourmashSelection, new_ksize: u32) {
+    let sel = SourmashSelection::as_rust_mut(ptr);
+    sel.set_ksize(new_ksize);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn selection_num(ptr: *const SourmashSelection) -> u32 {
+    let sel = SourmashSelection::as_rust(ptr);
+    if let Some(num) = sel.num() {
+        num
+    } else {
+        todo!("empty num case not supported yet")
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn selection_set_num(ptr: *mut SourmashSelection, new_num: u32) {
+    let sel = SourmashSelection::as_rust_mut(ptr);
+    sel.set_num(new_num);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn selection_scaled(ptr: *const SourmashSelection) -> u32 {
+    let sel = SourmashSelection::as_rust(ptr);
+    if let Some(scaled) = sel.scaled() {
+        scaled
+    } else {
+        todo!("empty scaled case not supported yet")
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn selection_set_scaled(ptr: *mut SourmashSelection, new_scaled: u32) {
+    let sel = SourmashSelection::as_rust_mut(ptr);
+    sel.set_scaled(new_scaled);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn selection_containment(ptr: *const SourmashSelection) -> bool {
+    let sel = SourmashSelection::as_rust(ptr);
+    if let Some(containment) = sel.containment() {
+        containment
+    } else {
+        todo!("empty scaled case not supported yet")
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn selection_set_containment(
+    ptr: *mut SourmashSelection,
+    new_containment: bool,
+) {
+    let sel = SourmashSelection::as_rust_mut(ptr);
+    sel.set_containment(new_containment);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn selection_abund(ptr: *const SourmashSelection) -> bool {
+    let sel = SourmashSelection::as_rust(ptr);
+    if let Some(abund) = sel.abund() {
+        abund
+    } else {
+        todo!("empty abund case not supported yet")
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn selection_set_abund(ptr: *mut SourmashSelection, new_abund: bool) {
+    let sel = SourmashSelection::as_rust_mut(ptr);
+    sel.set_abund(new_abund);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn selection_moltype(ptr: *const SourmashSelection) -> HashFunctions {
+    let sel = SourmashSelection::as_rust(ptr);
+    if let Some(hash_function) = sel.moltype() {
+        hash_function.into()
+    } else {
+        todo!("empty hash_function case not supported yet")
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn selection_set_moltype(
+    ptr: *mut SourmashSelection,
+    new_moltype: HashFunctions,
+) {
+    let sel = SourmashSelection::as_rust_mut(ptr);
+    sel.set_moltype(new_moltype.into());
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn selection_picklist(
+    ptr: *const SourmashSelection,
+) -> *const SourmashPicklist {
+    let sel = SourmashSelection::as_rust(ptr);
+    if let Some(picklist) = sel.picklist() {
+        SourmashPicklist::from_rust(picklist)
+    } else {
+        todo!("empty picklist case not supported yet")
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn selection_set_picklist(
+    ptr: *mut SourmashSelection,
+    new_picklist: *mut SourmashPicklist,
+) {
+    let sel = SourmashSelection::as_rust_mut(ptr);
+    let pick = SourmashPicklist::into_rust(new_picklist);
+    sel.set_picklist(*pick);
+}
+
+//================================================================
+//
+pub struct SignatureIterator {
+    iter: Box<dyn Iterator<Item = SigStore>>,
+}
+
+pub struct SourmashSignatureIter;
+
+impl ForeignObject for SourmashSignatureIter {
+    type RustObject = SignatureIterator;
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn signatures_iter_next(
+    ptr: *mut SourmashSignatureIter,
+) -> *const SourmashSignature {
+    let iterator = SourmashSignatureIter::as_rust_mut(ptr);
+
+    match iterator.iter.next() {
+        Some(sig) => SourmashSignature::from_rust(sig.into()),
+        None => std::ptr::null(),
+    }
 }

--- a/src/core/src/ffi/manifest.rs
+++ b/src/core/src/ffi/manifest.rs
@@ -1,0 +1,68 @@
+use crate::manifest::{Manifest, Record};
+
+use crate::ffi::utils::{ForeignObject, SourmashStr};
+
+pub struct SourmashManifest;
+
+impl ForeignObject for SourmashManifest {
+    type RustObject = Manifest;
+}
+
+pub struct ManifestRowIterator {
+    iter: Box<dyn Iterator<Item = &'static Record>>,
+}
+
+pub struct SourmashManifestRowIter;
+
+impl ForeignObject for SourmashManifestRowIter {
+    type RustObject = ManifestRowIterator;
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn manifest_rows_iter_next(
+    ptr: *mut SourmashManifestRowIter,
+) -> *const SourmashManifestRow {
+    let iterator = SourmashManifestRowIter::as_rust_mut(ptr);
+
+    match iterator.iter.next() {
+        Some(row) => SourmashManifestRow::from_rust(row.into()),
+        None => std::ptr::null(),
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn manifest_rows(
+    ptr: *const SourmashManifest,
+) -> *mut SourmashManifestRowIter {
+    let manifest = SourmashManifest::as_rust(ptr);
+
+    let iter = Box::new(manifest.iter());
+    SourmashManifestRowIter::from_rust(ManifestRowIterator { iter })
+}
+
+#[repr(C)]
+pub struct SourmashManifestRow {
+    pub ksize: u32,
+    pub with_abundance: bool,
+    pub md5: SourmashStr,
+    pub internal_location: SourmashStr,
+    pub name: SourmashStr,
+    pub moltype: SourmashStr,
+}
+
+impl ForeignObject for SourmashManifestRow {
+    type RustObject = SourmashManifestRow;
+}
+
+impl From<&Record> for SourmashManifestRow {
+    fn from(record: &Record) -> SourmashManifestRow {
+        Self {
+            ksize: *record.ksize(),
+            with_abundance: *record.with_abundance(),
+            md5: record.md5().clone().into(),
+            name: record.name().clone().into(),
+            moltype: record.moltype().to_string().into(),
+            internal_location: record.internal_location().to_string().into(),
+        }
+    }
+}

--- a/src/core/src/ffi/mod.rs
+++ b/src/core/src/ffi/mod.rs
@@ -9,8 +9,10 @@ pub mod utils;
 pub mod cmd;
 pub mod hyperloglog;
 pub mod index;
+pub mod manifest;
 pub mod minhash;
 pub mod nodegraph;
+pub mod picklist;
 pub mod signature;
 pub mod storage;
 

--- a/src/core/src/ffi/picklist.rs
+++ b/src/core/src/ffi/picklist.rs
@@ -1,0 +1,89 @@
+use std::os::raw::c_char;
+use std::slice;
+
+use crate::selection::{PickStyle, Picklist};
+
+use crate::ffi::utils::ForeignObject;
+
+pub struct SourmashPicklist;
+
+impl ForeignObject for SourmashPicklist {
+    type RustObject = Picklist;
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn picklist_new() -> *mut SourmashPicklist {
+    SourmashPicklist::from_rust(Picklist::default())
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn picklist_free(ptr: *mut SourmashPicklist) {
+    SourmashPicklist::drop(ptr);
+}
+
+ffi_fn! {
+unsafe fn picklist_set_coltype(
+    ptr: *mut SourmashPicklist,
+    coltype_ptr: *const c_char,
+    insize: usize,
+) -> Result<()> {
+    let coltype = {
+        assert!(!coltype_ptr.is_null());
+        let coltype = slice::from_raw_parts(coltype_ptr as *mut u8, insize);
+        std::str::from_utf8(coltype)?
+    };
+    let pl = SourmashPicklist::as_rust_mut(ptr);
+    pl.set_coltype(coltype.to_string());
+
+    Ok(())
+}
+}
+
+ffi_fn! {
+unsafe fn picklist_set_pickfile(
+    ptr: *mut SourmashPicklist,
+    prop_ptr: *const c_char,
+    insize: usize,
+) -> Result<()> {
+    let prop = {
+        assert!(!prop_ptr.is_null());
+        let prop = slice::from_raw_parts(prop_ptr as *mut u8, insize);
+        std::str::from_utf8(prop)?
+    };
+    let pl = SourmashPicklist::as_rust_mut(ptr);
+    pl.set_pickfile(prop.to_string());
+
+    Ok(())
+}
+}
+
+ffi_fn! {
+unsafe fn picklist_set_column_name(
+    ptr: *mut SourmashPicklist,
+    prop_ptr: *const c_char,
+    insize: usize,
+) -> Result<()> {
+    let prop = {
+        assert!(!prop_ptr.is_null());
+        let prop = slice::from_raw_parts(prop_ptr as *mut u8, insize);
+        std::str::from_utf8(prop)?
+    };
+    let pl = SourmashPicklist::as_rust_mut(ptr);
+    pl.set_column_name(prop.to_string());
+
+    Ok(())
+}
+}
+
+ffi_fn! {
+unsafe fn picklist_set_pickstyle(
+    ptr: *mut SourmashPicklist,
+    pickstyle: PickStyle,
+) -> Result<()> {
+    let pl = SourmashPicklist::as_rust_mut(ptr);
+
+    pl.set_pickstyle(pickstyle);
+
+    Ok(())
+}
+}

--- a/src/sourmash/picklist.py
+++ b/src/sourmash/picklist.py
@@ -298,6 +298,24 @@ class SignaturePicklist:
             if self.__contains__(ss):
                 yield ss
 
+    def _as_rust(self):
+        from ._lowlevel import ffi, lib
+        from .utils import rustcall, decode_str
+
+        ptr = lib.picklist_new()
+
+        rustcall(lib.picklist_set_coltype, ptr, self.coltype.encode('utf-8'), len(self.coltype))
+        rustcall(lib.picklist_set_pickfile, ptr, self.pickfile.encode('utf-8'), len(self.pickfile))
+        rustcall(lib.picklist_set_column_name, ptr, self.column_name.encode('utf-8'), len(self.column_name))
+        rustcall(lib.picklist_set_pickstyle, ptr, self.pickstyle.value)
+
+        #self.preprocess_fn = preprocess[coltype]
+        #self.pickset = None
+        #self.found = set()
+        #self.n_queries = 0
+
+        return ptr
+
 
 def passes_all_picklists(ss, picklists):
     "does the signature 'ss' pass all of the picklists?"


### PR DESCRIPTION
Implement `Manifest`, `Picklist` and `Selection` in Rust.

This is needed to better support Rust indices with the same feature set from Python indices.

(spun off #2230)