### PR TITLE
Build: Remove deprecated system_packages from readthedocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -20,4 +20,3 @@ python:
       path: .
       extra_requirements:
         - doc
-  system_packages: true


### PR DESCRIPTION
`python.system_packages` is deprecated and now breaks readthedocs build. Turns out we have all the dependencies properly specified, so no other changes needed.

More info: https://blog.readthedocs.com/drop-support-system-packages/