### PR TITLE
MRG: fix duplicate md5 in picklist problem

### DIFF
--- a/src/sourmash/index/sqlite_index.py
+++ b/src/sourmash/index/sqlite_index.py
@@ -889,7 +889,7 @@ class SqliteCollectionManifest(BaseCollectionManifest):
         for row in self.rows:
             pickset.add(row['md5'])
 
-        picklist = SignaturePicklist('md5')
+        picklist = SignaturePicklist('md5') # @CTB
         picklist.pickset = pickset
         return picklist
 

--- a/src/sourmash/index/sqlite_index.py
+++ b/src/sourmash/index/sqlite_index.py
@@ -885,13 +885,9 @@ class SqliteCollectionManifest(BaseCollectionManifest):
 
     def to_picklist(self):
         "Convert this manifest to a picklist."
-        pickset = set()
-        for row in self.rows:
-            pickset.add(row['md5'])
-
-        picklist = SignaturePicklist('md5') # @CTB
-        picklist.pickset = pickset
-        return picklist
+        pl = SignaturePicklist('manifest')
+        pl.pickset = { pl._get_value_for_manifest_row(row) for row in self.rows }
+        return pl
 
     @classmethod
     def _create_manifest_from_rows(cls, rows_iter, *, location=":memory:",

--- a/src/sourmash/manifest.py
+++ b/src/sourmash/manifest.py
@@ -8,7 +8,7 @@ import os.path
 from abc import abstractmethod
 import itertools
 
-from sourmash.picklist import SignaturePicklist
+from sourmash import picklist
 
 
 class BaseCollectionManifest:
@@ -339,7 +339,14 @@ class CollectionManifest(BaseCollectionManifest):
 
     def to_picklist(self):
         "Convert this manifest to a picklist."
-        picklist = SignaturePicklist('md5')
-        picklist.pickset = set(self._md5_set)
+        pl = picklist.SignaturePicklist('manifest')
+        fn = pl.preprocess_fn
 
-        return picklist
+        vals = ( (row['name'], row['md5']) for row in self.rows)
+
+        x = set()
+        for tup in vals:
+            x.add(fn(tup))
+        pl.pickset = x
+
+        return pl

--- a/src/sourmash/manifest.py
+++ b/src/sourmash/manifest.py
@@ -341,6 +341,6 @@ class CollectionManifest(BaseCollectionManifest):
         "Convert this manifest to a picklist."
         pl = picklist.SignaturePicklist('manifest')
 
-        pl.pickset = { pl._get_value_for_row(row) for row in self.rows }
+        pl.pickset = { pl._get_value_for_manifest_row(row) for row in self.rows }
 
         return pl

--- a/src/sourmash/manifest.py
+++ b/src/sourmash/manifest.py
@@ -342,11 +342,7 @@ class CollectionManifest(BaseCollectionManifest):
         pl = picklist.SignaturePicklist('manifest')
         fn = pl.preprocess_fn
 
-        vals = ( (row['name'], row['md5']) for row in self.rows)
-
-        x = set()
-        for tup in vals:
-            x.add(fn(tup))
-        pl.pickset = x
+        vals = { fn((row['name'], row['md5'])) for row in self.rows }
+        pl.pickset = vals
 
         return pl

--- a/src/sourmash/manifest.py
+++ b/src/sourmash/manifest.py
@@ -340,9 +340,7 @@ class CollectionManifest(BaseCollectionManifest):
     def to_picklist(self):
         "Convert this manifest to a picklist."
         pl = picklist.SignaturePicklist('manifest')
-        fn = pl.preprocess_fn
 
-        vals = { fn((row['name'], row['md5'])) for row in self.rows }
-        pl.pickset = vals
+        pl.pickset = { pl._get_value_for_row(row) for row in self.rows }
 
         return pl

--- a/src/sourmash/picklist.py
+++ b/src/sourmash/picklist.py
@@ -88,13 +88,13 @@ class SignaturePicklist:
                 coltype = 'md5prefix8'
                 column_name = 'match_md5'
             elif coltype == 'manifest':
-                column_name = 'manifest'
+                column_name = '(ident, md5)'
             elif coltype == 'search':
                 # for now, override => md5
                 coltype = 'md5'
                 column_name = 'md5'
             else:               # should never be reached!
-                assert 0
+                assert 0, coltype
 
         self.coltype = coltype
         self.pickfile = pickfile
@@ -138,7 +138,7 @@ class SignaturePicklist:
             q = ss.md5sum()
         elif coltype in ('name', 'ident', 'identprefix'):
             q = ss.name
-        elif coltype == 'manifest':
+        elif coltype == '(ident, md5)':
             q = (ss.name, ss.md5sum())
         else:
             assert 0
@@ -178,12 +178,12 @@ class SignaturePicklist:
                     return 0, 0
 
             # note: 'manifest' here becomes unusable as actual column name CTB
-            if not (column_name in r.fieldnames or column_name == 'manifest'):
+            if not (column_name in r.fieldnames or column_name == '(ident, md5)'):
                 raise ValueError(f"column '{column_name}' not in pickfile '{pickfile}'")
 
             for row in r:
                 # pick out values from column
-                if column_name == 'manifest':
+                if column_name == '(ident, md5)':
                     col = (row['name'], row['md5'])
                 else:
                     col = row[column_name]
@@ -239,7 +239,7 @@ class SignaturePicklist:
             elif self.coltype in ('name', 'ident', 'identprefix'):
                 colkey = 'name'
             else:
-                assert 0
+                assert 0, colkey
 
             q = row[colkey]
 
@@ -261,7 +261,7 @@ class SignaturePicklist:
 
         This is used for examining matches/nomatches to original picklist file.
         """
-        if self.column_name == 'manifest':
+        if self.column_name == '(ident, md5)':
             q = (row['name'], row['md5'])
         else:
             q = row[self.column_name]

--- a/src/sourmash/picklist.py
+++ b/src/sourmash/picklist.py
@@ -152,11 +152,14 @@ class SignaturePicklist:
         self.pickset = set(values)
         return self.pickset
 
-    def load(self, pickfile, column_name, *, allow_empty=False):
+    def load(self, *, allow_empty=False):
         "load pickset, return num empty vals, and set of duplicate vals."
         from . import sourmash_args
 
         pickset = self.init()
+
+        pickfile = self.pickfile
+        column_name = self.column_name
 
         if not os.path.exists(pickfile) or not os.path.isfile(pickfile):
             raise ValueError(f"pickfile '{pickfile}' must exist and be a regular file")
@@ -174,6 +177,7 @@ class SignaturePicklist:
                 else:
                     return 0, 0
 
+            # note: 'manifest' here becomes unusable as actual column name CTB
             if not (column_name in r.fieldnames or column_name == 'manifest'):
                 raise ValueError(f"column '{column_name}' not in pickfile '{pickfile}'")
 

--- a/src/sourmash/picklist.py
+++ b/src/sourmash/picklist.py
@@ -48,14 +48,13 @@ class SignaturePicklist:
     * 'md5short' - same as md5prefix8
     * 'ident' - exact match to signature's identifier
     * 'identprefix' - match to signature's identifier, before '.'
-    * 'manifest' - match to (ident, md5) tuple
 
     Identifiers are constructed by using the first space delimited word in
     the signature name.
 
-    You can also use 'gather', 'prefetch', and 'search' as
+    You can also use 'gather', 'prefetch', 'search', and 'manifest' as
     column types; these take the CSV output of 'gather', 'prefetch',
-    and 'search' as picklists. 'column' must be left
+    'search', and 'manifest' as picklists. 'column' must be left
     blank in this case: e.g. use 'pickfile.csv::gather'.
     """
     meta_coltypes = ('manifest', 'gather', 'prefetch', 'search')
@@ -177,7 +176,6 @@ class SignaturePicklist:
                 else:
                     return 0, 0
 
-            # note: 'manifest' here becomes unusable as actual column name CTB
             if not (column_name in r.fieldnames or column_name == '(ident, md5)'):
                 raise ValueError(f"column '{column_name}' not in pickfile '{pickfile}'")
 

--- a/src/sourmash/picklist.py
+++ b/src/sourmash/picklist.py
@@ -137,10 +137,10 @@ class SignaturePicklist:
             q = ss.md5sum()
         elif coltype in ('name', 'ident', 'identprefix'):
             q = ss.name
-        elif coltype == '(ident, md5)':
+        elif coltype == 'manifest':
             q = (ss.name, ss.md5sum())
         else:
-            assert 0
+            assert 0, coltype
 
         return q
 

--- a/src/sourmash/picklist.py
+++ b/src/sourmash/picklist.py
@@ -1,4 +1,14 @@
-"Picklist code for extracting subsets of signatures."
+"""Picklist code for extracting subsets of signatures.
+
+Picklists serve as a central inclusion/exclusion mechanism for sketches.
+Each picklist object operates on a particular type of value, and uses
+values specified by the user (if using an external picklist) or works with
+the output of sourmash (manifests or search/prefetch/gather output).
+
+Two key features of picklists is that they can be passed into Index.select
+and operate efficiently on manifests, so when used with e.g. zipfiles,
+only the selected sketches are loaded.
+"""
 import csv
 import os
 from enum import Enum
@@ -61,7 +71,8 @@ class SignaturePicklist:
     You can also use 'gather', 'prefetch', 'search', and 'manifest' as
     column types; these take the CSV output of 'gather', 'prefetch',
     'search', and 'manifest' as picklists. 'column' must be left
-    blank in this case: e.g. use 'pickfile.csv::gather'.
+    blank in this case: e.g. use 'pickfile.csv::gather'. These "meta-coltypes"
+    use composite selection on (ident, md5short) tuples.
     """
     meta_coltypes = ('manifest', 'gather', 'prefetch', 'search')
     supported_coltypes = ('md5', 'md5prefix8', 'md5short',
@@ -79,7 +90,7 @@ class SignaturePicklist:
         self.orig_coltype = coltype
         self.orig_colname = column_name
 
-        # if we're using gather or prefetch or manifest, set column_name
+        # if we're using gather, prefetch, manifest, or search, set column_name
         # automatically (after checks).
         if coltype in self.meta_coltypes:
             if column_name:

--- a/src/sourmash/sourmash_args.py
+++ b/src/sourmash/sourmash_args.py
@@ -125,7 +125,7 @@ def load_picklist(args):
 
             notify(f"picking column '{picklist.column_name}' of type '{picklist.coltype}' from '{picklist.pickfile}'")
 
-            n_empty_val, dup_vals = picklist.load(picklist.pickfile, picklist.column_name)
+            n_empty_val, dup_vals = picklist.load()
         except ValueError as exc:
             error("ERROR: could not load picklist.")
             error(str(exc))

--- a/tests/test_cmd_signature.py
+++ b/tests/test_cmd_signature.py
@@ -2689,7 +2689,7 @@ def test_sig_extract_12_picklist_bad_pickstyle(runtmp):
 
     err = runtmp.last_result.err
     print(err)
-    assert "invalid picklist 'pickstyle' argument, 'XXX': must be 'include' or 'exclude'" in err
+    assert "invalid picklist 'pickstyle' argument 4: 'XXX' must be 'include' or 'exclude'" in err
 
 
 def test_sig_extract_12_picklist_bad_colname(runtmp):

--- a/tests/test_cmd_signature.py
+++ b/tests/test_cmd_signature.py
@@ -2764,6 +2764,31 @@ def test_sig_extract_11_pattern_exclude(runtmp):
         assert 'shewanella' not in n.lower(), n
 
 
+def test_sig_extract_identical_md5s(runtmp):
+    # test that we properly handle different signatures with identical md5s
+    sig47 = utils.get_test_data('47.fa.sig')
+    ss = load_signatures(sig47)
+    sig = list(ss)[0]
+    new_sig = sig.to_mutable()
+    new_sig.name = 'foo'
+    sig47foo = runtmp.output('foo.sig')
+    # this was only a problem when the signatures are stored in the same file
+    with open(sig47foo, 'wt') as fp:
+        sourmash.save_signatures([new_sig, sig], fp)
+
+    runtmp.run_sourmash('sig', 'extract', '--name', 'foo', sig47foo)
+
+    out = runtmp.last_result.out
+    print(out)
+    ss = load_signatures(out)
+    ss = list(ss)
+    assert len(ss) == 1
+    ss = ss[0]
+    assert 'Shewanella' not in ss.name
+    assert 'foo' in ss.name
+    assert ss.md5sum() == '09a08691ce52952152f0e866a59f6261'
+
+
 def test_sig_flatten_1(runtmp):
     c = runtmp
 

--- a/tests/test_cmd_signature_grep.py
+++ b/tests/test_cmd_signature_grep.py
@@ -387,3 +387,26 @@ def test_sig_grep_8_count(runtmp):
 2 matches: prot/protein.zip
 """.splitlines():
         assert line.strip() in out
+
+def test_sig_grep_identical_md5s(runtmp):
+    # test that we properly handle different signatures with identical md5s
+    sig47 = utils.get_test_data('47.fa.sig')
+    ss = load_signatures(sig47)
+    sig = list(ss)[0]
+    new_sig = sig.to_mutable()
+    new_sig.name = 'foo'
+    sig47foo = runtmp.output('foo.sig')
+    # this was only a problem when the signatures are stored in the same file
+    with open(sig47foo, 'wt') as fp:
+        sourmash.save_signatures([new_sig, sig], fp)
+
+    runtmp.run_sourmash('sig', 'grep', '-i', 'foo', sig47foo)
+
+    out = runtmp.last_result.out
+    ss = load_signatures(out)
+    ss = list(ss)
+    assert len(ss) == 1
+    ss = ss[0]
+    assert 'Shewanella' not in ss.name
+    assert 'foo' in ss.name
+    assert ss.md5sum() == '09a08691ce52952152f0e866a59f6261'

--- a/tests/test_cmd_signature_grep.py
+++ b/tests/test_cmd_signature_grep.py
@@ -388,6 +388,7 @@ def test_sig_grep_8_count(runtmp):
 """.splitlines():
         assert line.strip() in out
 
+
 def test_sig_grep_identical_md5s(runtmp):
     # test that we properly handle different signatures with identical md5s
     sig47 = utils.get_test_data('47.fa.sig')

--- a/tests/test_lca.py
+++ b/tests/test_lca.py
@@ -2971,7 +2971,7 @@ def test_lca_index_select_with_picklist(runtmp, lca_db_format):
 
     idx = sourmash.load_file_as_index(outdb)
     picklist_obj = SignaturePicklist.from_picklist_args(f"{picklist}:md5:md5")
-    picklist_obj.load(picklist_obj.pickfile, picklist_obj.column_name)
+    picklist_obj.load()
 
     idx = idx.select(picklist=picklist_obj)
 
@@ -3002,7 +3002,7 @@ def test_lca_index_select_with_picklist_exclude(runtmp, lca_db_format):
 
     idx = sourmash.load_file_as_index(outdb)
     picklist_obj = SignaturePicklist.from_picklist_args(f"{picklist}:md5:md5:exclude")
-    picklist_obj.load(picklist_obj.pickfile, picklist_obj.column_name)
+    picklist_obj.load()
     idx = idx.select(picklist=picklist_obj)
 
     siglist = list(idx.signatures())

--- a/tests/test_picklist.py
+++ b/tests/test_picklist.py
@@ -59,6 +59,6 @@ def test_dup_md5_picked(runtmp):
 
     # use in select
     ml3 = ml2.select(picklist=pl)
-    print(len(ml3))
+    print('picked:', len(ml3))
 
-    assert 0
+    assert len(pl.pickset) == len(ml3)

--- a/tests/test_picklist.py
+++ b/tests/test_picklist.py
@@ -15,16 +15,16 @@ from sourmash.index import LinearIndex, MultiIndex
 def test_load_empty_picklist_fail():
     empty = utils.get_test_data('picklist/empty.csv')
 
-    pl = SignaturePicklist('manifest')
+    pl = SignaturePicklist('manifest', pickfile=empty)
     with pytest.raises(ValueError):
-        pl.load(empty, 'foo', allow_empty=False)
+        pl.load(allow_empty=False)
 
 
 def test_load_empty_picklist_allow():
     empty = utils.get_test_data('picklist/empty.csv')
 
-    pl = SignaturePicklist('manifest')
-    pl.load(empty, 'foo', allow_empty=True)
+    pl = SignaturePicklist('manifest', pickfile=empty)
+    pl.load(allow_empty=True)
 
 
 def test_dup_md5_picked(runtmp):
@@ -54,7 +54,7 @@ def test_dup_md5_picked(runtmp):
 
     # create a picklist...
     pl = SignaturePicklist('manifest', pickfile=mf_csv)
-    print(pl.load(mf_csv, pl.column_name))
+    print(pl.load())
     print('loaded:', len(pl.pickset))
 
     # use in select

--- a/tests/test_picklist.py
+++ b/tests/test_picklist.py
@@ -10,6 +10,7 @@ import sourmash_tst_utils as utils
 from sourmash import picklist
 from sourmash.picklist import SignaturePicklist
 from sourmash.index import LinearIndex, MultiIndex
+from sourmash.index.sqlite_index import SqliteIndex
 
 
 def test_load_empty_picklist_fail():
@@ -28,7 +29,7 @@ def test_load_empty_picklist_allow():
 
 
 def test_dup_md5_picked(runtmp):
-    # load a sig, duplicate
+    # load a sig, duplicate, and see if a picklist gets the right one
     sig47 = utils.get_test_data('47.fa.sig')
     ss = sourmash.load_signatures(sig47)
     sig = list(ss)[0]
@@ -58,6 +59,70 @@ def test_dup_md5_picked(runtmp):
     print('loaded:', len(pl.pickset))
 
     # use in select
+    ml3 = ml2.select(picklist=pl)
+    print('picked:', len(ml3))
+
+    assert len(pl.pickset) == len(ml3)
+
+
+def test_dup_md5_picked_mf_to_picklist(runtmp):
+    # load a sig, duplicate, and see if a picklist gets the right one
+    # uses an in memory picklist
+    sig47 = utils.get_test_data('47.fa.sig')
+    ss = sourmash.load_signatures(sig47)
+    sig = list(ss)[0]
+
+    # save a manifest with one entry
+    xl = LinearIndex([sig])
+    ml = MultiIndex.load([xl], [None], None)
+
+    print(ml.manifest.rows)
+    assert len(ml.manifest) == 1
+
+    pl = ml.manifest.to_picklist()
+
+    # now make an index to select against, with an identical signature
+    # (but diff name)
+    new_sig = sig.to_mutable()
+    new_sig.name = 'foo'
+    xl = LinearIndex([sig, new_sig])
+    ml2 = MultiIndex.load([xl], [None], None)
+
+    assert len(ml2) == 2
+
+    # use picklist in select
+    ml3 = ml2.select(picklist=pl)
+    print('picked:', len(ml3))
+
+    assert len(pl.pickset) == len(ml3)
+
+
+def test_dup_md5_picked_mf_to_picklist_sqlite(runtmp):
+    # load a sig, duplicate, and see if a picklist gets the right one
+    # use a sqlite db with its own to_picklist behavior.
+    sig47 = utils.get_test_data('47.fa.sig')
+    ss = sourmash.load_signatures(sig47)
+    sig = list(ss)[0]
+
+    # save a manifest with one entry
+    xl = SqliteIndex.create(':memory:')
+    xl.insert(sig)
+
+    print(xl.manifest.rows)
+    assert len(xl.manifest) == 1
+
+    pl = xl.manifest.to_picklist()
+
+    # now make an index to select against, with an identical signature
+    # (but diff name)
+    new_sig = sig.to_mutable()
+    new_sig.name = 'foo'
+    xl = LinearIndex([sig, new_sig])
+    ml2 = MultiIndex.load([xl], [None], None)
+
+    assert len(ml2) == 2
+
+    # use picklist in select
     ml3 = ml2.select(picklist=pl)
     print('picked:', len(ml3))
 


### PR DESCRIPTION
This PR changes picklists using `manifest`, `prefetch`, `search`, and `gather` coltypes to use a composite tuple of `(ident, md5short)` for selection. This should have essentially zero false positives, unlike the current behavior (which relies solely on md5).

The basic problem solved: when two signatures with different signature metadata (name, etc) but the same md5sum were in a single index, grepping/extracting via metadata (e.g. with a name) would return all signatures with matching md5sum.

This PR fixes this behavior, and also cleans up `SignaturePicklist` a fair bit.

The only potential downsides:
* the memory size of picklists will increase because it is storing `ident` not just `md5`
* `name`/`ident` takes on more official meaning in sourmash (as in, they should be meaningful or at least distinct)

Fixes #2617
Fixes https://github.com/sourmash-bio/sourmash/issues/2593
Closes https://github.com/sourmash-bio/sourmash/pull/2602