### PR TITLE
MRG: add `__all__` to `sig/__main__.py`

### DIFF
--- a/src/sourmash/sig/__main__.py
+++ b/src/sourmash/sig/__main__.py
@@ -1,6 +1,27 @@
 """
 Command-line entry point for 'python -m sourmash.sig'
 """
+__all__ = ["cat",
+           "split",
+           "describe",
+           "manifest",
+           "overlap",
+           "merge",
+           "intersect",
+           "inflate",
+           "subtract",
+           "rename",
+           "extract",
+           "filter",
+           "flatten",
+           "downsample",
+           "sig_import",
+           "export",
+           "kmers",
+           "fileinfo",
+           "check",
+           "collect"]
+
 import sys
 import csv
 import json


### PR DESCRIPTION
This change limits what is imported with `from sourmash.sig.__main__ import *`.

Fixes https://github.com/sourmash-bio/sourmash/issues/2714