### PR TITLE
MRG: update more text to suggest `sourmash tax` / deprecate `sourmash lca`

### DIFF
--- a/doc/command-line.md
+++ b/doc/command-line.md
@@ -373,10 +373,9 @@ collection itself.
 
 Note:
 
-Use `sourmash gather` to classify a metagenome against a collection of
-genomes with no (or incomplete) taxonomic information.  Use `sourmash
-lca summarize` to classify a metagenome using a collection of genomes
-with taxonomic information.
+Use `sourmash gather` to analyze a metagenome against a collection of
+genomes.  Then use `sourmash tax metagenome` to integrate that collection
+of genomes with taxonomic information.
 
 #### Alternative search mode for low-memory (but slow) search: `--linear`
 


### PR DESCRIPTION
This PR further updates the command-line docs and the classifying-signatures docs to deprecate LCA.

Fixes https://github.com/sourmash-bio/sourmash/issues/2779
