### PR TITLE
MRG: update docs for tax grep: only searches tax

### DIFF
--- a/doc/command-line.md
+++ b/doc/command-line.md
@@ -1041,6 +1041,9 @@ superkingdom, phylum, class, order, family, genus, and species.
 to ignore case and `-v` to output only taxonomic lineages that do
 _not_ match the pattern.
 
+Note: `tax grep` only searches taxonomic ranks, not identifier strings.
+Use `sig grep` to search for identifiers in sketch collections.
+
 Currently only CSV output (optionally gzipped) is supported; use `sourmash tax prepare` to
 convert CSV output from `tax grep` into a sqlite3 taxonomy database.
 

--- a/src/sourmash/cli/tax/grep.py
+++ b/src/sourmash/cli/tax/grep.py
@@ -1,4 +1,4 @@
-"""search taxonomies and output picklists.."""
+"""search taxonomies and output picklists."""
 
 usage="""
 
@@ -8,6 +8,9 @@ usage="""
 optionally restricting the string search to a specific taxonomic rank.
 It creates new files containing matching taxonomic entries; these new
 files can serve as taxonomies and can also be used as picklists.
+
+`tax grep` only searches taxonomic ranks, not identifier strings.
+Use `sig grep` to search for identifiers in sketch collections.
 
 Please see the 'tax grep' documentation for more details:
   https://sourmash.readthedocs.io/en/latest/command-line.html#sourmash-tax-grep-subset-taxonomies-and-create-picklists-based-on-taxonomy-string-matches


### PR DESCRIPTION
Updates `tax grep` documentation to make it clear that it only searches taxonomic
ranks, not identifiers; `sig grep` searches sketch names.

Fixes https://github.com/sourmash-bio/sourmash/issues/2607