### PR TITLE
MRG: chrono version pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "maturin>=1,<2",
+    "maturin>=1,<1.3.0",
     "cffi",
 ]
 build-backend = 'maturin'

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -97,7 +97,7 @@ version = "0.3.64"
 features = ["console", "File"]
 
 [target.'cfg(all(target_arch = "wasm32"))'.dependencies.chrono]
-version = "0.4.31"
+version = "0.4.28"
 features = ["wasmbind"]
 
 [target.'cfg(all(target_arch = "wasm32", target_os="unknown"))'.dev-dependencies]


### PR DESCRIPTION
To install sourmash from mastiff branch in pyo3-branchwater, I need to bump chrono back to 0.4.28 (from 0.4.31) to avoid incompatibilities with `piz`. 

but maybe you have a better solution, @luizirber?