### PR TITLE
EXP: try pinning maturin to <1.3.0 to fix dev build CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "maturin>=1,<2",
+    "maturin>=1,<1.3.0",
     "cffi",
 ]
 build-backend = 'maturin'


### PR DESCRIPTION
As of 17 hours ago (so, like, midnight PDT on Oct 2?), "Dev env instructions" build is failing. 

The error might belong to maturin - here is the message:
```
Processing ./.tox/.tmp/package/1/sourmash-4.8.5.dev0.tar.gz
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'done'
  Preparing metadata (pyproject.toml): started
  Preparing metadata (pyproject.toml): finished with status 'error'
  error: subprocess-exited-with-error
  
  × Preparing metadata (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [12 lines of output]
      error: current package believes it's in a workspace when it's not:
      current:   /tmp/pip-req-build-x9u8ulfq/src/core/Cargo.toml
      workspace: /tmp/pip-req-build-x9u8ulfq/Cargo.toml
      
      this may be fixable by adding `src/core` to the `workspace.members` array of the manifest located at: /tmp/pip-req-build-x9u8ulfq/Cargo.toml
      Alternatively, to keep it out of the workspace, add the package to the `workspace.exclude` array, or add an empty `[workspace]` table to the package's manifest.
      💥 maturin failed
        Caused by: Cargo metadata failed. Does your crate compile with `cargo build`?
        Caused by: `cargo metadata` exited with an error:
      Error running maturin: Command '['maturin', 'pep517', 'write-dist-info', '--metadata-directory', '/tmp/pip-modern-metadata-v0x443be', '--interpreter', '/home/runner/work/sourmash/sourmash/.tox/py39/bin/python']' returned non-zero exit status 1.
      Checking for Rust toolchain....
      Running `maturin pep517 write-dist-info --metadata-directory /tmp/pip-modern-metadata-v0x443be --interpreter /home/runner/work/sourmash/sourmash/.tox/py39/bin/python`
      [end of output]
```

Looking at the maturin releases, v1.3.0 was released yesterday, so maybe that's the problem? Trying out this PR as a temporary fix.
