### PR TITLE
CI: Fix wheel building and semver checks post r0.12.0

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -234,6 +234,8 @@ jobs:
         with:
           crate-name: sourmash
           version-tag-prefix: r
+          feature-group: default-features
+          features: branchwater
 
       - name: Make sure we can publish the sourmash crate
         uses: actions-rs/cargo@v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,7 +164,7 @@ known_first_party = ["sourmash"]
 
 [tool.cibuildwheel]
 build = "cp310-*"
-skip = "*-win32 *-manylinux_i686 *-musllinux_*"
+skip = "*-win32 *-manylinux_i686 *-musllinux_* *-ppc64le *-s390x"
 before-all = [
   "curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain=stable",
   "cargo update --dry-run",


### PR DESCRIPTION
`latest` checks are broken due to a misconfiguration of `cargo-semver-checks` and trying to build wheels for platforms where rocksdb is not being built yet (`ppc64le` and `s390x`).