### PR TITLE
Deps: update typed-builder and histogram, bump MSRV to 1.65

### DIFF
--- a/.github/workflows/build_wheel_all_archs.yml
+++ b/.github/workflows/build_wheel_all_archs.yml
@@ -16,8 +16,8 @@ jobs:
       matrix:
         build: [
           linux-aarch64,
-          linux-ppc64le,
-          linux-s390x,
+          #linux-ppc64le,
+          #linux-s390x,
         ]
         include:
           - build: linux-aarch64

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -250,11 +250,11 @@ jobs:
 
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: "1.64.0"
+          toolchain: "1.65.0"
           override: true
 
       - name: check if README matches MSRV defined here
-        run: grep '1.64.0' src/core/README.md
+        run: grep '1.65.0' src/core/README.md
 
       - name: Check if it builds properly
         uses: actions-rs/cargo@v1

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,7 +8,7 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.10"
-    rust: "1.64"
+    rust: "1.70"
   apt_packages:
     - llvm-dev
     - libclang-dev

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -639,9 +639,12 @@ checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
 
 [[package]]
 name = "histogram"
-version = "0.6.9"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12cb882ccb290b8646e554b157ab0b71e64e8d5bef775cd66b6531e52d302669"
+checksum = "72cc09ccef50843ffa24cfc42861950fd45a2b377cc4b66c49ac47d17449f144"
+dependencies = [
+ "thiserror",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -1598,13 +1601,22 @@ dependencies = [
 
 [[package]]
 name = "typed-builder"
-version = "0.14.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64cba322cb9b7bc6ca048de49e83918223f35e7a86311267013afff257004870"
+checksum = "e47c0496149861b7c95198088cbf36645016b1a0734cf350c50e2a38e070f38a"
+dependencies = [
+ "typed-builder-macro",
+]
+
+[[package]]
+name = "typed-builder-macro"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "982ee4197351b5c9782847ef5ec1fdcaf50503fb19d68f9771adae314e72b492"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.104",
+ "syn 2.0.23",
 ]
 
 [[package]]

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1700014976,
-        "narHash": "sha256-dSGpS2YeJrXW5aH9y7Abd235gGufY3RuZFth6vuyVtU=",
+        "lastModified": 1701589523,
+        "narHash": "sha256-7LK019+Y9khM18WjIt4ISK2yd1P5z+CXJq0ts+E13UA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "592047fc9e4f7b74a4dc85d1b9f5243dfe4899e3",
+        "rev": "ec04772e7516b6d58d98b491e68b329b7558b14d",
         "type": "github"
       },
       "original": {
@@ -33,11 +33,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1700084394,
-        "narHash": "sha256-ZPvcR/TBpKTDXtjVfuQP3ntHnRl1ZX8DUYJX+/qTzcc=",
+        "lastModified": 1701569797,
+        "narHash": "sha256-ObvQFAPpC5IVbI2GHedSTQVzYxht2qhBgHHQnh3mYTs=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "c1125ef3963884cc5bc534ba752baaf2af835dac",
+        "rev": "516c9477757b628b157780d96d84e8c82b46dc99",
         "type": "github"
       },
       "original": {

--- a/src/core/CHANGELOG.md
+++ b/src/core/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+Fixed:
+
+- CI: Fix wheel building and semver checks post r0.12.0 (#2857)
+
 ## [0.12.0] - 2023-11-26
 
 MSRV: 1.64

--- a/src/core/CHANGELOG.md
+++ b/src/core/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Fixed:
 
+- Deps: update typed-builder and histogram, bump MSRV to 1.65 (#2858)
 - CI: Fix wheel building and semver checks post r0.12.0 (#2857)
 
 ## [0.12.0] - 2023-11-26

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 readme = "README.md"
 autoexamples = false
 autobins = false
-rust-version = "1.64.0"
+rust-version = "1.65.0"
 
 [lib]
 name = "sourmash"
@@ -37,7 +37,7 @@ finch = { version = "0.6.0", optional = true }
 fixedbitset = "0.4.0"
 getrandom = { version = "0.2", features = ["js"] }
 getset = "0.1.1"
-histogram = "0.6.9"
+histogram = "0.8.3"
 log = "0.4.20"
 md5 = "0.7.0"
 memmap2 = "0.9.0"
@@ -56,7 +56,7 @@ serde = { version = "1.0.168", features = ["derive"] }
 serde_json = "1.0.108"
 thiserror = "1.0"
 twox-hash = "1.6.0"
-typed-builder = "0.14.0"
+typed-builder = "0.18.0"
 vec-collections = "0.4.3"
 
 [dev-dependencies]

--- a/src/core/README.md
+++ b/src/core/README.md
@@ -38,4 +38,4 @@ Development happens on github at
 
 ## Minimum supported Rust version
 
-Currently the minimum supported Rust version is 1.64.0.
+Currently the minimum supported Rust version is 1.65.0.

--- a/src/core/src/index/revindex/mod.rs
+++ b/src/core/src/index/revindex/mod.rs
@@ -414,7 +414,8 @@ fn stats_for_cf(db: Arc<DB>, cf_name: &str, deep_check: bool, quick: bool) -> Db
     let iter = db.iterator_cf(&cf, rocksdb::IteratorMode::Start);
     let mut kcount = 0;
     let mut vcount = 0;
-    let mut vcounts = Histogram::new();
+    // Using power values from https://docs.rs/histogram/0.8.3/histogram/struct.Config.html#resulting-size
+    let mut vcounts = Histogram::new(12, 64).expect("Error initializing histogram");
     let mut datasets: Datasets = Default::default();
 
     for result in iter {


### PR DESCRIPTION
Small MSRV bump to move to newer versions of `typed-builder` and `histogram`.

Update nix flake deps.

Also disable CI jobs from #2857 until wheel building is fixed.