### PR TITLE
CI: macos deployment target and maturin updates

### DIFF
--- a/.github/workflows/build_wheel_all_archs.yml
+++ b/.github/workflows/build_wheel_all_archs.yml
@@ -18,7 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        target: [aarch64, s390x, ppc64le]
+        target: [aarch64, ppc64le]
+        #target: [aarch64, s390x, ppc64le]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -32,9 +33,10 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist --find-interpreter
+          args: --release --out dist --find-interpreter --zig
           sccache: 'true'
           manylinux: auto
+          container: 'off'
 
       - name: Upload wheels
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build_wheel_all_archs.yml
+++ b/.github/workflows/build_wheel_all_archs.yml
@@ -33,7 +33,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist --find-interpreter --zig
+          args: --release --out dist --find-interpreter --zig --strip
           sccache: 'true'
           manylinux: auto
           container: 'off'

--- a/.github/workflows/build_wheel_all_archs.yml
+++ b/.github/workflows/build_wheel_all_archs.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
 
-  build_wheels:
+  linux:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -44,11 +44,34 @@ jobs:
           name: wheels
           path: dist
 
+  windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+          architecture: ${{ matrix.target }}
+
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          target: x64
+          args: --release --out dist --find-interpreter
+          sccache: 'true'
+
+      - name: Upload wheels
+        uses: actions/upload-artifact@v3
+        with:
+          name: wheels
+          path: dist
+
   release:
     name: Publish wheels
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: build_wheels
+    needs: [linux, windows]
 
     steps:
       - name: Fetch wheels from artifacts

--- a/.github/workflows/build_wheel_all_archs.yml
+++ b/.github/workflows/build_wheel_all_archs.yml
@@ -1,77 +1,50 @@
-name: cibuildwheel_ubuntu
+name: maturin wheels
 
 on:
-  #pull_request:        # use for testing modifications to this action
+  pull_request:        # use for testing modifications to this action
   push:
     branches: [latest]
     tags: v*
+  workflow_dispatch:
   schedule:
     - cron: "0 0 * * *" # daily
 
+permissions:
+  contents: read
+
 jobs:
+
   build_wheels:
-    name: Build wheels for ${{ matrix.os }}-${{ matrix.arch }}
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        build: [
-          linux-aarch64,
-          #linux-ppc64le,
-          #linux-s390x,
-        ]
-        include:
-          - build: linux-aarch64
-            os: ubuntu-20.04
-            arch: aarch64
-            macos_target: ''
-      fail-fast: false
-
+        target: [aarch64, s390x, ppc64le]
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - uses: actions/setup-python@v5
-        name: Install Python
         with:
           python-version: '3.10'
 
-      # Added due to weird error when building inside docker container
-      # for other platforms...
-      # https://github.com/JonasAlfredsson/docker-nginx-certbot/issues/30
-      - name: Set Swap Space
-        if: runner.os == 'Linux'
-        uses: pierotofy/set-swap-space@v1.0
-        with:
-          swap-size-gb: 10
-      - run: |
-          # Workaround for https://github.com/rust-lang/cargo/issues/8719
-          sudo mkdir -p /var/lib/docker
-          sudo mount -t tmpfs -o size=10G none /var/lib/docker
-          sudo systemctl restart docker
-        if: runner.os == 'Linux'
-
-      - name: Set up QEMU
-        if: runner.os == 'Linux'
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: all
-
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.2
-        env:
-          CIBW_ENVIRONMENT_MACOS: ${{ matrix.macos_target }}
-          CIBW_ARCHS_LINUX: ${{ matrix.arch }}
-          CIBW_ARCHS_MACOS: ${{ matrix.arch }}
-          CARGO_NET_GIT_FETCH_WITH_CLI: true
-
-      - uses: actions/upload-artifact@v3
+        uses: PyO3/maturin-action@v1
         with:
-          path: './wheelhouse/sourmash*.whl'
+          target: ${{ matrix.target }}
+          args: --release --out dist --find-interpreter
+          sccache: 'true'
+          manylinux: auto
+
+      - name: Upload wheels
+        uses: actions/upload-artifact@v3
+        with:
+          name: wheels
+          path: dist
 
   release:
     name: Publish wheels
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
     needs: build_wheels
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "maturin>=1,<1.3.0",
+    "maturin>=1,<1.5.0",
     "cffi",
 ]
 build-backend = 'maturin'
@@ -150,7 +150,7 @@ module-name = "sourmash._lowlevel"
 
 # macOS deployment target SDK version
 [tool.maturin.target.x86_64-apple-darwin]
-macos-deployment-target = "11.0"
+macos-deployment-target = "10.14"
 [tool.maturin.target.aarch64-apple-darwin]
 macos-deployment-target = "11.0"
 


### PR DESCRIPTION
- macOS fixes from https://github.com/conda-forge/sourmash-minimal-feedstock/pull/55
- bump maturin to 1.4.0
- use maturin-action for linux `aarch64` and `ppc64le` (`s390x` is still annoying to get right) and windows (turns out it just works)