### PR TITLE
MRG: fix uploading of wheels after upload-artifact upgrade.

### DIFF
--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -81,6 +81,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
+          name: binary-${{ matrix.build }}-${{ matrix.os }}
           path: './dist/sourmash*.whl'
 
 

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -53,6 +53,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
+          name: binary-${{ matrix.build }}-${{ matrix.os }}
           path: './wheelhouse/sourmash*.whl'
 
   build_wasm:

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -53,7 +53,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: binary-${{ matrix.build }}-${{ matrix.os }}
+          name: wheel-${{ matrix.build }}-${{ matrix.os }}
           path: './wheelhouse/sourmash*.whl'
 
   build_wasm:
@@ -82,7 +82,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: binary-${{ matrix.build }}-${{ matrix.os }}
+          name: wheel-wasm
           path: './dist/sourmash*.whl'
 
 

--- a/.github/workflows/build_wheel_all_archs.yml
+++ b/.github/workflows/build_wheel_all_archs.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: wheels-${{ matrix.target }}
           path: dist
 
   windows:

--- a/.github/workflows/build_wheel_all_archs.yml
+++ b/.github/workflows/build_wheel_all_archs.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: wheels-${{ matrix.target }}
+          name: wheel-${{ matrix.target }}
           path: dist
 
   windows:
@@ -64,7 +64,7 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: wheel-win64
           path: dist
 
   release:


### PR DESCRIPTION
This fixes a problem introduced by https://github.com/sourmash-bio/sourmash/pull/2883, via the solution mentioned [here](https://github.com/actions/upload-artifact#not-uploading-to-the-same-artifact) of naming artifacts using matrix variables.

The output artifacts from the updated `build_wheel.yml` are:
<img width="1062" alt="Screenshot 2023-12-19 at 1 41 24 PM" src="https://github.com/sourmash-bio/sourmash/assets/51016/55bed1f6-e2e0-40ba-8d66-f6216078256e">

The output artifacts from the updated `build_wheel_all_archs.yml`:
<img width="1080" alt="Screenshot 2023-12-19 at 1 43 01 PM" src="https://github.com/sourmash-bio/sourmash/assets/51016/3736f651-832b-468a-b2dd-ada6f866ad2b">

