### PR TITLE
nix updates for pyopensci review

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Pre-commit updates (#2427)
+fee62922d8857ce93f1d4e90fd7240629d606997

--- a/.github/workflows/dev_envs.yml
+++ b/.github/workflows/dev_envs.yml
@@ -5,25 +5,21 @@ on:
     branches: [latest]
 jobs:
   nix:
-    runs-on: ubuntu-latest
+    runs-on: [ubuntu-latest, macos-14]
     steps:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
-
-    - uses: cachix/install-nix-action@v25
-      with:
-        extra_nix_config: |
-          access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
-
-    - uses: cachix/cachix-action@v14
-      with:
-        name: sourmash-bio
-        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+    - name: Install Nix
+      uses: DeterminateSystems/nix-installer-action@v4
+    - name: Run the Magic Nix Cache
+      uses: DeterminateSystems/magic-nix-cache-action@v1
+    - name: flake checks
+      run: nix flake check --keep-going --print-build-logs
 
     - run: nix run .# -- --version
 
-    - run: nix-shell --command "tox -e py310"
+    - run: nix develop --command "tox -e py310"
 
   mamba:
     runs-on: ubuntu-latest

--- a/.github/workflows/dev_envs.yml
+++ b/.github/workflows/dev_envs.yml
@@ -5,17 +5,19 @@ on:
     branches: [latest]
 jobs:
   nix:
-    runs-on: [ubuntu-latest, macos-14]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-14]
     steps:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
+
     - name: Install Nix
       uses: DeterminateSystems/nix-installer-action@v4
     - name: Run the Magic Nix Cache
       uses: DeterminateSystems/magic-nix-cache-action@v1
-    - name: flake checks
-      run: nix flake check --keep-going --print-build-logs
 
     - run: nix run .# -- --version
 

--- a/.github/workflows/dev_envs.yml
+++ b/.github/workflows/dev_envs.yml
@@ -21,7 +21,7 @@ jobs:
 
     - run: nix run .# -- --version
 
-    - run: nix develop --command "tox -e py310"
+    - run: nix develop --command bash -c "tox -e py310"
 
   mamba:
     runs-on: ubuntu-latest

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1701589523,
-        "narHash": "sha256-7LK019+Y9khM18WjIt4ISK2yd1P5z+CXJq0ts+E13UA=",
+        "lastModified": 1706925685,
+        "narHash": "sha256-hVInjWMmgH4yZgA4ZtbgJM1qEAel72SYhP5nOWX4UIM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ec04772e7516b6d58d98b491e68b329b7558b14d",
+        "rev": "79a13f1437e149dc7be2d1290c74d378dad60814",
         "type": "github"
       },
       "original": {
@@ -33,11 +33,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1701569797,
-        "narHash": "sha256-ObvQFAPpC5IVbI2GHedSTQVzYxht2qhBgHHQnh3mYTs=",
+        "lastModified": 1707099356,
+        "narHash": "sha256-ph483MDKLi9I/gndYOieVP41es633DOOmPjEI50x5KU=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "516c9477757b628b157780d96d84e8c82b46dc99",
+        "rev": "61dfa5a8129f7edbe9150253c68f673f87b16fb1",
         "type": "github"
       },
       "original": {
@@ -66,11 +66,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1694529238,
-        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "lastModified": 1705309234,
+        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,28 @@
           rustc = rustVersion;
         };
 
+        inherit (pkgs) lib;
+
         python = pkgs.python311Packages;
+
+        stdenv = if pkgs.stdenv.isDarwin then pkgs.overrideSDK pkgs.stdenv "11.0" else pkgs.stdenv;
+
+        commonArgs = {
+          src = ./.;
+          stdenv = stdenv;
+          preConfigure = lib.optionalString stdenv.isDarwin ''
+            export MACOSX_DEPLOYMENT_TARGET=10.14
+          '';
+
+          # Work around https://github.com/NixOS/nixpkgs/issues/166205.
+          env = lib.optionalAttrs stdenv.cc.isClang {
+            NIX_LDFLAGS = "-l${stdenv.cc.libcxx.cxxabi.libName}";
+          };
+
+          buildInputs = lib.optionals stdenv.isDarwin [ pkgs.libiconv pkgs.darwin.apple_sdk.frameworks.Security ];
+
+          nativeBuildInputs = with rustPlatform; [ cargoSetupHook maturinBuildHook bindgenHook ];
+        };
 
       in
 
@@ -38,32 +59,26 @@
       {
         packages = {
 
-          lib = rustPlatform.buildRustPackage {
+          lib = rustPlatform.buildRustPackage ( commonArgs // {
             name = "libsourmash";
-            src = lib.cleanSource ./.;
             copyLibs = true;
             cargoLock.lockFile = ./Cargo.lock;
             nativeBuildInputs = with rustPlatform; [ bindgenHook ];
-          };
+          });
 
-          sourmash = python.buildPythonPackage rec {
+          sourmash = python.buildPythonPackage ( commonArgs // rec {
             pname = "sourmash";
             version = "4.8.6-dev";
             format = "pyproject";
-
-            src = ./.;
 
             cargoDeps = rustPlatform.importCargoLock {
               lockFile = ./Cargo.lock;
             };
 
-            nativeBuildInputs = with rustPlatform; [ cargoSetupHook maturinBuildHook bindgenHook ];
-
-            buildInputs = lib.optionals stdenv.isDarwin [ libiconv ];
             propagatedBuildInputs = with python; [ cffi deprecation cachetools bitstring numpy scipy matplotlib screed ];
 
             DYLD_LIBRARY_PATH = "${self.packages.${system}.lib}/lib";
-          };
+          });
 
           docker =
             let
@@ -83,7 +98,7 @@
 
         defaultPackage = self.packages.${system}.sourmash;
 
-        devShell = mkShell {
+        devShells.default = pkgs.mkShell.override { stdenv = stdenv; } (commonArgs // {
           nativeBuildInputs = with rustPlatform; [ bindgenHook ];
 
           buildInputs = [
@@ -113,15 +128,19 @@
             cargo-outdated
             cargo-udeps
             cargo-deny
-            cargo-semver-checks
+            #cargo-semver-checks
             nixpkgs-fmt
           ];
+
+          shellHook = ''
+              export MACOSX_DEPLOYMENT_TARGET=10.14
+            '';
 
           # Needed for matplotlib
           LD_LIBRARY_PATH = lib.makeLibraryPath [ pkgs.stdenv.cc.cc.lib ];
 
           # workaround for https://github.com/NixOS/nixpkgs/blob/48dfc9fa97d762bce28cc8372a2dd3805d14c633/doc/languages-frameworks/python.section.md#python-setuppy-bdist_wheel-cannot-create-whl
           SOURCE_DATE_EPOCH = 315532800; # 1980
-        };
+        });
       });
 }

--- a/tox.ini
+++ b/tox.ini
@@ -56,6 +56,7 @@ wheel_build_env = .pkg
 pass_env =
     LIBCLANG_PATH
     BINDGEN_EXTRA_CLANG_ARGS
+    NIX_*
 
 [testenv:pypy3]
 deps =


### PR DESCRIPTION
Fix #2905 #2907 

- Use `DeterminateSystems/nix-installer-action` and `DeterminateSystems/magic-nix-cache-action` for installing nix and caching
- Also run nix on macos-14 (arm64)
- run `nix develop` instead of `nix-shell` to mirror direnv