### PR TITLE
MRG: docs: add branchwater reference; make FAQ more visible

### DIFF
--- a/doc/faq.md
+++ b/doc/faq.md
@@ -302,6 +302,6 @@ lot of new k-mers that pop up with a longer k-mer size (e.g. because
 of included variation)? These questions must be answered by experimentation
 and may be data-set specific.
 
-## Can sourmash run multi-threaded?
+## Can sourmash run with multiple theads?
 
 sourmash is currently single-threaded, but the [branchwater plugin for sourmash](https://github.com/sourmash-bio/sourmash_plugin_branchwater) provides faster and lower-memory  multithreaded implementations of several important sourmash features - sketching, searching, and gather (metagenome decomposition). It does so by implementing higher-level functions in Rust on top of the core Rust library of sourmash. As a result it provides some of the same functionality as sourmash, but 10-100x faster and in 10x lower memory. Note that this code is functional and tested, but does not have all of the features of sourmash. Code and features will be integrated back into sourmash as they mature.

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -302,3 +302,6 @@ lot of new k-mers that pop up with a longer k-mer size (e.g. because
 of included variation)? These questions must be answered by experimentation
 and may be data-set specific.
 
+## Can sourmash run multi-threaded?
+
+sourmash is currently single-threaded, but the [branchwater plugin for sourmash](https://github.com/sourmash-bio/sourmash_plugin_branchwater) provides faster and lower-memory  multithreaded implementations of several important sourmash features - sketching, searching, and gather (metagenome decomposition). It does so by implementing higher-level functions in Rust on top of the core Rust library of sourmash. As a result it provides some of the same functionality as sourmash, but 10-100x faster and in 10x lower memory. Note that this code is functional and tested, but does not have all of the features of sourmash. Code and features will be integrated back into sourmash as they mature.

--- a/doc/index.md
+++ b/doc/index.md
@@ -58,6 +58,8 @@ sourmash is inspired by [mash](https://mash.readthedocs.io), and
 supports most mash analyses. sourmash also implements an expanded set
 of functionality for metagenome and taxonomic analysis.
 
+While sourmash is currently single-threaded, the [branchwater plugin for sourmash](https://github.com/sourmash-bio/sourmash_plugin_branchwater) provides faster and lower-memory implementations of several important sourmash features - sketching, searching, and gather (metagenome decomposition). It does so by implementing higher-level functions in Rust on top of the core Rust library of sourmash. As a result it provides some of the same functionality as sourmash, but 10-100x faster and in 10x lower memory. Note that this code is functional and tested, but does not have all of the features of sourmash. Code and features will be integrated back into sourmash as they mature.
+
 sourmash development was initiated with a grant from the Moore
 Foundation under the Data Driven Discovery program, and has been
 supported by further funding from the NIH and NSF. Please see
@@ -94,6 +96,10 @@ X and Linux. They require about 5 GB of disk space and 5 GB of RAM.
 
 * [A short guide to using sourmash output with R](other-languages.md).
 
+## Frequently Asked Questions
+
+* [Frequently asked questions](faq.md)
+
 ### How sourmash works under the hood
 
 * [An introduction to k-mers for genome comparison and analysis](kmers-and-minhash.ipynb)
@@ -128,6 +134,6 @@ hidden: true
 
 sidebar
 command-line
-api-example
 databases
+api-example
 ```

--- a/doc/index.md
+++ b/doc/index.md
@@ -58,7 +58,7 @@ sourmash is inspired by [mash](https://mash.readthedocs.io), and
 supports most mash analyses. sourmash also implements an expanded set
 of functionality for metagenome and taxonomic analysis.
 
-While sourmash is currently single-threaded, the [branchwater plugin for sourmash](https://github.com/sourmash-bio/sourmash_plugin_branchwater) provides faster and lower-memory implementations of several important sourmash features - sketching, searching, and gather (metagenome decomposition). It does so by implementing higher-level functions in Rust on top of the core Rust library of sourmash. As a result it provides some of the same functionality as sourmash, but 10-100x faster and in 10x lower memory. Note that this code is functional and tested, but does not have all of the features of sourmash. Code and features will be integrated back into sourmash as they mature.
+While sourmash is currently single-threaded, the [branchwater plugin for sourmash](https://github.com/sourmash-bio/sourmash_plugin_branchwater) provides faster and lower-memory multithreaded implementations of several important sourmash features - sketching, searching, and gather (metagenome decomposition). It does so by implementing higher-level functions in Rust on top of the core Rust library of sourmash. As a result it provides some of the same functionality as sourmash, but 10-100x faster and in 10x lower memory. Note that this code is functional and tested, but does not have all of the features of sourmash. Code and features will be integrated back into sourmash as they mature.
 
 sourmash development was initiated with a grant from the Moore
 Foundation under the Data Driven Discovery program, and has been

--- a/doc/sidebar.md
+++ b/doc/sidebar.md
@@ -25,6 +25,10 @@ X and Linux. They require about 5 GB of disk space and 5 GB of RAM.
 
 * [A short guide to using sourmash output with R](other-languages.md).
 
+## Frequently Asked Questions
+
+* [Frequently asked questions](faq.md)
+
 ## How sourmash works under the hood
 
 * [An introduction to k-mers for genome comparison and analysis](kmers-and-minhash.ipynb)
@@ -38,7 +42,6 @@ X and Linux. They require about 5 GB of disk space and 5 GB of RAM.
 * [Publications about sourmash](publications.md)
 * [A guide to the internal design and structure of sourmash](sourmash-internals.md)
 * [Funding acknowledgements](funding.md)
-* [Frequently asked questions](faq.md)
 
 ## Developing and extending sourmash
 


### PR DESCRIPTION
- fixes #2983 
- adds links to branchwater plugin

view draft docs: https://sourmash--2984.org.readthedocs.build/en/2984/