### PR TITLE
MRG: re-establish `tax` gather reading flexibility

### DIFF
--- a/src/sourmash/tax/tax_utils.py
+++ b/src/sourmash/tax/tax_utils.py
@@ -1733,6 +1733,11 @@ class GatherRow:
     match_containment_ani_low: float = None
     match_containment_ani_high: float = None
 
+    def __post_init__(self):
+        if 'match_name' in self.__dict__ and self.__dict__['match_name'] is not None:
+            if self.name is None: # if name wasn't provided, use match_name
+                self.name = self.__dict__['match_name']
+            del self.__dict__['match_name'] # rm bc not needed 
 
 @dataclass
 class QueryInfo:

--- a/src/sourmash/tax/tax_utils.py
+++ b/src/sourmash/tax/tax_utils.py
@@ -1721,32 +1721,10 @@ class GatherRow:
     ksize: int
     scaled: int
 
-    # non-essential
-    intersect_bp: int = None
-    f_orig_query: float = None
-    f_match: float = None
-    average_abund: float = None
-    median_abund: float = None
-    std_abund: float = None
-    filename: str = None
-    md5: str = None
-    f_match_orig: float = None
-    gather_result_rank: str = None
-    moltype: str = None
+    # non-essential, but used if available
     query_n_hashes: int = None
-    query_abundance: int = None
-    query_containment_ani: float = None
-    match_containment_ani: float = None
-    average_containment_ani: float = None
-    max_containment_ani: float = None
-    potential_false_negative: bool = None
-    n_unique_weighted_found: int = None
     sum_weighted_found: int = None
     total_weighted_hashes: int = None
-    query_containment_ani_low: float = None
-    query_containment_ani_high: float = None
-    match_containment_ani_low: float = None
-    match_containment_ani_high: float = None
 
 
 @dataclass

--- a/src/sourmash/tax/tax_utils.py
+++ b/src/sourmash/tax/tax_utils.py
@@ -742,7 +742,9 @@ def load_gather_results(
         for n, row in enumerate(r):
             # try reading each gather row into a TaxResult
             try:
-                filt_row = filter_row(row, GatherRow) # filter row first to allow extra (unused) columns in csv
+                filt_row = filter_row(
+                    row, GatherRow
+                )  # filter row first to allow extra (unused) columns in csv
                 gatherRow = GatherRow(**filt_row)
             except TypeError as exc:
                 raise ValueError(
@@ -1685,9 +1687,10 @@ def filter_row(row, dataclass_type):
     """
     valid_keys = {field.name for field in fields(dataclass_type)}
     # 'match_name' and 'name' should be interchangeable (sourmash 4.x)
-    if 'match_name' in row.keys() and 'name' not in row.keys():
-        row['name'] = row.pop('match_name')
+    if "match_name" in row.keys() and "name" not in row.keys():
+        row["name"] = row.pop("match_name")
     return {k: v for k, v in row.items() if k in valid_keys}
+
 
 @dataclass
 class GatherRow:

--- a/src/sourmash/tax/tax_utils.py
+++ b/src/sourmash/tax/tax_utils.py
@@ -1680,7 +1680,7 @@ def filter_row(row, dataclass_type):
     """
     Filter the row to only include keys that exist in the dataclass fields.
     This allows extra columns to be passed in with the gather csv while still
-    taking advantage of the type setting and checks that come with dataclass
+    taking advantage of the checks for required columns that come with dataclass
     initialization.
     """
     valid_keys = {field.name for field in fields(dataclass_type)}

--- a/tests/test_tax_utils.py
+++ b/tests/test_tax_utils.py
@@ -37,7 +37,7 @@ from sourmash.tax.tax_utils import (
     LineageDB,
     LineageDB_Sqlite,
     MultiLineageDB,
-    filter_row
+    filter_row,
 )
 
 

--- a/tests/test_tax_utils.py
+++ b/tests/test_tax_utils.py
@@ -37,6 +37,7 @@ from sourmash.tax.tax_utils import (
     LineageDB,
     LineageDB_Sqlite,
     MultiLineageDB,
+    filter_row
 )
 
 
@@ -93,7 +94,8 @@ def make_GatherRow(gather_dict=None, exclude_cols=[]):
         gatherD.update(gather_dict)
     for col in exclude_cols:
         gatherD.pop(col)
-    gatherRaw = GatherRow(**gatherD)
+    fgatherD = filter_row(gatherD, GatherRow)
+    gatherRaw = GatherRow(**fgatherD)
     return gatherRaw
 
 
@@ -805,6 +807,21 @@ def test_GatherRow_old_gather():
         make_GatherRow(gA, exclude_cols=["query_bp"])
     print(str(exc))
     assert "__init__() missing 1 required positional argument: 'query_bp'" in str(exc)
+
+
+def test_GatherRow_match_name_not_name():
+    # gather contains match_name but not name column
+    gA = {"match_name": "gA.1 name"}
+    grow = make_GatherRow(gA, exclude_cols=["name"])
+    print(grow)
+    assert grow.name == "gA.1 name"
+
+
+def test_GatherRow_extra_cols():
+    # gather contains extra columns
+    gA = {"not-a-col": "nope"}
+    grow = make_GatherRow(gA)
+    assert isinstance(grow, GatherRow)
 
 
 def test_get_ident_default():


### PR DESCRIPTION
A while back, I introduced `GatherRow` to handle checking for required gather columns for us. However, it ended up being overly restrictive -- any extra columns cause `gather_csv` reading to fail.

Here, I add a filtration step that lets us ignore unspecified columns entirely before reading a GatherRow. Initializing the GatherRow after this filtration continues to handle the checks for all required columns while restoring flexibility.

As a consequence, we can actually delete all the `non-essential` names in `GatherRow` and avoid carrying them around (saving some memory)