### PR TITLE
Fix tox and nix configs so all tox tests execute correctly

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -141,6 +141,9 @@
 
           # workaround for https://github.com/NixOS/nixpkgs/blob/48dfc9fa97d762bce28cc8372a2dd3805d14c633/doc/languages-frameworks/python.section.md#python-setuppy-bdist_wheel-cannot-create-whl
           SOURCE_DATE_EPOCH = 315532800; # 1980
+
+          # exporting to fix doc building errors in sphinx
+          LC_ALL="C.utf8";
         });
       });
 }

--- a/tox.ini
+++ b/tox.ini
@@ -91,7 +91,7 @@ commands =
 [testenv:khmer_master]
 basepython = python3.10
 deps =
-    -e
+    git+https://github.com/dib-lab/khmer.git\#egg
 commands =
     pytest \
       --cov "{envsitepackagesdir}/sourmash" \

--- a/tox.ini
+++ b/tox.ini
@@ -91,7 +91,7 @@ commands =
 [testenv:khmer_master]
 basepython = python3.10
 deps =
-    -e
+    -e 'git+https://github.com/dib-lab/khmer.git\#egg=khmer'
 commands =
     pytest \
       --cov "{envsitepackagesdir}/sourmash" \

--- a/tox.ini
+++ b/tox.ini
@@ -91,7 +91,7 @@ commands =
 [testenv:khmer_master]
 basepython = python3.10
 deps =
-    -e 'git+https://github.com/dib-lab/khmer.git\#egg=khmer'
+    -e
 commands =
     pytest \
       --cov "{envsitepackagesdir}/sourmash" \

--- a/tox.ini
+++ b/tox.ini
@@ -73,7 +73,7 @@ commands =
       --run-hypothesis \
       --hypothesis-show-statistics \
       --hypothesis-profile ci \
-      {posargs:.}
+      {posargs:doc tests}
 
 [testenv:khmer]
 basepython = python3.10
@@ -86,7 +86,7 @@ commands =
       --cov-report= \
       --junitxml {toxworkdir}/junit.{envname}.xml \
       -k test_nodegraph \
-      {posargs:.}
+      {posargs:doc tests}
 
 [testenv:khmer_master]
 basepython = python3.10
@@ -99,7 +99,7 @@ commands =
       --cov-report= \
       --junitxml {toxworkdir}/junit.{envname}.xml \
       -k test_nodegraph \
-      {posargs:.}
+      {posargs:doc tests}
 
 [testenv:asv]
 description = run asv for benchmarking (compare current commit with latest)
@@ -121,7 +121,10 @@ commands =
     python -c 'import pathlib; print("documentation available under file://\{0\}".format(pathlib.Path(r"{toxworkdir}") / "docs_out" / "index.html"))'
 allowlist_externals = pandoc
 change_dir = {toxinidir}
-pass_env = HOME
+pass_env =
+    HOME
+    LC_ALL
+    LOCALE_*
 
 [testenv:package_description]
 description = check that the long description is valid


### PR DESCRIPTION
Closes #2907

`tox -e docs` was failing due to missing env vars in tox.ini config
`tox -e khmer_master` fails to due to external errors now, it was missing the URL for installing latest version from github.

Also limit test discovery in `hypothesis`, `khmer`, and `khmer_master` to `doc tests`, avoiding going into `.tox` and other internal directories containing python code.