### PR TITLE
Use cargo llvm-cov for coverage reports

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -85,31 +85,21 @@ jobs:
 
   coverage:
     runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_COLOR: always
     steps:
       - uses: actions/checkout@v4
-
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-
-      - name: Install cargo-binstall
-        run: |
-          wget https://github.com/ryankurte/cargo-binstall/releases/latest/download/cargo-binstall-x86_64-unknown-linux-gnu.tgz
-          tar xf cargo-binstall-x86_64-unknown-linux-gnu.tgz
-          chmod +x cargo-binstall
-          mv cargo-binstall "$HOME/.cargo/bin"
-
-      - name: Install cargo-tarpaulin
-        run: cargo binstall --no-confirm cargo-tarpaulin
-
-      - name: Coverage with tarpaulin
-        run: cargo tarpaulin --all --all-features --timeout 600 --out xml -- --test-threads 1
-
-      - name: Upload Rust coverage to codecov
+      - name: Install Rust
+        run: rustup update stable
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Generate code coverage
+        run: cargo llvm-cov --all-features --workspace --codecov --output-path codecov.json
+      - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:
           flags: rust
+          files: codecov.json
           fail_ci_if_error: true
 
   lints:

--- a/flake.nix
+++ b/flake.nix
@@ -59,14 +59,14 @@
       {
         packages = {
 
-          lib = rustPlatform.buildRustPackage ( commonArgs // {
+          lib = rustPlatform.buildRustPackage (commonArgs // {
             name = "libsourmash";
             copyLibs = true;
             cargoLock.lockFile = ./Cargo.lock;
             nativeBuildInputs = with rustPlatform; [ bindgenHook ];
           });
 
-          sourmash = python.buildPythonPackage ( commonArgs // rec {
+          sourmash = python.buildPythonPackage (commonArgs // rec {
             pname = "sourmash";
             version = "4.8.6";
             format = "pyproject";
@@ -128,14 +128,15 @@
             cargo-outdated
             cargo-udeps
             cargo-deny
-            #cargo-semver-checks
             nixpkgs-fmt
+          ] ++ lib.optionals (!stdenv.isDarwin) [
+            cargo-semver-checks
             cargo-llvm-cov
           ];
 
           shellHook = ''
-              export MACOSX_DEPLOYMENT_TARGET=10.14
-            '';
+            export MACOSX_DEPLOYMENT_TARGET=10.14
+          '';
 
           # Needed for matplotlib
           LD_LIBRARY_PATH = lib.makeLibraryPath [ pkgs.stdenv.cc.cc.lib ];

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
           inherit system overlays;
         };
         rustVersion = pkgs.rust-bin.stable.latest.default.override {
-          #extensions = [ "rust-src" ];
+          extensions = [ "rust-src" "llvm-tools-preview" ];
           #targets = [ "x86_64-unknown-linux-musl" ];
           targets = [ "wasm32-wasi" "wasm32-unknown-unknown" "wasm32-unknown-emscripten" ];
         };
@@ -130,6 +130,7 @@
             cargo-deny
             #cargo-semver-checks
             nixpkgs-fmt
+            cargo-llvm-cov
           ];
 
           shellHook = ''


### PR DESCRIPTION
Explore using https://github.com/taiki-e/cargo-llvm-cov for Rust coverage report

I think this might unlock Python+Rust coverage too, where we measure coverage for Rust code from python tests too.
More info:
- https://github.com/cjermain/rust-python-coverage
- https://github.com/PyO3/pyo3/pull/2105