### PR TITLE
[MRG] Adding cANI Rust implementation to PR #2943

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -982,9 +982,9 @@ dependencies = [
 
 [[package]]
 name = "num-iter"
-version = "0.1.43"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
+checksum = "d869c01cc0c455284163fd0092f1f93835385ccab5a98a0dcc497b2f8bf055a9"
 dependencies = [
  "autocfg",
  "num-integer",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1836,9 +1836,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.67"
+version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58cd2333b6e0be7a39605f0e255892fd7418a682d8da8fe042fe25128794d2ed"
+checksum = "96565907687f7aceb35bc5fc03770a8a0471d82e479f25832f54a0e3f4b28446"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1599,18 +1599,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.56"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
+checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.56"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
+checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -751,9 +751,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.67"
+version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a1d36f1235bc969acba30b7f5990b864423a6068a10f7c90ae8f0112e3a59d1"
+checksum = "406cda4b368d531c842222cf9d2600a9a4acce8d29423695379c6868a143a9ee"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1743,9 +1743,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.90"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1223296a201415c7fad14792dbefaace9bd52b62d33453ade1c5b5f07555406"
+checksum = "c1e124130aee3fb58c5bdd6b639a0509486b0338acaaae0c84a5124b0f588b7f"
 dependencies = [
  "cfg-if",
  "serde",
@@ -1755,9 +1755,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.90"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcdc935b63408d58a32f8cc9738a0bffd8f05cc7c002086c6ef20b7312ad9dcd"
+checksum = "c9e7e1900c352b609c8488ad12639a311045f40a35491fb69ba8c12f758af70b"
 dependencies = [
  "bumpalo",
  "log",
@@ -1770,9 +1770,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.40"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bde2032aeb86bdfaecc8b261eef3cba735cc426c1f3a3416d1e0791be95fc461"
+checksum = "877b9c3f61ceea0e56331985743b13f3d25c406a7098d45180fb5f09bc19ed97"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -1782,9 +1782,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.90"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e4c238561b2d428924c49815533a8b9121c664599558a5d9ec51f8a1740a999"
+checksum = "b30af9e2d358182b5c7449424f017eba305ed32a7010509ede96cdc4696c46ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1792,9 +1792,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.90"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bae1abb6806dc1ad9e560ed242107c0f6c84335f1749dd4e8ddb012ebd5e25a7"
+checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1805,15 +1805,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.90"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d91413b1c31d7539ba5ef2451af3f0b833a005eb27a631cec32bc0635a8602b"
+checksum = "4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838"
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.40"
+version = "0.3.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139bd73305d50e1c1c4333210c0db43d989395b64a237bd35c10ef3832a7f70c"
+checksum = "143ddeb4f833e2ed0d252e618986e18bfc7b0e52f2d28d77d05b2f045dd8eb61"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",
@@ -1825,9 +1825,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.40"
+version = "0.3.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70072aebfe5da66d2716002c729a14e4aec4da0e23cc2ea66323dac541c93928"
+checksum = "a5211b7550606857312bba1d978a8ec75692eae187becc5e680444fffc5e6f89"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -58,6 +58,9 @@ thiserror = "1.0"
 twox-hash = "1.6.0"
 typed-builder = "0.18.0"
 vec-collections = "0.4.3"
+statrs = "0.16.0"
+ndarray = "0.15.6"
+roots = "0.0.8"
 
 [dev-dependencies]
 criterion = "0.5.1"

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -92,7 +92,7 @@ version = "0.2.89"
 features = ["serde-serialize"]
 
 [target.'cfg(all(target_arch = "wasm32", target_os="unknown"))'.dependencies.web-sys]
-version = "0.3.67"
+version = "0.3.68"
 features = ["console", "File"]
 
 [target.'cfg(all(target_arch = "wasm32"))'.dependencies.chrono]

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -44,7 +44,7 @@ memmap2 = "0.9.4"
 murmurhash3 = "0.0.5"
 niffler = { version = "2.3.1", default-features = false, features = [ "gz" ] }
 nohash-hasher = "0.2.0"
-num-iter = "0.1.43"
+num-iter = "0.1.44"
 once_cell = "1.18.0"
 ouroboros = "0.18.3"
 piz = "0.5.0"

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -100,7 +100,7 @@ version = "0.4.33"
 features = ["wasmbind"]
 
 [target.'cfg(all(target_arch = "wasm32", target_os="unknown"))'.dev-dependencies]
-wasm-bindgen-test = "0.3.40"
+wasm-bindgen-test = "0.3.41"
 
 ### These crates don't compile on wasm
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/src/core/src/c_ani.rs
+++ b/src/core/src/c_ani.rs
@@ -1,0 +1,241 @@
+use roots::{find_root_brent, SimpleConvergency};
+use statrs::distribution::{ContinuousCDF, Normal};
+use std::error::Error;
+
+#[derive(Debug)]
+#[allow(dead_code)]
+pub struct CiAniResult {
+    pub point_estimate: f64,
+    prob_nothing_in_common: f64,
+    dist_low: Option<f64>,
+    dist_high: Option<f64>,
+    p_threshold: f64,
+}
+
+fn exp_n_mutated(l: u64, k: u32, r1: f64) -> f64 {
+    let q = r1_to_q(k, r1);
+    l as f64 * q
+}
+
+fn var_n_mutated(l: u64, k: u32, r1: f64, q: Option<f64>) -> Result<f64, Box<dyn Error>> {
+    if r1 == 0.0 {
+        return Ok(0.0);
+    }
+
+    let q = q.unwrap_or_else(|| r1_to_q(k, r1));
+
+    let var_n = l as f64 * (1.0 - q) * (q * (2.0 * k as f64 + (2.0 / r1) - 1.0) - 2.0 * k as f64)
+        + k as f64 * (k as f64 - 1.0) * (1.0 - q).powi(2)
+        + (2.0 * (1.0 - q) / (r1.powi(2))) * ((1.0 + (k as f64 - 1.0) * (1.0 - q)) * r1 - q);
+
+    if var_n < 0.0 {
+        Err("Error: varN < 0.0!".into())
+    } else {
+        Ok(var_n)
+    }
+}
+
+fn exp_n_mutated_squared(l: u64, k: u32, p: f64) -> Result<f64, Box<dyn Error>> {
+    let var_n = var_n_mutated(l, k, p, None)?;
+    Ok(var_n + exp_n_mutated(l, k, p).powi(2))
+}
+
+fn probit(p: f64) -> f64 {
+    Normal::new(0.0, 1.0).unwrap().inverse_cdf(p)
+}
+
+fn r1_to_q(k: u32, r1: f64) -> f64 {
+    1.0 - (1.0 - r1).powi(k as i32)
+}
+
+fn get_exp_probability_nothing_common(
+    mutation_rate: f64,
+    kmer_size: u32,
+    scaled: u64,
+    n_unique_kmers: u64,
+) -> f64 {
+    // Inverse of the scale factor, used in probability calculation.
+    let inverse_scaled = 1.0 / scaled as f64;
+
+    // Handle special cases for mutation rate.
+    if mutation_rate == 1.0 {
+        1.0
+    } else if mutation_rate == 0.0 {
+        0.0
+    } else {
+        // Calculate the expected log probability.
+        let expected_log_probability =
+            get_expected_log_probability(n_unique_kmers, kmer_size, mutation_rate, inverse_scaled);
+        // Return the exponential of the expected log probability.
+        expected_log_probability.exp()
+    }
+}
+
+fn get_expected_log_probability(
+    n_unique_kmers: u64,
+    ksize: u32,
+    mutation_rate: f64,
+    scaled_fraction: f64,
+) -> f64 {
+    let exp_nmut = exp_n_mutated(n_unique_kmers, ksize, mutation_rate);
+    let result = (n_unique_kmers as f64 - exp_nmut) * (1.0 - scaled_fraction).ln();
+
+    if result.is_infinite() {
+        f64::NEG_INFINITY
+    } else {
+        result
+    }
+}
+
+fn handle_seqlen_nkmers(
+    ksize: u32,
+    sequence_len_bp: Option<u64>,
+    n_unique_kmers: Option<u64>,
+) -> Result<u64, Box<dyn Error>> {
+    match n_unique_kmers {
+        Some(n) => Ok(n),
+        None => match sequence_len_bp {
+            Some(len) => Ok(len.saturating_sub(ksize as u64 - 1)),
+            None => Err(
+                "Error: distance estimation requires 'sequence_len_bp' or 'n_unique_kmers'".into(),
+            ),
+        },
+    }
+}
+
+fn check_distance(dist: f64) -> Result<f64, Box<dyn Error>> {
+    if dist >= 0.0 && dist <= 1.0 {
+        Ok(dist)
+    } else {
+        Err(format!("Error: distance value {:.4} is not between 0 and 1!", dist).into())
+    }
+}
+
+impl CiAniResult {
+    fn new(
+        point_estimate: f64,
+        prob_nothing_in_common: f64,
+        dist_low: Option<f64>,
+        dist_high: Option<f64>,
+        p_threshold: f64,
+    ) -> Result<Self, Box<dyn Error>> {
+        let dist_low_checked = dist_low.map_or(Ok(None), |d| check_distance(d).map(Some))?;
+        let dist_high_checked = dist_high.map_or(Ok(None), |d| check_distance(d).map(Some))?;
+
+        Ok(Self {
+            point_estimate,
+            prob_nothing_in_common,
+            dist_low: dist_low_checked,
+            dist_high: dist_high_checked,
+            p_threshold,
+        })
+    }
+}
+
+pub fn containment_to_distance(
+    containment: f64,
+    ksize: u32,
+    scaled: u64,
+    n_unique_kmers: Option<u64>,
+    sequence_len_bp: Option<u64>,
+    confidence: Option<f64>,
+    estimate_ci: Option<bool>,
+    prob_threshold: Option<f64>,
+) -> Result<CiAniResult, Box<dyn Error>> {
+    let scaled_f64 = scaled as f64;
+    let n_unique_kmers = handle_seqlen_nkmers(ksize, sequence_len_bp, n_unique_kmers)?;
+
+    let confidence = confidence.unwrap_or(0.95);
+    let estimate_ci = estimate_ci.unwrap_or(false);
+    let prob_threshold = prob_threshold.unwrap_or(1e-3);
+
+    let point_estimate = if containment == 0.0 {
+        1.0
+    } else if containment == 1.0 {
+        0.0
+    } else {
+        1.0 - containment.powf(1.0 / ksize as f64)
+    };
+
+    let mut sol1 = None;
+    let mut sol2 = None;
+
+    if estimate_ci {
+        let alpha = 1.0 - confidence;
+        let z_alpha = probit(1.0 - alpha / 2.0);
+        let f_scaled = 1.0 / scaled_f64;
+        let bias_factor = 1.0 - (1.0 - f_scaled).powi(n_unique_kmers as i32);
+        let term_1 =
+            (1.0 - f_scaled) / (f_scaled * (n_unique_kmers as f64).powi(3) * bias_factor.powi(2));
+        let term_2 = |pest: f64| {
+            n_unique_kmers as f64 * exp_n_mutated(n_unique_kmers, ksize, pest)
+                - exp_n_mutated_squared(n_unique_kmers, ksize, pest).unwrap_or(0.0)
+        };
+        let term_3 = |pest: f64| {
+            var_n_mutated(n_unique_kmers, ksize, pest, None).unwrap_or(0.0)
+                / (n_unique_kmers as f64).powi(2)
+        };
+
+        let var_direct = |pest: f64| term_1 * term_2(pest) + term_3(pest);
+
+        let f1 = |pest: f64| {
+            (1.0 - pest).powi(ksize as i32) + z_alpha * var_direct(pest).sqrt() - containment
+        };
+        let f2 = |pest: f64| {
+            (1.0 - pest).powi(ksize as i32) - z_alpha * var_direct(pest).sqrt() - containment
+        };
+
+        let mut convergency = SimpleConvergency {
+            eps: 1e-15,
+            max_iter: 1000,
+        };
+        sol1 = find_root_brent(0.0000001, 0.9999999, &f1, &mut convergency).ok();
+        sol2 = find_root_brent(0.0000001, 0.9999999, &f2, &mut convergency).ok();
+    }
+
+    let prob_nothing_in_common =
+        get_exp_probability_nothing_common(point_estimate, ksize, scaled, n_unique_kmers);
+
+    CiAniResult::new(
+        point_estimate,
+        prob_nothing_in_common,
+        sol1,
+        sol2,
+        prob_threshold,
+    )
+}
+
+/* I calculate the distance, then I do 1 - distance to get the ANI identity.
+
+fn main() {
+    let containment = 0.1;
+    let ksize = 31;
+    let scaled = 1000; // u64
+    let n_unique_kmers = 1000;
+    let sequence_len_bp = n_unique_kmers * scaled;
+    let confidence = Some(0.95);
+    let estimate_ci = Some(true);
+    let prob_threshold = Some(1e-3);
+
+    let result = containment_to_distance(
+        containment,
+        ksize,
+        scaled,
+        Some(n_unique_kmers),
+        Some(sequence_len_bp),
+        confidence,
+        estimate_ci,
+        prob_threshold,
+    );
+
+
+    match result {
+        Ok(ci_result) => {
+            let ani_result = 1.0 - ci_result.point_estimate;
+            println!("ANI: {}", ani_result);
+        }
+
+        Err(e) => println!("Error occurred: {:?}", e),
+    }
+}
+*/

--- a/src/core/src/lib.rs
+++ b/src/core/src/lib.rs
@@ -34,7 +34,7 @@ pub mod selection;
 pub mod signature;
 pub mod sketch;
 pub mod storage;
-
+pub mod c_ani;
 pub mod encodings;
 
 #[cfg(feature = "from-finch")]

--- a/src/core/src/lib.rs
+++ b/src/core/src/lib.rs
@@ -27,15 +27,15 @@ pub mod prelude;
 
 pub mod cmd;
 
+pub mod c_ani;
 pub mod collection;
+pub mod encodings;
 pub mod index;
 pub mod manifest;
 pub mod selection;
 pub mod signature;
 pub mod sketch;
 pub mod storage;
-pub mod c_ani;
-pub mod encodings;
 
 #[cfg(feature = "from-finch")]
 pub mod from;


### PR DESCRIPTION
# Rust implementation for ANI estimation

## Usage example:

```Rust

use crate::c_ani::containment_to_distance;

fn main() {
    let containment = 0.1;
    let ksize = 31;
    let scaled = 1000; // u64
    let n_unique_kmers = 1000;
    let sequence_len_bp = n_unique_kmers * scaled;
    let confidence = Some(0.95);
    let estimate_ci = Some(true);
    let prob_threshold = Some(1e-3);

    let result = containment_to_distance(
        containment,
        ksize,
        scaled,
        Some(n_unique_kmers),
        Some(sequence_len_bp),
        confidence,
        estimate_ci,
        prob_threshold,
    );


    match result {
        Ok(ci_result) => {
            let ani_result = 1.0 - ci_result.point_estimate;
            println!("ANI: {}", ani_result);
        }

        Err(e) => println!("Error occurred: {:?}", e),
    }
}
```