### PR TITLE
MRG: make core Manifest booleans python compatible (core)

### DIFF
--- a/src/core/src/manifest.rs
+++ b/src/core/src/manifest.rs
@@ -45,7 +45,6 @@ pub struct Record {
     filename: String,
 }
 
-
 fn to_pybool<S>(x: &bool, s: S) -> std::result::Result<S::Ok, S::Error>
 where
     S: serde::Serializer,
@@ -56,8 +55,6 @@ where
         s.serialize_str("False")
     }
 }
-
-
 
 fn to_bool<'de, D>(deserializer: D) -> std::result::Result<bool, D::Error>
 where

--- a/src/core/src/manifest.rs
+++ b/src/core/src/manifest.rs
@@ -26,7 +26,7 @@ pub struct Record {
 
     md5short: String,
 
-    #[getset(get = "pub", set = "pub")]
+    #[getset(get_copy = "pub", set = "pub")]
     ksize: u32,
 
     moltype: String,
@@ -35,7 +35,7 @@ pub struct Record {
     scaled: u64,
     n_hashes: usize,
 
-    #[getset(get = "pub", set = "pub")]
+    #[getset(get_copy = "pub", set = "pub")]
     #[serde(serialize_with = "intbool", deserialize_with = "to_bool")]
     with_abundance: bool,
 
@@ -203,7 +203,7 @@ impl Select for Manifest {
                 valid
             };
             valid = if let Some(abund) = selection.abund() {
-                valid && *row.with_abundance() == abund
+                valid && row.with_abundance() == abund
             } else {
                 valid
             };
@@ -430,9 +430,9 @@ mod test {
         for record in m2.iter() {
             eprintln!("{:?}", record.name());
             if record.name().contains("OS185") {
-                assert_eq!(record.with_abundance(), &false)
+                assert_eq!(record.with_abundance(), false)
             } else {
-                assert_eq!(record.with_abundance(), &true)
+                assert_eq!(record.with_abundance(), true)
             }
         }
     }

--- a/src/core/src/manifest.rs
+++ b/src/core/src/manifest.rs
@@ -36,7 +36,7 @@ pub struct Record {
     n_hashes: usize,
 
     #[getset(get = "pub", set = "pub")]
-    #[serde(deserialize_with = "to_bool")]
+    #[serde(serialize_with = "to_pybool", deserialize_with = "to_bool")]
     with_abundance: bool,
 
     #[getset(get = "pub", set = "pub")]
@@ -44,6 +44,20 @@ pub struct Record {
 
     filename: String,
 }
+
+
+fn to_pybool<S>(x: &bool, s: S) -> std::result::Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    if *x {
+        s.serialize_str("True")
+    } else {
+        s.serialize_str("False")
+    }
+}
+
+
 
 fn to_bool<'de, D>(deserializer: D) -> std::result::Result<bool, D::Error>
 where
@@ -53,11 +67,11 @@ where
         .to_ascii_lowercase()
         .as_ref()
     {
-        "0" | "false" => Ok(false),
-        "1" | "true" => Ok(true),
+        "0" | "false" | "False" => Ok(false),
+        "1" | "true" | "True" => Ok(true),
         other => Err(de::Error::invalid_value(
             de::Unexpected::Str(other),
-            &"0/1 or true/false are the only supported values",
+            &"0/1, true/false, True/False are the only supported values",
         )),
     }
 }

--- a/src/core/src/selection.rs
+++ b/src/core/src/selection.rs
@@ -121,8 +121,8 @@ impl Selection {
 
     pub fn from_record(row: &Record) -> Result<Self> {
         Ok(Self {
-            ksize: Some(*row.ksize()),
-            abund: Some(*row.with_abundance()),
+            ksize: Some(row.ksize()),
+            abund: Some(row.with_abundance()),
             moltype: Some(row.moltype()),
             num: None,
             scaled: None,


### PR DESCRIPTION
rust bools are `true/false`, python bools are `True/False`. 
When we read in a manifest csv in python (e.g. for `sourmash sig summarize`), we use `ast.literal_eval`, which does not consider `true/false` valid bools.

This PR adds custom serialization `manifest::intbool` to write 0/1 instead of string booleans . This allows us to read manifests written here from python. Alternatively, we could use`True/False`.


```
for k in boolrows:
    row[k] = bool(ast.literal_eval(str(row[k])))
```
https://github.com/sourmash-bio/sourmash/blob/f3dc5f2198cda2c539bdd4dd4676dd901e37d72e/src/sourmash/manifest.py#L92-L93


Problem arises when using core manifest utils in  `branchwater manysketch`
https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/217
https://github.com/sourmash-bio/sourmash_plugin_branchwater/issues/203
