### PR TITLE
replace piz with rc-zip

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,6 +236,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chardetng"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14b8f0b65b7b08ae3c8187e8d77174de20cb6777864c6b832d8ad365999cf1ea"
+dependencies = [
+ "cfg-if",
+ "encoding_rs",
+ "memchr",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -540,6 +551,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "enum_dispatch"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -550,6 +570,12 @@ dependencies = [
  "quote",
  "syn 2.0.87",
 ]
+
+[[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
@@ -582,7 +608,7 @@ dependencies = [
  "cfg-if",
  "crc32fast",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.4.4",
 ]
 
 [[package]]
@@ -650,6 +676,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -692,6 +724,16 @@ checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
 dependencies = [
  "cxx",
  "cxx-build",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.15.2",
 ]
 
 [[package]]
@@ -941,6 +983,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
+dependencies = [
+ "adler",
+]
+
+[[package]]
 name = "murmurhash3"
 version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1054,6 +1105,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e613fc340b2220f734a8595782c551f1250e969d87d3be1ae0579e8d4065179"
+dependencies = [
+ "num_enum_derive",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "oem_cp"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "330138902ab4dab09a86e6b7ab7ddeffb5f8435d52fe0df1bce8b06a17b10ee4"
+dependencies = [
+ "phf",
+ "phf_codegen",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1090,10 +1174,81 @@ dependencies = [
 ]
 
 [[package]]
+name = "oval"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135cef32720c6746450d910890b0b69bcba2bbf6f85c9f4583df13fe415de828"
+
+[[package]]
+name = "ownable"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dcba94d1536fcc470287d96fd26356c38da8215fdb9a74285b09621f35d9350"
+dependencies = [
+ "ownable-macro",
+]
+
+[[package]]
+name = "ownable-macro"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2c91d2781624dec1234581a1a01e63638f36546ad72ee82873ac1b84f41117b"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
+
+[[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "piz"
@@ -1146,6 +1301,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "positioned-io"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccabfeeb89c73adf4081f0dca7f8e28dbda90981a222ceea37f619e93ea6afe9"
+dependencies = [
+ "byteorder",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1158,6 +1324,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc0d895b311e3af9902528fbb8f928688abbd95872819320517cc24ca6b2bd08"
 dependencies = [
  "num-integer",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]
@@ -1362,6 +1560,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "rc-zip"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a26a26f527c4dcc6f72f18ec24bd7172dff872a1a6a3ad616566b6e3359701f6"
+dependencies = [
+ "chardetng",
+ "chrono",
+ "crc32fast",
+ "encoding_rs",
+ "miniz_oxide 0.7.4",
+ "num_enum",
+ "oem_cp",
+ "oval",
+ "ownable",
+ "thiserror 1.0.69",
+ "tracing",
+ "winnow 0.5.40",
+]
+
+[[package]]
+name = "rc-zip-sync"
+version = "4.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57e1d13c4c826c9a6af74f5077e58435d97ee966940c79fbabcfb0917c8e925d"
+dependencies = [
+ "oval",
+ "positioned-io",
+ "rc-zip",
+ "tracing",
+]
+
+[[package]]
 name = "regex"
 version = "1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1400,7 +1630,7 @@ dependencies = [
  "bitvec",
  "bytecheck",
  "bytes",
- "hashbrown",
+ "hashbrown 0.12.3",
  "ptr_meta",
  "rend",
  "rkyv_derive",
@@ -1591,6 +1821,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
 
 [[package]]
+name = "siphasher"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+
+[[package]]
 name = "smallvec"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1638,6 +1874,8 @@ dependencies = [
  "proptest",
  "rand 0.9.0",
  "rayon",
+ "rc-zip",
+ "rc-zip-sync",
  "rkyv",
  "roaring",
  "rocksdb",
@@ -1798,6 +2036,54 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+
+[[package]]
+name = "toml_edit"
+version = "0.22.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "winnow 0.7.2",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+dependencies = [
+ "once_cell",
+]
 
 [[package]]
 name = "twox-hash"
@@ -2203,6 +2489,24 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59690dea168f2198d1a3b0cac23b8063efcd11012f10ae4698f284808c8ef603"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -52,8 +52,6 @@ ouroboros = "0.18.5"
 piz = "0.5.0"
 primal-check = "0.3.4"
 rayon = { version = "1.10.0", optional = true }
-rc-zip = { version = "5.2.0", default-features = false }
-rc-zip-sync = "4.2.4"
 rkyv = { version = "0.7.45", optional = true }
 roaring = "0.10.10"
 roots = "0.0.8"
@@ -117,8 +115,8 @@ default-features = false
 features = [ "bindgen-runtime", "snappy", "zstd" ]
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-rc-zip = { version = "4.0.0", default-features = false }
-rc-zip-sync = "4.0.0"
+rc-zip = { version = "5.2.0", default-features = false }
+rc-zip-sync = "4.2.4"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 criterion = "0.5.1"

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -52,6 +52,8 @@ ouroboros = "0.18.5"
 piz = "0.5.0"
 primal-check = "0.3.4"
 rayon = { version = "1.10.0", optional = true }
+rc-zip = { version = "5.2.0", default-features = false }
+rc-zip-sync = "4.2.4"
 rkyv = { version = "0.7.45", optional = true }
 roaring = "0.10.10"
 roots = "0.0.8"

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -116,5 +116,9 @@ optional = true
 default-features = false
 features = [ "bindgen-runtime", "snappy", "zstd" ]
 
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+rc-zip = { version = "4.0.0", default-features = false }
+rc-zip-sync = "4.0.0"
+
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 criterion = "0.5.1"

--- a/src/core/src/collection.rs
+++ b/src/core/src/collection.rs
@@ -6,7 +6,7 @@ use camino::Utf8PathBuf as PathBuf;
 use crate::encodings::Idx;
 use crate::manifest::{Manifest, Record};
 use crate::prelude::*;
-use crate::storage::{FSStorage, InnerStorage, MemStorage, SigStore, ZipStorage};
+use crate::storage::{FSStorage, InnerStorage, MemStorage, SigStore};
 use crate::{Error, Result, ScaledType};
 
 #[cfg(feature = "parallel")]
@@ -130,8 +130,9 @@ impl Collection {
             .ok_or(Error::MismatchKSizes)
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn from_zipfile<P: AsRef<Path>>(zipfile: P) -> Result<Self> {
-        let storage = ZipStorage::from_file(zipfile)?;
+        let storage = crate::storage::ZipStorage::from_file(zipfile)?;
         // Load manifest from standard location in zipstorage
         let manifest = Manifest::from_reader(storage.load("SOURMASH-MANIFEST.csv")?.as_slice())?;
         Ok(Self {

--- a/src/core/src/errors.rs
+++ b/src/core/src/errors.rs
@@ -1,5 +1,6 @@
 use thiserror::Error;
 
+#[non_exhaustive]
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum SourmashError {

--- a/src/core/src/errors.rs
+++ b/src/core/src/errors.rs
@@ -1,6 +1,5 @@
 use thiserror::Error;
 
-#[non_exhaustive]
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum SourmashError {

--- a/src/core/src/errors.rs
+++ b/src/core/src/errors.rs
@@ -92,12 +92,13 @@ pub enum SourmashError {
     #[error(transparent)]
     CsvError(#[from] csv::Error),
 
-    #[error(transparent)]
-    ZipError(#[from] rc_zip::error::Error),
-
     #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
     #[error(transparent)]
     Panic(#[from] crate::ffi::utils::Panic),
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[error(transparent)]
+    ZipError(#[from] rc_zip::error::Error),
 
     #[cfg(not(target_arch = "wasm32"))]
     #[cfg(feature = "branchwater")]

--- a/src/core/src/errors.rs
+++ b/src/core/src/errors.rs
@@ -103,9 +103,6 @@ pub enum SourmashError {
     #[cfg(feature = "branchwater")]
     #[error(transparent)]
     RocksDBError(#[from] rocksdb::Error),
-
-    #[error(transparent)]
-    ZipError(#[from] piz::result::ZipError),
 }
 
 #[derive(Debug, Error)]
@@ -203,8 +200,6 @@ impl SourmashErrorCode {
             #[cfg(not(target_arch = "wasm32"))]
             #[cfg(feature = "branchwater")]
             SourmashError::RocksDBError { .. } => SourmashErrorCode::RocksDBError,
-
-            SourmashError::ZipError { .. } => SourmashErrorCode::ZipError,
         }
     }
 }

--- a/src/core/src/errors.rs
+++ b/src/core/src/errors.rs
@@ -91,6 +91,9 @@ pub enum SourmashError {
     #[error(transparent)]
     CsvError(#[from] csv::Error),
 
+    #[error(transparent)]
+    ZipError(#[from] rc_zip::error::Error),
+
     #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
     #[error(transparent)]
     Panic(#[from] crate::ffi::utils::Panic),
@@ -194,6 +197,7 @@ impl SourmashErrorCode {
             SourmashError::NifflerError { .. } => SourmashErrorCode::NifflerError,
             SourmashError::Utf8Error { .. } => SourmashErrorCode::Utf8Error,
             SourmashError::CsvError { .. } => SourmashErrorCode::CsvError,
+            SourmashError::ZipError { .. } => SourmashErrorCode::ZipError,
 
             #[cfg(not(target_arch = "wasm32"))]
             #[cfg(feature = "branchwater")]

--- a/src/core/src/storage/mod.rs
+++ b/src/core/src/storage/mod.rs
@@ -151,11 +151,6 @@ pub mod rocksdb;
 #[cfg(all(feature = "branchwater", not(target_arch = "wasm32")))]
 pub use self::rocksdb::RocksDBStorage;
 
-pub type Metadata<'a> = BTreeMap<&'a OsStr, &'a piz::read::FileMetadata<'a>>;
-
-||||||| parent of 6ec1787b (replace piz with rc-zip):src/core/src/storage.rs
-pub type Metadata<'a> = BTreeMap<&'a OsStr, &'a piz::read::FileMetadata<'a>>;
-
 // =========================================
 
 impl InnerStorage {
@@ -375,7 +370,7 @@ impl ZipStorage {
             subdir: None,
             path: Some(location.as_ref().into()),
         }
-        .try_build()?;
+        .build();
 
         let subdir = {
             let subdirs: Vec<_> = storage

--- a/src/core/src/storage/mod.rs
+++ b/src/core/src/storage/mod.rs
@@ -4,11 +4,9 @@ use std::io::{BufReader, BufWriter, Read, Write};
 use std::ops::Deref;
 use std::sync::{Arc, RwLock};
 
-use camino::Utf8Path as Path;
 use camino::Utf8PathBuf as PathBuf;
 use cfg_if::cfg_if;
 use once_cell::sync::OnceCell;
-use rc_zip_sync::{ArchiveHandle, ReadZip};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use typed_builder::TypedBuilder;
@@ -125,25 +123,18 @@ pub struct FSStorage {
     subdir: String,
 }
 
-/// Store files in a zip file.
-#[ouroboros::self_referencing]
-pub struct ZipStorage {
-    file: std::fs::File,
-
-    #[borrows(file)]
-    #[covariant]
-    archive: ArchiveHandle<'this, std::fs::File>,
-
-    subdir: Option<String>,
-    path: Option<PathBuf>,
-}
-
 /// Store data in memory (no permanent storage)
 #[derive(TypedBuilder, Debug, Clone, Default)]
 pub struct MemStorage {
     //store: HashMap<String, Vec<u8>>,
     sigs: Arc<RwLock<HashMap<String, SigStore>>>,
 }
+
+#[cfg(not(target_arch = "wasm32"))]
+pub mod zip;
+
+#[cfg(not(target_arch = "wasm32"))]
+pub use self::zip::ZipStorage;
 
 #[cfg(all(feature = "branchwater", not(target_arch = "wasm32")))]
 pub mod rocksdb;
@@ -178,7 +169,14 @@ impl InnerStorage {
             }
             x if x.starts_with("zip") => {
                 let path = x.split("://").last().expect("not a valid path");
-                InnerStorage::new(ZipStorage::from_file(path)?)
+
+                cfg_if! {
+                    if #[cfg(not(target_arch = "wasm32"))] {
+                        InnerStorage::new(ZipStorage::from_file(path)?)
+                    } else {
+                        return Err(StorageError::MissingFeature("wasm".into(), path.into()).into())
+                    }
+                }
             }
             _ => todo!("storage not supported, throw error"),
         })
@@ -317,121 +315,6 @@ impl Storage for FSStorage {
 
     fn spec(&self) -> String {
         format!("fs://{}", self.subdir)
-    }
-}
-
-impl Storage for ZipStorage {
-    fn save(&self, _path: &str, _content: &[u8]) -> Result<String> {
-        unimplemented!();
-    }
-
-    fn load(&self, path: &str) -> Result<Vec<u8>> {
-        let archive = self.borrow_archive();
-        if let Some(entry) = archive.by_name(path) {
-            return Ok(entry.bytes()?);
-        }
-
-        if let Some(subdir) = &self.borrow_subdir() {
-            if let Some(entry) = archive.by_name(subdir.to_owned() + path) {
-                return Ok(entry.bytes()?);
-            }
-        }
-
-        Err(StorageError::PathNotFoundError(path.into()).into())
-    }
-
-    fn args(&self) -> StorageArgs {
-        unimplemented!();
-    }
-
-    fn load_sig(&self, path: &str) -> Result<SigStore> {
-        let raw = self.load(path)?;
-        let mut vs = Signature::from_reader(&mut &raw[..])?;
-        if vs.len() > 1 {
-            unimplemented!("only one Signature currently allowed");
-        }
-        let sig = vs.swap_remove(0);
-
-        Ok(sig.into())
-    }
-
-    fn spec(&self) -> String {
-        format!("zip://{}", self.borrow_path().clone().unwrap_or("".into()))
-    }
-}
-
-impl ZipStorage {
-    pub fn from_file<P: AsRef<Path>>(location: P) -> Result<Self> {
-        let file = File::open(location.as_ref())?;
-
-        let mut storage = ZipStorageBuilder {
-            file,
-            archive_builder: |file: &std::fs::File| file.read_zip().expect("Error loading zipfile"),
-            subdir: None,
-            path: Some(location.as_ref().into()),
-        }
-        .build();
-
-        let subdir = {
-            let subdirs: Vec<_> = storage
-                .borrow_archive()
-                .entries()
-                .filter(|entry| matches!(entry.kind(), rc_zip::parse::EntryKind::Directory))
-                .collect();
-            if subdirs.len() == 1 {
-                Some(
-                    subdirs[0]
-                        .sanitized_name()
-                        .expect("TODO throw right error")
-                        .into(),
-                )
-            } else {
-                None
-            }
-        };
-
-        storage.with_mut(|fields| *fields.subdir = subdir);
-        Ok(storage)
-    }
-
-    pub fn path(&self) -> Option<PathBuf> {
-        self.borrow_path().clone()
-    }
-
-    pub fn subdir(&self) -> Option<String> {
-        self.borrow_subdir().clone()
-    }
-
-    pub fn set_subdir(&mut self, path: String) {
-        self.with_mut(|fields| *fields.subdir = Some(path))
-    }
-
-    pub fn list_sbts(&self) -> Result<Vec<String>> {
-        Ok(self
-            .borrow_archive()
-            .entries()
-            .filter_map(|entry| {
-                let path = entry.sanitized_name().expect("TODO throw right error");
-                if path.ends_with(".sbt.json") {
-                    Some(path.into())
-                } else {
-                    None
-                }
-            })
-            .collect())
-    }
-
-    pub fn filenames(&self) -> Result<Vec<String>> {
-        Ok(self
-            .borrow_archive()
-            .entries()
-            .map(|entry| {
-                entry
-                    .sanitized_name()
-                    .expect("TODO throw right error")
-                    .into()
-            })
-            .collect())
     }
 }
 

--- a/src/core/src/storage/mod.rs
+++ b/src/core/src/storage/mod.rs
@@ -1,5 +1,4 @@
-use std::collections::{BTreeMap, HashMap};
-use std::ffi::OsStr;
+use std::collections::HashMap;
 use std::fs::{DirBuilder, File};
 use std::io::{BufReader, BufWriter, Read, Write};
 use std::ops::Deref;
@@ -9,6 +8,7 @@ use camino::Utf8Path as Path;
 use camino::Utf8PathBuf as PathBuf;
 use cfg_if::cfg_if;
 use once_cell::sync::OnceCell;
+use rc_zip_sync::{ArchiveHandle, ReadZip};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use typed_builder::TypedBuilder;
@@ -128,18 +128,14 @@ pub struct FSStorage {
 /// Store files in a zip file.
 #[ouroboros::self_referencing]
 pub struct ZipStorage {
-    mapping: Option<memmap2::Mmap>,
+    file: std::fs::File,
 
-    #[borrows(mapping)]
+    #[borrows(file)]
     #[covariant]
-    archive: piz::ZipArchive<'this>,
+    archive: ArchiveHandle<'this, std::fs::File>,
 
     subdir: Option<String>,
     path: Option<PathBuf>,
-
-    #[borrows(archive)]
-    #[covariant]
-    metadata: Metadata<'this>,
 }
 
 /// Store data in memory (no permanent storage)
@@ -155,6 +151,9 @@ pub mod rocksdb;
 #[cfg(all(feature = "branchwater", not(target_arch = "wasm32")))]
 pub use self::rocksdb::RocksDBStorage;
 
+pub type Metadata<'a> = BTreeMap<&'a OsStr, &'a piz::read::FileMetadata<'a>>;
+
+||||||| parent of 6ec1787b (replace piz with rc-zip):src/core/src/storage.rs
 pub type Metadata<'a> = BTreeMap<&'a OsStr, &'a piz::read::FileMetadata<'a>>;
 
 // =========================================
@@ -326,56 +325,24 @@ impl Storage for FSStorage {
     }
 }
 
-fn lookup<'a, P: AsRef<Path>>(
-    metadata: &'a Metadata,
-    path: P,
-) -> Result<&'a piz::read::FileMetadata<'a>> {
-    let path = path.as_ref();
-    metadata
-        .get(&path.as_os_str())
-        .ok_or_else(|| StorageError::PathNotFoundError(path.to_string()).into())
-        .copied()
-}
-
-fn find_subdirs<'a>(archive: &'a piz::ZipArchive<'a>) -> Result<Option<String>> {
-    let subdirs: Vec<_> = archive
-        .entries()
-        .iter()
-        .filter(|entry| entry.is_dir())
-        .collect();
-    if subdirs.len() == 1 {
-        Ok(Some(subdirs[0].path.as_str().into()))
-    } else {
-        Ok(None)
-    }
-}
-
 impl Storage for ZipStorage {
     fn save(&self, _path: &str, _content: &[u8]) -> Result<String> {
         unimplemented!();
     }
 
     fn load(&self, path: &str) -> Result<Vec<u8>> {
-        let metadata = self.borrow_metadata();
+        let archive = self.borrow_archive();
+        if let Some(entry) = archive.by_name(path) {
+            return Ok(entry.bytes()?);
+        }
 
-        let entry = lookup(metadata, path).or_else(|_| {
-            if let Some(subdir) = self.borrow_subdir() {
-                lookup(metadata, subdir.to_owned() + path)
-                    .map_err(|_| StorageError::PathNotFoundError(path.into()))
-            } else {
-                Err(StorageError::PathNotFoundError(path.into()))
+        if let Some(subdir) = &self.borrow_subdir() {
+            if let Some(entry) = archive.by_name(subdir.to_owned() + path) {
+                return Ok(entry.bytes()?);
             }
-        })?;
+        }
 
-        let mut reader = BufReader::new(
-            self.borrow_archive()
-                .read(entry)
-                .map_err(|_| StorageError::DataReadError(path.into()))?,
-        );
-        let mut contents = Vec::new();
-        reader.read_to_end(&mut contents)?;
-
-        Ok(contents)
+        Err(StorageError::PathNotFoundError(path.into()).into())
     }
 
     fn args(&self) -> StorageArgs {
@@ -394,35 +361,41 @@ impl Storage for ZipStorage {
     }
 
     fn spec(&self) -> String {
-        format!("zip://{}", self.path().unwrap_or_else(|| "".into()))
+        format!("zip://{}", self.borrow_path().clone().unwrap_or("".into()))
     }
 }
 
 impl ZipStorage {
     pub fn from_file<P: AsRef<Path>>(location: P) -> Result<Self> {
-        let zip_file = File::open(location.as_ref())?;
-        let mapping = unsafe { memmap2::Mmap::map(&zip_file)? };
+        let file = File::open(location.as_ref())?;
 
-        let mut storage = ZipStorageTryBuilder {
-            mapping: Some(mapping),
-            archive_builder: |mapping: &Option<memmap2::Mmap>| {
-                piz::ZipArchive::new(mapping.as_ref().unwrap())
-            },
-            metadata_builder: |archive: &piz::ZipArchive| {
-                Ok(archive
-                    .entries()
-                    .iter()
-                    .map(|entry| (entry.path.as_os_str(), entry))
-                    .collect())
-            },
+        let mut storage = ZipStorageBuilder {
+            file,
+            archive_builder: |file: &std::fs::File| file.read_zip().expect("Error loading zipfile"),
             subdir: None,
             path: Some(location.as_ref().into()),
         }
         .try_build()?;
 
-        let subdir = find_subdirs(storage.borrow_archive())?;
-        storage.with_mut(|fields| *fields.subdir = subdir);
+        let subdir = {
+            let subdirs: Vec<_> = storage
+                .borrow_archive()
+                .entries()
+                .filter(|entry| matches!(entry.kind(), rc_zip::parse::EntryKind::Directory))
+                .collect();
+            if subdirs.len() == 1 {
+                Some(
+                    subdirs[0]
+                        .sanitized_name()
+                        .expect("TODO throw right error")
+                        .into(),
+                )
+            } else {
+                None
+            }
+        };
 
+        storage.with_mut(|fields| *fields.subdir = subdir);
         Ok(storage)
     }
 
@@ -442,9 +415,8 @@ impl ZipStorage {
         Ok(self
             .borrow_archive()
             .entries()
-            .iter()
             .filter_map(|entry| {
-                let path = entry.path.as_str();
+                let path = entry.sanitized_name().expect("TODO throw right error");
                 if path.ends_with(".sbt.json") {
                     Some(path.into())
                 } else {
@@ -458,8 +430,12 @@ impl ZipStorage {
         Ok(self
             .borrow_archive()
             .entries()
-            .iter()
-            .map(|entry| entry.path.as_str().into())
+            .map(|entry| {
+                entry
+                    .sanitized_name()
+                    .expect("TODO throw right error")
+                    .into()
+            })
             .collect())
     }
 }

--- a/src/core/src/storage/zip.rs
+++ b/src/core/src/storage/zip.rs
@@ -1,0 +1,137 @@
+use std::fs::File;
+
+use camino::Utf8Path as Path;
+use camino::Utf8PathBuf as PathBuf;
+use rc_zip_sync::{ArchiveHandle, ReadZip};
+
+use crate::prelude::*;
+use crate::storage::{StorageError,SigStore, StorageArgs};
+use crate::Result;
+
+/// Store files in a zip file.
+#[ouroboros::self_referencing]
+pub struct ZipStorage {
+    file: std::fs::File,
+
+    #[borrows(file)]
+    #[covariant]
+    archive: ArchiveHandle<'this, std::fs::File>,
+
+    subdir: Option<String>,
+    path: Option<PathBuf>,
+}
+
+impl Storage for ZipStorage {
+    fn save(&self, _path: &str, _content: &[u8]) -> Result<String> {
+        unimplemented!();
+    }
+
+    fn load(&self, path: &str) -> Result<Vec<u8>> {
+        let archive = self.borrow_archive();
+        if let Some(entry) = archive.by_name(path) {
+            return Ok(entry.bytes()?);
+        }
+
+        if let Some(subdir) = &self.borrow_subdir() {
+            if let Some(entry) = archive.by_name(subdir.to_owned() + path) {
+                return Ok(entry.bytes()?);
+            }
+        }
+
+        Err(StorageError::PathNotFoundError(path.into()).into())
+    }
+
+    fn args(&self) -> StorageArgs {
+        unimplemented!();
+    }
+
+    fn load_sig(&self, path: &str) -> Result<SigStore> {
+        let raw = self.load(path)?;
+        let mut vs = Signature::from_reader(&mut &raw[..])?;
+        if vs.len() > 1 {
+            unimplemented!("only one Signature currently allowed");
+        }
+        let sig = vs.swap_remove(0);
+
+        Ok(sig.into())
+    }
+
+    fn spec(&self) -> String {
+        format!("zip://{}", self.borrow_path().clone().unwrap_or("".into()))
+    }
+}
+
+impl ZipStorage {
+    pub fn from_file<P: AsRef<Path>>(location: P) -> Result<Self> {
+        let file = File::open(location.as_ref())?;
+
+        let mut storage = ZipStorageBuilder {
+            file,
+            archive_builder: |file: &std::fs::File| file.read_zip().expect("Error loading zipfile"),
+            subdir: None,
+            path: Some(location.as_ref().into()),
+        }
+        .build();
+
+        let subdir = {
+            let subdirs: Vec<_> = storage
+                .borrow_archive()
+                .entries()
+                .filter(|entry| matches!(entry.kind(), rc_zip::parse::EntryKind::Directory))
+                .collect();
+            if subdirs.len() == 1 {
+                Some(
+                    subdirs[0]
+                        .sanitized_name()
+                        .expect("TODO throw right error")
+                        .into(),
+                )
+            } else {
+                None
+            }
+        };
+
+        storage.with_mut(|fields| *fields.subdir = subdir);
+        Ok(storage)
+    }
+
+    pub fn path(&self) -> Option<PathBuf> {
+        self.borrow_path().clone()
+    }
+
+    pub fn subdir(&self) -> Option<String> {
+        self.borrow_subdir().clone()
+    }
+
+    pub fn set_subdir(&mut self, path: String) {
+        self.with_mut(|fields| *fields.subdir = Some(path))
+    }
+
+    pub fn list_sbts(&self) -> Result<Vec<String>> {
+        Ok(self
+            .borrow_archive()
+            .entries()
+            .filter_map(|entry| {
+                let path = entry.sanitized_name().expect("TODO throw right error");
+                if path.ends_with(".sbt.json") {
+                    Some(path.into())
+                } else {
+                    None
+                }
+            })
+            .collect())
+    }
+
+    pub fn filenames(&self) -> Result<Vec<String>> {
+        Ok(self
+            .borrow_archive()
+            .entries()
+            .map(|entry| {
+                entry
+                    .sanitized_name()
+                    .expect("TODO throw right error")
+                    .into()
+            })
+            .collect())
+    }
+}


### PR DESCRIPTION
rc-zip can work on top of regular files (not memmap-ed files like piz).

It is also much easier to interact with.

Pending: more perf tests, but mem-wise I ran the command from https://github.com/sourmash-bio/sourmash/pull/1909#issuecomment-1092307414 and was seeing ~110MB max memory consumption.

---

Sadly, I think this will be draft for quite some time, it needs Rust 1.74 to compile =/
(it also broke wasm, need to do some splitting in `src/core/src/storage.rs` to be able to compile a subset...)