### PR TITLE
MRG: adjust protein ksize for record/manifest

### DIFF
--- a/src/core/src/manifest.rs
+++ b/src/core/src/manifest.rs
@@ -108,7 +108,7 @@ impl Record {
                 let md5short = md5[0..8].into();
 
                 if moltype != HashFunctions::Murmur64Dna {
-                    ksize = ksize / 3;
+                    ksize /= 3;
                 }
 
                 Self {

--- a/src/core/src/manifest.rs
+++ b/src/core/src/manifest.rs
@@ -82,7 +82,8 @@ impl Record {
     pub fn from_sig(sig: &Signature, path: &str) -> Vec<Self> {
         sig.iter()
             .map(|sketch| {
-                let (ksize, md5, with_abundance, moltype, n_hashes, num, scaled) = match sketch {
+                let (mut ksize, md5, with_abundance, moltype, n_hashes, num, scaled) = match sketch
+                {
                     Sketch::MinHash(mh) => (
                         mh.ksize() as u32,
                         mh.md5sum(),
@@ -105,6 +106,10 @@ impl Record {
                 };
 
                 let md5short = md5[0..8].into();
+
+                if moltype != HashFunctions::Murmur64Dna {
+                    ksize = ksize / 3;
+                }
 
                 Self {
                     internal_location: path.into(),


### PR DESCRIPTION
Protein k-mer sizes are k=k*3 internally, but k in a manifest. 

Record is used within manifest, so should reflect k.

This should not impact selection at sig level. In`signature::Select`:
```
 valid = if let Some(ksize) = selection.ksize() {
                let k = s.ksize() as u32;
                k == ksize || k == ksize * 3
```
So here we match exact ksize or k=k*3, regardless of ksize or molecule type. This is b/c we don't have access to `is_protein` or any other property unless we load the minhash.

we may want to be more explicit at some point, but this solves the immediate problem