### PR TITLE
Add pre-commit check for cargo fmt, with autofix

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,3 +24,8 @@ repos:
     hooks:
       - id: check-hooks-apply
       - id: check-useless-excludes
+  - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
+    rev: 97a46d97aea9f027a3a8714244f5c93a74d742de
+    hooks:
+    - id: pretty-format-rust
+      args: [--autofix]


### PR DESCRIPTION
Since we have the pre-commit CI check that can autoformat code for Python, set one up for Rust too