### PR TITLE
Update asv to 0.6.2

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -104,7 +104,7 @@ commands =
 [testenv:asv]
 description = run asv for benchmarking (compare current commit with latest)
 deps =
-    asv==0.5.1
+    asv==0.6.2
     virtualenv
 changedir = {toxinidir}
 commands =


### PR DESCRIPTION
We've been stuck with `asv==0.5.1` for quite some time, but I tried out the new `0.6.2` release and it is working, so why not update? =]