### PR TITLE
MRG: fix `calculate_gather_stats` `threshold=0` bug

### DIFF
--- a/src/core/src/index/mod.rs
+++ b/src/core/src/index/mod.rs
@@ -280,7 +280,7 @@ pub fn calculate_gather_stats(
 
     // If abundance, calculate abund-related metrics (vs current query)
     if calc_abund_stats {
-        // take abunds from orig_query b/c match_mh may have hashes that have already been removed from query
+        // take abunds from subtracted query
         let (abunds, unique_weighted_found) = match match_mh.inflated_abundances(&query) {
             Ok((abunds, unique_weighted_found)) => (abunds, unique_weighted_found),
             Err(e) => {

--- a/src/core/src/index/mod.rs
+++ b/src/core/src/index/mod.rs
@@ -280,13 +280,13 @@ pub fn calculate_gather_stats(
 
     // If abundance, calculate abund-related metrics (vs current query)
     if calc_abund_stats {
-        // need current downsampled query here to get f_unique_weighted
-        let (abunds, unique_weighted_found) = match match_mh.inflated_abundances(&query) {
+        let (abunds, unique_weighted_found) = match match_mh.inflated_abundances(orig_query) {
             Ok((abunds, unique_weighted_found)) => (abunds, unique_weighted_found),
             Err(e) => {
                 return Err(e);
             }
         };
+        // if !abunds.is_empty() {
         n_unique_weighted_found = unique_weighted_found as usize;
         sum_total_weighted_found = sum_weighted_found + n_unique_weighted_found;
         f_unique_weighted = n_unique_weighted_found as f64 / total_weighted_hashes as f64;
@@ -294,8 +294,10 @@ pub fn calculate_gather_stats(
         average_abund = n_unique_weighted_found as f64 / abunds.len() as f64;
 
         // todo: try to avoid clone for these?
+        // median_abund = median(abunds.iter().cloned()).unwrap_or(1.0);
         median_abund = median(abunds.iter().cloned()).unwrap();
         std_abund = stddev(abunds.iter().cloned());
+        // }
     }
 
     let result = GatherResult::builder()

--- a/src/core/src/index/mod.rs
+++ b/src/core/src/index/mod.rs
@@ -288,18 +288,18 @@ pub fn calculate_gather_stats(
         };
         if abunds.is_empty() {
             eprintln!("match: {}, match_size: {}, query_size: {}, query_trackabund: {}, empty abund vector!", match_sig.name(), match_size, query.size(), query.track_abundance());
+        } else {
+            n_unique_weighted_found = unique_weighted_found as usize;
+            sum_total_weighted_found = sum_weighted_found + n_unique_weighted_found;
+            f_unique_weighted = n_unique_weighted_found as f64 / total_weighted_hashes as f64;
+
+            average_abund = n_unique_weighted_found as f64 / abunds.len() as f64;
+
+            // todo: try to avoid clone for these?
+            // median_abund = median(abunds.iter().cloned()).unwrap_or(1.0);
+            median_abund = median(abunds.iter().cloned()).unwrap();
+            std_abund = stddev(abunds.iter().cloned());
         }
-        n_unique_weighted_found = unique_weighted_found as usize;
-        sum_total_weighted_found = sum_weighted_found + n_unique_weighted_found;
-        f_unique_weighted = n_unique_weighted_found as f64 / total_weighted_hashes as f64;
-
-        average_abund = n_unique_weighted_found as f64 / abunds.len() as f64;
-
-        // todo: try to avoid clone for these?
-        // median_abund = median(abunds.iter().cloned()).unwrap_or(1.0);
-        median_abund = median(abunds.iter().cloned()).unwrap();
-        std_abund = stddev(abunds.iter().cloned());
-        // }
     }
 
     let result = GatherResult::builder()

--- a/src/core/src/index/mod.rs
+++ b/src/core/src/index/mod.rs
@@ -286,7 +286,9 @@ pub fn calculate_gather_stats(
                 return Err(e);
             }
         };
-        // if !abunds.is_empty() {
+        if abunds.is_empty() {
+            eprintln!("match: {}, match_size: {}, query_size: {}, query_trackabund: {}, empty abund vector!", match_sig.name(), match_size, query.size(), query.track_abundance());
+        }
         n_unique_weighted_found = unique_weighted_found as usize;
         sum_total_weighted_found = sum_weighted_found + n_unique_weighted_found;
         f_unique_weighted = n_unique_weighted_found as f64 / total_weighted_hashes as f64;

--- a/src/core/src/index/mod.rs
+++ b/src/core/src/index/mod.rs
@@ -281,12 +281,13 @@ pub fn calculate_gather_stats(
     // If abundance, calculate abund-related metrics (vs current query)
     if calc_abund_stats {
         // take abunds from orig_query b/c match_mh may have hashes that have already been removed from query
-        let (abunds, unique_weighted_found) = match match_mh.inflated_abundances(orig_query) {
+        let (abunds, unique_weighted_found) = match match_mh.inflated_abundances(&query) {
             Ok((abunds, unique_weighted_found)) => (abunds, unique_weighted_found),
             Err(e) => {
                 return Err(e);
             }
         };
+
         n_unique_weighted_found = unique_weighted_found as usize;
         sum_total_weighted_found = sum_weighted_found + n_unique_weighted_found;
         f_unique_weighted = n_unique_weighted_found as f64 / total_weighted_hashes as f64;

--- a/src/core/src/index/mod.rs
+++ b/src/core/src/index/mod.rs
@@ -280,26 +280,22 @@ pub fn calculate_gather_stats(
 
     // If abundance, calculate abund-related metrics (vs current query)
     if calc_abund_stats {
+        //take abunds from orig_query
         let (abunds, unique_weighted_found) = match match_mh.inflated_abundances(orig_query) {
             Ok((abunds, unique_weighted_found)) => (abunds, unique_weighted_found),
             Err(e) => {
                 return Err(e);
             }
         };
-        if abunds.is_empty() {
-            eprintln!("match: {}, match_size: {}, query_size: {}, query_trackabund: {}, empty abund vector!", match_sig.name(), match_size, query.size(), query.track_abundance());
-        } else {
-            n_unique_weighted_found = unique_weighted_found as usize;
-            sum_total_weighted_found = sum_weighted_found + n_unique_weighted_found;
-            f_unique_weighted = n_unique_weighted_found as f64 / total_weighted_hashes as f64;
+        n_unique_weighted_found = unique_weighted_found as usize;
+        sum_total_weighted_found = sum_weighted_found + n_unique_weighted_found;
+        f_unique_weighted = n_unique_weighted_found as f64 / total_weighted_hashes as f64;
 
-            average_abund = n_unique_weighted_found as f64 / abunds.len() as f64;
+        average_abund = n_unique_weighted_found as f64 / abunds.len() as f64;
 
-            // todo: try to avoid clone for these?
-            // median_abund = median(abunds.iter().cloned()).unwrap_or(1.0);
-            median_abund = median(abunds.iter().cloned()).unwrap();
-            std_abund = stddev(abunds.iter().cloned());
-        }
+        // todo: try to avoid clone for these?
+        median_abund = median(abunds.iter().cloned()).unwrap();
+        std_abund = stddev(abunds.iter().cloned());
     }
 
     let result = GatherResult::builder()

--- a/src/core/src/index/mod.rs
+++ b/src/core/src/index/mod.rs
@@ -280,7 +280,7 @@ pub fn calculate_gather_stats(
 
     // If abundance, calculate abund-related metrics (vs current query)
     if calc_abund_stats {
-        //take abunds from orig_query
+        // take abunds from orig_query b/c match_mh may have hashes that have already been removed from query
         let (abunds, unique_weighted_found) = match match_mh.inflated_abundances(orig_query) {
             Ok((abunds, unique_weighted_found)) => (abunds, unique_weighted_found),
             Err(e) => {

--- a/src/core/src/index/revindex/disk_revindex.rs
+++ b/src/core/src/index/revindex/disk_revindex.rs
@@ -330,6 +330,10 @@ impl RevIndexOps for RevIndex {
 
             let (dataset_id, size) = counter.k_most_common_ordered(1)[0];
             match_size = if size >= threshold { size } else { break };
+            // handle special case where threshold was set to 0
+            if match_size == 0 {
+                break;
+            }
 
             // this should downsample mh for us
             let match_sig = self.collection.sig_for_dataset(dataset_id)?;


### PR DESCRIPTION

The error shows up when we try to calculate abundance info with a `match_size` of 0:
```
match: GCF_002819265.1 Choclo virus, match_size: 0, query_size: 273, query_trackabund: true
thread '<unnamed>' panicked at 'called `Option::unwrap()` on a `None` value', /home/ntpierce/sourmash/src/core/src/index/mod.rs:301:55
```

...we should never be trying to calculate statistics on `match_size` of 0, but the logic is currently `match_size >= threshold`.This includes a check to break if `match_size` is 0.

- fixes #3051 

