### PR TITLE
MRG: support proper manifest creation with `--relpath` for `sig check` and `sig collect`

### DIFF
--- a/doc/command-line.md
+++ b/doc/command-line.md
@@ -1956,6 +1956,10 @@ picklist CSV. With `--save-manifest-matching`, `sig check` will save all
 of the _matched_ elements to a manifest file, which can then be used as a
 sourmash database.
 
+When saving manifests with matched elements, sourmash will by default
+not rewrite paths to the containers for the matched elements. This will
+create buggy manifests ... @CTB.
+
 `sourmash sig check` is particularly useful when working with large
 collections of signatures and identifiers.
 

--- a/doc/command-line.md
+++ b/doc/command-line.md
@@ -551,7 +551,7 @@ sourmash multigather --query <queries ...> --db <collections>
 ```
 
 Note that multigather is single threaded, so it offers no substantial
-efficiency gains over just running gather multiple times!  Nontheless, it
+efficiency gains over just running gather multiple times!  Nonetheless, it
 is useful for situations where you have many sketches organized in a
 combined file, e.g. sketches built with `sourmash sketch
 ... --singleton`).
@@ -1956,12 +1956,18 @@ picklist CSV. With `--save-manifest-matching`, `sig check` will save all
 of the _matched_ elements to a manifest file, which can then be used as a
 sourmash database.
 
-When saving manifests with matched elements, sourmash will by default
-not rewrite paths to the containers for the matched elements. This will
-create buggy manifests ... @CTB.
-
 `sourmash sig check` is particularly useful when working with large
 collections of signatures and identifiers.
+
+With `-m/--save-manifest-matching`, `sig check` creates a standalone
+manifest. In these manifests, sourmash v4 will by default write paths
+to the matched elements that are relative to the current working
+directory.  In some cases - when the matched elements are in
+subdirectories - this will create manifests that do not work properly
+with sourmash.  The `--relpath` argument will rewrite the paths to be
+relative to the manifest, while the `--abspath` argument will rewrite
+paths to be absolute.  The `--relpath` behavior will be the default in
+sourmash v5.
 
 ### `sourmash signature collect` - collect manifests across databases
 
@@ -1980,6 +1986,15 @@ This manifest file can be loaded directly from the command line by sourmash.
 `sourmash sig collect` defaults to outputting SQLite manifests. It is
 particularly useful when working with large collections of signatures and
 identifiers, and has command line options for merging and updating manifests.
+
+As with `sig check`, the standalone manifests created by `sig collect`
+in sourmash v4 will by default write paths to the matched elements
+relative to the current working directory.  When the matched elements
+are in subdirectories this will create manifests that do not work
+properly with sourmash.  The `--relpath` argument will rewrite the
+paths to be relative to the manifest, while the `--abspath` argument
+will rewrite paths to be absolute.  The `--relpath` behavior will be
+the default in sourmash v5.
 
 ## Advanced command-line usage
 

--- a/doc/command-line.md
+++ b/doc/command-line.md
@@ -1962,8 +1962,8 @@ collections of signatures and identifiers.
 With `-m/--save-manifest-matching`, `sig check` creates a standalone
 manifest. In these manifests, sourmash v4 will by default write paths
 to the matched elements that are relative to the current working
-directory.  In some cases - when the matched elements are in
-subdirectories - this will create manifests that do not work properly
+directory.  In some cases - when the output manifest is in different
+directory - this will create manifests that do not work properly
 with sourmash.  The `--relpath` argument will rewrite the paths to be
 relative to the manifest, while the `--abspath` argument will rewrite
 paths to be absolute.  The `--relpath` behavior will be the default in
@@ -1989,8 +1989,8 @@ identifiers, and has command line options for merging and updating manifests.
 
 As with `sig check`, the standalone manifests created by `sig collect`
 in sourmash v4 will by default write paths to the matched elements
-relative to the current working directory.  When the matched elements
-are in subdirectories this will create manifests that do not work
+relative to the current working directory.  When the output manifest
+is in a different directory, this will create manifests that do not work
 properly with sourmash.  The `--relpath` argument will rewrite the
 paths to be relative to the manifest, while the `--abspath` argument
 will rewrite paths to be absolute.  The `--relpath` behavior will be

--- a/doc/sourmash-internals.md
+++ b/doc/sourmash-internals.md
@@ -368,7 +368,10 @@ Thus, while standalone manifests can point at any kind of container,
 including JSON files or LCA databases, they are most efficient when
 `internal_location` points at a file with either a single sketch in
 it, or a manifest that supports direct loading of sketches. Therefore,
-we suggest using standalone manifest indices.
+we suggest using standalone manifest indices.  Note that sourmash
+interprets paths to locations in standalone manifests relative to the
+manifest filename; see the `--relpath` behavior in `sig check` and
+`sig collect` for details.
 
 Note that searching a standalone manifest is currently done through a
 linear iteration, and does not use any features of indexed containers

--- a/doc/sourmash-internals.md
+++ b/doc/sourmash-internals.md
@@ -371,7 +371,8 @@ it, or a manifest that supports direct loading of sketches. Therefore,
 we suggest using standalone manifest indices.  Note that sourmash
 interprets paths to locations in standalone manifests relative to the
 manifest filename; see the `--relpath` behavior in `sig check` and
-`sig collect` for details.
+`sig collect` to output manifests that deal with relative filenames
+properly.
 
 Note that searching a standalone manifest is currently done through a
 linear iteration, and does not use any features of indexed containers

--- a/src/sourmash/cli/sig/check.py
+++ b/src/sourmash/cli/sig/check.py
@@ -67,6 +67,18 @@ def subparser(subparsers):
         default="csv",
         choices=["csv", "sql"],
     )
+    subparser.add_argument(
+        "--abspath", help="convert all locations to absolute paths", action="store_true"
+    )
+    subparser.add_argument(
+        "--no-abspath", help="do not convert all locations to absolute paths", action="store_false", dest='abspath'
+    )
+    subparser.add_argument(
+        "--relpath", help="convert all locations to paths relative to the output manifest", action="store_true"
+    )
+    subparser.add_argument(
+        "--no-relpath", help="do not convert all locations to paths relative to the output manifest", action="store_false", dest='relpath'
+    )
 
     add_ksize_arg(subparser)
     add_moltype_args(subparser)

--- a/src/sourmash/cli/sig/check.py
+++ b/src/sourmash/cli/sig/check.py
@@ -68,13 +68,13 @@ def subparser(subparsers):
         choices=["csv", "sql"],
     )
     subparser.add_argument(
-        "--abspath", help="convert all locations to absolute paths", action="store_true"
+        "--abspath", "--use-absolute-paths", help="convert all locations to absolute paths", action="store_true"
     )
     subparser.add_argument(
-        "--no-abspath", help="do not convert all locations to absolute paths", action="store_false", dest='abspath'
+        "--no-abspath", help="do not convert all locations to absolute paths", action="store_false", dest='abspath',
     )
     subparser.add_argument(
-        "--relpath", help="convert all locations to paths relative to the output manifest", action="store_true"
+        "--relpath", "--use-relative-paths", help="convert all locations to paths relative to the output manifest", action="store_true",
     )
     subparser.add_argument(
         "--no-relpath", help="do not convert all locations to paths relative to the output manifest", action="store_false", dest='relpath'

--- a/src/sourmash/cli/sig/check.py
+++ b/src/sourmash/cli/sig/check.py
@@ -68,16 +68,28 @@ def subparser(subparsers):
         choices=["csv", "sql"],
     )
     subparser.add_argument(
-        "--abspath", "--use-absolute-paths", help="convert all locations to absolute paths", action="store_true"
+        "--abspath",
+        "--use-absolute-paths",
+        help="convert all locations to absolute paths",
+        action="store_true",
     )
     subparser.add_argument(
-        "--no-abspath", help="do not convert all locations to absolute paths", action="store_false", dest='abspath',
+        "--no-abspath",
+        help="do not convert all locations to absolute paths",
+        action="store_false",
+        dest="abspath",
     )
     subparser.add_argument(
-        "--relpath", "--use-relative-paths", help="convert all locations to paths relative to the output manifest", action="store_true",
+        "--relpath",
+        "--use-relative-paths",
+        help="convert all locations to paths relative to the output manifest",
+        action="store_true",
     )
     subparser.add_argument(
-        "--no-relpath", help="do not convert all locations to paths relative to the output manifest", action="store_false", dest='relpath'
+        "--no-relpath",
+        help="do not convert all locations to paths relative to the output manifest",
+        action="store_false",
+        dest="relpath",
     )
 
     add_ksize_arg(subparser)

--- a/src/sourmash/cli/sig/collect.py
+++ b/src/sourmash/cli/sig/collect.py
@@ -54,13 +54,13 @@ def subparser(subparsers):
         help="merge new manifests into existing",
     )
     subparser.add_argument(
-        "--abspath", help="convert all locations to absolute paths", action="store_true"
+        "--abspath", "--use-absolute-paths", help="convert all locations to absolute paths", action="store_true"
     )
     subparser.add_argument(
         "--no-abspath", help="do not convert all locations to absolute paths", action="store_false", dest='abspath'
     )
     subparser.add_argument(
-        "--relpath", help="convert all locations to paths relative to the output manifest", action="store_true"
+        "--relpath", "--use-relative-paths", help="convert all locations to paths relative to the output manifest", action="store_true",
     )
     subparser.add_argument(
         "--no-relpath", help="do not convert all locations to paths relative to the output manifest", action="store_false", dest='relpath'

--- a/src/sourmash/cli/sig/collect.py
+++ b/src/sourmash/cli/sig/collect.py
@@ -56,6 +56,15 @@ def subparser(subparsers):
     subparser.add_argument(
         "--abspath", help="convert all locations to absolute paths", action="store_true"
     )
+    subparser.add_argument(
+        "--no-abspath", help="do not convert all locations to absolute paths", action="store_false", dest='abspath'
+    )
+    subparser.add_argument(
+        "--relpath", help="convert all locations to paths relative to the output manifest", action="store_true"
+    )
+    subparser.add_argument(
+        "--no-relpath", help="do not convert all locations to paths relative to the output manifest", action="store_false", dest='relpath'
+    )
 
     add_ksize_arg(subparser)
     add_moltype_args(subparser)

--- a/src/sourmash/cli/sig/collect.py
+++ b/src/sourmash/cli/sig/collect.py
@@ -54,16 +54,28 @@ def subparser(subparsers):
         help="merge new manifests into existing",
     )
     subparser.add_argument(
-        "--abspath", "--use-absolute-paths", help="convert all locations to absolute paths", action="store_true"
+        "--abspath",
+        "--use-absolute-paths",
+        help="convert all locations to absolute paths",
+        action="store_true",
     )
     subparser.add_argument(
-        "--no-abspath", help="do not convert all locations to absolute paths", action="store_false", dest='abspath'
+        "--no-abspath",
+        help="do not convert all locations to absolute paths",
+        action="store_false",
+        dest="abspath",
     )
     subparser.add_argument(
-        "--relpath", "--use-relative-paths", help="convert all locations to paths relative to the output manifest", action="store_true",
+        "--relpath",
+        "--use-relative-paths",
+        help="convert all locations to paths relative to the output manifest",
+        action="store_true",
     )
     subparser.add_argument(
-        "--no-relpath", help="do not convert all locations to paths relative to the output manifest", action="store_false", dest='relpath'
+        "--no-relpath",
+        help="do not convert all locations to paths relative to the output manifest",
+        action="store_false",
+        dest="relpath",
     )
 
     add_ksize_arg(subparser)

--- a/src/sourmash/index/__init__.py
+++ b/src/sourmash/index/__init__.py
@@ -1156,15 +1156,15 @@ class StandaloneManifestIndex(Index):
 
         if prefix is None:
             # @CTB hmm, good or bad idea?
-            if location.startswith('/'):
+            if location.startswith("/"):
                 prefix = os.path.dirname(location)
             else:
                 prefix = os.path.dirname(location)
-                print('XXX prefix is', (prefix,))
+                print("XXX prefix is", (prefix,))
                 relpath = os.path.relpath(os.curdir, prefix)
-                print('YYY relpath is', (relpath,))
+                print("YYY relpath is", (relpath,))
                 prefix = os.path.join(prefix, relpath)
-                print('ZZZ prefix is now', (prefix,))
+                print("ZZZ prefix is now", (prefix,))
 
         return cls(m, location, prefix=prefix)
 

--- a/src/sourmash/index/__init__.py
+++ b/src/sourmash/index/__init__.py
@@ -1155,15 +1155,8 @@ class StandaloneManifestIndex(Index):
         m = CollectionManifest.load_from_filename(location)
 
         if prefix is None:
-            # @CTB hmm, good or bad idea?
-            # if we disable, tests break. maybe change tests?
-            if location.startswith("/"):
-                prefix = os.path.dirname(location)
-            else:
-                # calculate paths relative to cwd; @CTB more/better docs.
-                prefix = os.path.dirname(location)
-                relpath = os.path.relpath(os.curdir, prefix)
-                prefix = os.path.join(prefix, relpath)
+            # by default, calculate paths relative to manifest location.
+            prefix = os.path.dirname(location)
 
         return cls(m, location, prefix=prefix)
 

--- a/src/sourmash/index/__init__.py
+++ b/src/sourmash/index/__init__.py
@@ -1155,7 +1155,16 @@ class StandaloneManifestIndex(Index):
         m = CollectionManifest.load_from_filename(location)
 
         if prefix is None:
-            prefix = os.path.dirname(location)
+            # @CTB hmm, good or bad idea?
+            if location.startswith('/'):
+                prefix = os.path.dirname(location)
+            else:
+                prefix = os.path.dirname(location)
+                print('XXX prefix is', (prefix,))
+                relpath = os.path.relpath(os.curdir, prefix)
+                print('YYY relpath is', (relpath,))
+                prefix = os.path.join(prefix, relpath)
+                print('ZZZ prefix is now', (prefix,))
 
         return cls(m, location, prefix=prefix)
 

--- a/src/sourmash/index/__init__.py
+++ b/src/sourmash/index/__init__.py
@@ -1156,15 +1156,14 @@ class StandaloneManifestIndex(Index):
 
         if prefix is None:
             # @CTB hmm, good or bad idea?
+            # if we disable, tests break. maybe change tests?
             if location.startswith("/"):
                 prefix = os.path.dirname(location)
             else:
+                # calculate paths relative to cwd; @CTB more/better docs.
                 prefix = os.path.dirname(location)
-                print("XXX prefix is", (prefix,))
                 relpath = os.path.relpath(os.curdir, prefix)
-                print("YYY relpath is", (relpath,))
                 prefix = os.path.join(prefix, relpath)
-                print("ZZZ prefix is now", (prefix,))
 
         return cls(m, location, prefix=prefix)
 

--- a/src/sourmash/index/__init__.py
+++ b/src/sourmash/index/__init__.py
@@ -1113,16 +1113,18 @@ class StandaloneManifestIndex(Index):
     with many signature collections underneath it, and you don't want to load
     every collection each time you run sourmash.
 
-    Instead, you can run 'sourmash sig manifest <directory> -o mf.csv' to
-    output a manifest and then use this class to load 'mf.csv' directly.
+    Instead, you can run 'sourmash sig collect <directory> -o <manifest>' to
+    output a manifest and then use this class to load <manifest> directly.
     Sketch type selection, picklists, and pattern matching will all work
     directly on the manifest and will load signatures only upon demand.
 
-    One feature of this class is that absolute paths to sketches in
-    the 'internal_location' field of the manifests will be loaded properly.
-    This permits manifests to be constructed for various collections of
-    signatures that reside elsewhere, and not just below a single directory
-    prefix.
+    One feature of this class is that external paths to sketches in
+    the 'internal_location' field of the manifests will be loaded
+    properly.  This permits manifests to be constructed for various
+    collections of signatures that reside elsewhere, and not just
+    below a single directory prefix. By default paths are interpreted
+    relative to the location of the manifest, unless an absolute path
+    is provided in the 'internal_location' field.
 
     StandaloneManifestIndex does _not_ store signatures in memory.
 
@@ -1130,6 +1132,7 @@ class StandaloneManifestIndex(Index):
     MultiIndex.load_from_pathlist is used to load other Index
     objects. However, this class does not store any signatures in
     memory, unlike MultiIndex.
+
     """
 
     is_database = True

--- a/src/sourmash/sig/__main__.py
+++ b/src/sourmash/sig/__main__.py
@@ -1625,6 +1625,17 @@ def collect(args):
 
         mf = sourmash_args.get_manifest(idx)
 
+        # decide how to rewrite locations to container:
+        if args.abspath:
+            # convert to abspath
+            new_iloc = os.path.abspath(loc)
+        elif args.relpath:
+            # interpret paths relative to manifest directory
+            new_iloc = os.path.join(relpath, loc)
+        else:
+            # default: paths are relative to cwd
+            new_iloc = loc
+
         for row in mf.rows:
             row["internal_location"] = loc
             collected_mf.add_row(row)

--- a/src/sourmash/sig/__main__.py
+++ b/src/sourmash/sig/__main__.py
@@ -1435,22 +1435,30 @@ def check(args):
     else:
         debug("sig check: manifest required")
 
-    total_manifest_rows = CollectionManifest([])
+    # abspath/relpath checks
+    if args.abspath and args.relpath:
+        error("** Cannot specify both --abspath and --relpath; pick one!")
+        sys.exit(-1)
 
-    output_manifest_dir = os.curdir # CTB cleanup / test
-    if args.save_manifest_matching:
+    if args.relpath or args.abspath and not args.save_manifest_matching:
+        notify("** WARNING: --abspath and --relpath only have effects when saving a manifest")
+
+    relpath = "."
+    if args.relpath and args.save_manifest_matching:
         output_manifest_dir = os.path.dirname(args.save_manifest_matching)
         relpath = os.path.relpath(os.curdir, output_manifest_dir)
+
+    total_manifest_rows = CollectionManifest([])
 
     # start loading!
     total_rows_examined = 0
     for filename in args.signatures:
+        # if saving a manifest, think about how to rewrite locations.
         if args.abspath:
             # convert to abspath
             new_iloc = os.path.abspath(filename)
         elif args.relpath:
             # interpret paths relative to manifest directory
-            prefix = os.path.dirname(filename)
             new_iloc = os.path.join(relpath, filename)
         else:
             # default: paths are relative to cwd

--- a/src/sourmash/sig/__main__.py
+++ b/src/sourmash/sig/__main__.py
@@ -1604,9 +1604,10 @@ def collect(args):
     # load from_file
     _extend_signatures_with_from_file(args, target_attr="locations")
 
-    # convert to abspath
-    if args.abspath:
-        args.locations = [os.path.abspath(iloc) for iloc in args.locations]
+    relpath = None
+    if args.relpath:
+        output_manifest_dir = os.path.dirname(args.output)
+        relpath = os.path.relpath(os.curdir, output_manifest_dir)
 
     # iterate through, loading all the manifests from all the locations.
     for n_files, loc in enumerate(args.locations):
@@ -1637,7 +1638,7 @@ def collect(args):
             new_iloc = loc
 
         for row in mf.rows:
-            row["internal_location"] = loc
+            row["internal_location"] = new_iloc
             collected_mf.add_row(row)
 
     if args.manifest_format == "csv":

--- a/src/sourmash/sig/__main__.py
+++ b/src/sourmash/sig/__main__.py
@@ -1460,10 +1460,11 @@ def check(args):
             # convert to abspath
             new_iloc = os.path.abspath(filename)
         elif args.relpath:
-            # interpret paths relative to manifest directory
+            # interpret paths relative to manifest directory.
             new_iloc = os.path.join(relpath, filename)
         else:
-            # default: paths are relative to cwd
+            # default: paths are relative to cwd. This breaks when sketches
+            # are in subdirectories; will be deprecated for v5.
             new_iloc = filename
 
         idx = sourmash_args.load_file_as_index(filename, yield_all_files=args.force)
@@ -1483,7 +1484,6 @@ def check(args):
 
         # rewrite locations so that each signature can be found by filename
         # of its container; this follows `sig collect` logic.
-        # CTB: note that this is relative to cwd, not manifest location.
         for row in sub_manifest.rows:
             row["internal_location"] = new_iloc
             total_manifest_rows.add_row(row)
@@ -1636,7 +1636,8 @@ def collect(args):
             # interpret paths relative to manifest directory
             new_iloc = os.path.join(relpath, loc)
         else:
-            # default: paths are relative to cwd
+            # default: paths are relative to cwd. This breaks when sketches
+            # are in subdirectories; will be deprecated for v5.
             new_iloc = loc
 
         for row in mf.rows:

--- a/src/sourmash/sig/__main__.py
+++ b/src/sourmash/sig/__main__.py
@@ -1441,7 +1441,9 @@ def check(args):
         sys.exit(-1)
 
     if args.relpath or args.abspath and not args.save_manifest_matching:
-        notify("** WARNING: --abspath and --relpath only have effects when saving a manifest")
+        notify(
+            "** WARNING: --abspath and --relpath only have effects when saving a manifest"
+        )
 
     relpath = "."
     if args.relpath and args.save_manifest_matching:

--- a/src/sourmash/sig/__main__.py
+++ b/src/sourmash/sig/__main__.py
@@ -1562,6 +1562,11 @@ def collect(args):
             f"WARNING: --merge-previous specified, but output file '{args.output}' does not already exist?"
         )
 
+    # abspath/relpath checks
+    if args.abspath and args.relpath:
+        error("** Cannot specify both --abspath and --relpath; pick one!")
+        sys.exit(-1)
+
     # load previous manifest for --merge-previous. This gets tricky with
     # mismatched manifest types, which we forbid.
     try:

--- a/src/sourmash/sig/__main__.py
+++ b/src/sourmash/sig/__main__.py
@@ -1461,6 +1461,8 @@ def check(args):
             new_iloc = os.path.abspath(filename)
         elif args.relpath:
             # interpret paths relative to manifest directory.
+            if filename.startswith('/'):
+                notify(f"** WARNING: cannot convert abspath {filename} into relative path.")
             new_iloc = os.path.join(relpath, filename)
         else:
             # default: paths are relative to cwd. This breaks when sketches
@@ -1639,6 +1641,8 @@ def collect(args):
             new_iloc = os.path.abspath(loc)
         elif args.relpath:
             # interpret paths relative to manifest directory
+            if loc.startswith('/'):
+                notify(f"** WARNING: cannot convert abspath {loc} into relative path.")
             new_iloc = os.path.join(relpath, loc)
         else:
             # default: paths are relative to cwd. This breaks when sketches

--- a/src/sourmash/sig/__main__.py
+++ b/src/sourmash/sig/__main__.py
@@ -1461,8 +1461,10 @@ def check(args):
             new_iloc = os.path.abspath(filename)
         elif args.relpath:
             # interpret paths relative to manifest directory.
-            if filename.startswith('/'):
-                notify(f"** WARNING: cannot convert abspath {filename} into relative path.")
+            if filename.startswith("/"):
+                notify(
+                    f"** WARNING: cannot convert abspath {filename} into relative path."
+                )
             new_iloc = os.path.join(relpath, filename)
         else:
             # default: paths are relative to cwd. This breaks when sketches
@@ -1641,7 +1643,7 @@ def collect(args):
             new_iloc = os.path.abspath(loc)
         elif args.relpath:
             # interpret paths relative to manifest directory
-            if loc.startswith('/'):
+            if loc.startswith("/"):
                 notify(f"** WARNING: cannot convert abspath {loc} into relative path.")
             new_iloc = os.path.join(relpath, loc)
         else:

--- a/src/sourmash/sig/__main__.py
+++ b/src/sourmash/sig/__main__.py
@@ -1615,7 +1615,7 @@ def collect(args):
     for n_files, loc in enumerate(args.locations):
         notify(f"Loading signature information from {loc}.")
 
-        if n_files % 100 == 0:
+        if n_files and n_files % 100 == 0:
             notify(f"... loaded {len(collected_mf)} sigs from {n_files} files")
         idx = sourmash.load_file_as_index(loc)
         if idx.manifest is None and require_manifest:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -95,6 +95,7 @@ def sig_save_extension_abund(request):
 def abspath_or_relpath(request):
     return request.param
 
+
 # this will fail if subdirs used; see #3008. but ths ensures v4 behavior of
 # sig collect/sig check works, where manifest paths interpreted relative
 # to cwd.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -89,6 +89,20 @@ def sig_save_extension_abund(request):
     return request.param
 
 
+# these should both always succeed for 'sig check' and 'sig collect' output
+# manifests.
+@pytest.fixture(params=["--abspath", "--relpath"])
+def abspath_or_relpath(request):
+    return request.param
+
+# this will fail if subdirs used; see #3008. but ths ensures v4 behavior of
+# sig collect/sig check works, where manifest paths interpreted relative
+# to cwd.
+@pytest.fixture(params=["--no-abspath", "--abspath", "--relpath"])
+def abspath_relpath_v4(request):
+    return request.param
+
+
 # --- BEGIN - Only run tests using a particular fixture --- #
 # Cribbed from: http://pythontesting.net/framework/pytest/pytest-run-tests-using-particular-fixture/
 def pytest_collection_modifyitems(items, config):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -96,8 +96,8 @@ def abspath_or_relpath(request):
     return request.param
 
 
-# this will fail if subdirs used; see #3008. but ths ensures v4 behavior of
-# sig collect/sig check works, where manifest paths interpreted relative
+# this will fail if subdirs used; see #3008. but this ensures v4 behavior of
+# sig collect/sig check works, where manifest paths are interpreted relative
 # to cwd.
 @pytest.fixture(params=["--no-abspath", "--abspath", "--relpath"])
 def abspath_relpath_v4(request):

--- a/tests/test_cmd_signature.py
+++ b/tests/test_cmd_signature.py
@@ -31,6 +31,11 @@ def _write_file(runtmp, basename, lines, *, gz=False):
     return loc
 
 
+@pytest.fixture(params=['--no-abspath', '--abspath'])
+def abspath(request):
+    return request.param
+
+
 def test_run_sourmash_signature_cmd():
     status, out, err = utils.runscript("sourmash", ["signature"], fail_ok=True)
     assert "sourmash: error: argument cmd: invalid choice:" not in err
@@ -3798,6 +3803,7 @@ signature license: CC0
 
 def test_sig_describe_3_manifest_works(runtmp):
     # test on a manifest with relative paths, in proper location
+    # @CTB => has a / in it
     mf = utils.get_test_data("scaled/mf.csv")
     runtmp.sourmash("sig", "describe", mf, "--csv", "out.csv")
 
@@ -4799,13 +4805,13 @@ def test_sig_kmers_2_hp(runtmp):
     assert check_mh2.similarity(mh) == 1.0
 
 
-def test_sig_check_1(runtmp):
+def test_sig_check_1(runtmp, abspath):
     # basic check functionality
     sigfiles = glob.glob(utils.get_test_data("gather/GCF*.sig"))
     picklist = utils.get_test_data("gather/salmonella-picklist.csv")
 
     runtmp.sourmash(
-        "sig", "check", *sigfiles, "--picklist", f"{picklist}::manifest", "-m", "mf.csv"
+        "sig", "check", *sigfiles, "--picklist", f"{picklist}::manifest", "-m", "mf.csv", abspath
     )
 
     out_mf = runtmp.output("mf.csv")
@@ -4826,7 +4832,7 @@ def test_sig_check_1(runtmp):
     assert 31 in ksizes
 
 
-def test_sig_check_1_mf_csv_gz(runtmp):
+def test_sig_check_1_mf_csv_gz(runtmp, abspath):
     # basic check functionality, with gzipped manifest output
     sigfiles = glob.glob(utils.get_test_data("gather/GCF*.sig"))
     picklist = utils.get_test_data("gather/salmonella-picklist.csv")
@@ -4839,6 +4845,7 @@ def test_sig_check_1_mf_csv_gz(runtmp):
         f"{picklist}::manifest",
         "-m",
         "mf.csv.gz",
+        abspath
     )
 
     out_mf = runtmp.output("mf.csv.gz")
@@ -4859,7 +4866,7 @@ def test_sig_check_1_mf_csv_gz(runtmp):
     assert 31 in ksizes
 
 
-def test_sig_check_1_gz(runtmp):
+def test_sig_check_1_gz(runtmp, abspath):
     # basic check functionality with gzipped picklist
     sigfiles = glob.glob(utils.get_test_data("gather/GCF*.sig"))
     picklist = utils.get_test_data("gather/salmonella-picklist.csv")
@@ -4877,6 +4884,7 @@ def test_sig_check_1_gz(runtmp):
         "salmonella.csv.gz::manifest",
         "-m",
         "mf.csv",
+        abspath
     )
 
     out_mf = runtmp.output("mf.csv")
@@ -4897,7 +4905,7 @@ def test_sig_check_1_gz(runtmp):
     assert 31 in ksizes
 
 
-def test_sig_check_1_nofail(runtmp):
+def test_sig_check_1_nofail(runtmp, abspath):
     # basic check functionality with --fail-if-missing
     sigfiles = glob.glob(utils.get_test_data("gather/GCF*.sig"))
     picklist = utils.get_test_data("gather/salmonella-picklist.csv")
@@ -4911,6 +4919,7 @@ def test_sig_check_1_nofail(runtmp):
         "-m",
         "mf.csv",
         "--fail-if-missing",
+        abspath
     )
 
     out_mf = runtmp.output("mf.csv")
@@ -4952,7 +4961,7 @@ def test_sig_check_1_no_picklist(runtmp):
         ("name", "identprefix"),
     ),
 )
-def test_sig_check_1_column(runtmp, column, coltype):
+def test_sig_check_1_column(runtmp, column, coltype, abspath):
     # basic check functionality for various columns/coltypes
     sigfiles = glob.glob(utils.get_test_data("gather/GCF*.sig"))
     picklist = utils.get_test_data("gather/salmonella-picklist.csv")
@@ -4967,6 +4976,7 @@ def test_sig_check_1_column(runtmp, column, coltype):
         "mf.csv",
         "-o",
         "missing.csv",
+        abspath
     )
 
     out_mf = runtmp.output("mf.csv")
@@ -4987,7 +4997,7 @@ def test_sig_check_1_column(runtmp, column, coltype):
     assert 31 in ksizes
 
 
-def test_sig_check_1_diff_col_name(runtmp):
+def test_sig_check_1_diff_col_name(runtmp, abspath):
     # 'sig check' with 'name2' column instead of default name
     sigfiles = glob.glob(utils.get_test_data("gather/GCF*.sig"))
     picklist = utils.get_test_data("gather/salmonella-picklist-diffcolumn.csv")
@@ -5002,6 +5012,7 @@ def test_sig_check_1_diff_col_name(runtmp):
         "missing.csv",
         "-m",
         "mf.csv",
+        abspath
     )
 
     out_mf = runtmp.output("mf.csv")
@@ -5036,7 +5047,7 @@ def test_sig_check_1_diff_col_name(runtmp):
     assert rows[1][0] == "NOT THERE"
 
 
-def test_sig_check_1_diff_col_name_zip(runtmp):
+def test_sig_check_1_diff_col_name_zip(runtmp, abspath):
     # 'sig check' with 'name2' column instead of default name, on a zip file
     sigfiles = glob.glob(utils.get_test_data("gather/GCF*.sig"))
     picklist = utils.get_test_data("gather/salmonella-picklist-diffcolumn.csv")
@@ -5055,6 +5066,7 @@ def test_sig_check_1_diff_col_name_zip(runtmp):
         "missing.csv",
         "-m",
         "mf.csv",
+        abspath,
     )
 
     out_mf = runtmp.output("mf.csv")
@@ -5089,7 +5101,7 @@ def test_sig_check_1_diff_col_name_zip(runtmp):
     assert rows[1][0] == "NOT THERE"
 
 
-def test_sig_check_1_diff_col_name_exclude(runtmp):
+def test_sig_check_1_diff_col_name_exclude(runtmp, abspath):
     # 'sig check' with 'name2' column, :exclude picklist
     sigfiles = glob.glob(utils.get_test_data("gather/GCF*.sig"))
     picklist = utils.get_test_data("gather/salmonella-picklist-diffcolumn.csv")
@@ -5102,6 +5114,7 @@ def test_sig_check_1_diff_col_name_exclude(runtmp):
         f"{picklist}:name2:name:exclude",
         "-m",
         "mf.csv",
+        abspath
     )
 
     out_mf = runtmp.output("mf.csv")
@@ -5122,7 +5135,7 @@ def test_sig_check_1_diff_col_name_exclude(runtmp):
     assert 31 in ksizes
 
 
-def test_sig_check_1_ksize(runtmp):
+def test_sig_check_1_ksize(runtmp, abspath):
     # basic check functionality with selection for ksize
     sigfiles = glob.glob(utils.get_test_data("gather/GCF*.sig"))
     picklist = utils.get_test_data("gather/salmonella-picklist.csv")
@@ -5137,6 +5150,7 @@ def test_sig_check_1_ksize(runtmp):
         f"{picklist}::manifest",
         "-m",
         "mf.csv",
+        abspath,
     )
 
     out_mf = runtmp.output("mf.csv")
@@ -5155,7 +5169,7 @@ def test_sig_check_1_ksize(runtmp):
     assert 31 in ksizes
 
 
-def test_sig_check_1_ksize_output_sql(runtmp):
+def test_sig_check_1_ksize_output_sql(runtmp, abspath):
     # basic check functionality with selection for ksize
     sigfiles = glob.glob(utils.get_test_data("gather/GCF*.sig"))
     picklist = utils.get_test_data("gather/salmonella-picklist.csv")
@@ -5172,6 +5186,7 @@ def test_sig_check_1_ksize_output_sql(runtmp):
         "mf.mfsql",
         "-F",
         "sql",
+        abspath
     )
 
     out_mf = runtmp.output("mf.mfsql")
@@ -5190,7 +5205,7 @@ def test_sig_check_1_ksize_output_sql(runtmp):
     assert 31 in ksizes
 
 
-def test_sig_check_2_output_missing(runtmp):
+def test_sig_check_2_output_missing(runtmp, abspath):
     # output missing all as identical to input picklist
     sigfiles = utils.get_test_data("gather/combined.sig")
     picklist = utils.get_test_data("gather/salmonella-picklist.csv")
@@ -5205,6 +5220,7 @@ def test_sig_check_2_output_missing(runtmp):
         "missing.csv",
         "-m",
         "mf.csv",
+        abspath,
     )
 
     out_csv = runtmp.output("missing.csv")
@@ -5265,7 +5281,7 @@ def test_sig_check_2_output_missing_error_exit(runtmp):
         ("name", "identprefix"),
     ),
 )
-def test_sig_check_2_output_missing_column(runtmp, column, coltype):
+def test_sig_check_2_output_missing_column(runtmp, column, coltype, abspath):
     # output missing all as identical to input picklist
     sigfiles = utils.get_test_data("gather/combined.sig")
     picklist = utils.get_test_data("gather/salmonella-picklist.csv")
@@ -5278,6 +5294,7 @@ def test_sig_check_2_output_missing_column(runtmp, column, coltype):
         f"{picklist}::manifest",
         "-o",
         "missing.csv",
+        abspath
     )
 
     out_csv = runtmp.output("missing.csv")
@@ -5328,7 +5345,7 @@ def test_sig_check_3_no_manifest(runtmp):
     assert "sig check requires a manifest by default, but no manifest present." in err
 
 
-def test_sig_check_3_no_manifest_ok(runtmp):
+def test_sig_check_3_no_manifest_ok(runtmp, abspath):
     # generate manifest if --no-require-manifest
     sbt = utils.get_test_data("v6.sbt.zip")
     picklist = utils.get_test_data("v6.sbt.zip.mf.csv")
@@ -5340,6 +5357,7 @@ def test_sig_check_3_no_manifest_ok(runtmp):
         "--no-require-manifest",
         "--picklist",
         f"{picklist}::manifest",
+        abspath,
     )
 
     print(runtmp.last_result.out)
@@ -5350,7 +5368,7 @@ def test_sig_check_3_no_manifest_ok(runtmp):
     )
 
 
-def test_sig_check_4_manifest_cwd_cwd(runtmp):
+def test_sig_check_4_manifest_cwd_cwd(runtmp, abspath):
     # check: manifest and sigs in cwd
     prot_zip = utils.get_test_data("prot/all.zip")
 
@@ -5369,6 +5387,7 @@ def test_sig_check_4_manifest_cwd_cwd(runtmp):
         "--picklist",
         "picklist.csv::manifest",
         "prot.zip",
+        abspath,
     )
 
     # check that it all works
@@ -5395,13 +5414,16 @@ def test_sig_check_4_manifest_subdir_cwd(runtmp):
         "--picklist",
         "picklist.csv::manifest",
         "prot.zip",
+        "--relpath",
     )
+
+    print(runtmp.last_result.out)
+    print(runtmp.last_result.err)
 
     # check that it all works
     runtmp.sourmash("sig", "cat", "mf_dir/mf.csv")
 
-
-def test_sig_check_4_manifest_cwd_subdir(runtmp):
+def test_sig_check_4_manifest_cwd_subdir(runtmp, abspath):
     # check: manifest in cwd and sigs in subdir
     prot_zip = utils.get_test_data("prot/all.zip")
 
@@ -5421,7 +5443,11 @@ def test_sig_check_4_manifest_cwd_subdir(runtmp):
         "--picklist",
         "picklist.csv::manifest",
         "zip_dir/prot.zip",
+        abspath,
     )
+
+    print(runtmp.last_result.out)
+    print(runtmp.last_result.err)
 
     # check that it all works
     runtmp.sourmash("sig", "cat", "mf.csv")
@@ -5448,7 +5474,11 @@ def test_sig_check_4_manifest_subdir_subdir(runtmp):
         "--picklist",
         "picklist.csv::manifest",
         "zip_dir/prot.zip",
+        "--relpath",
     )
+
+    print(runtmp.last_result.out)
+    print(runtmp.last_result.err)
 
     # check that it all works
     runtmp.sourmash("sig", "cat", "mf_dir/mf.csv")

--- a/tests/test_cmd_signature.py
+++ b/tests/test_cmd_signature.py
@@ -5352,81 +5352,103 @@ def test_sig_check_3_no_manifest_ok(runtmp):
 
 def test_sig_check_4_manifest_cwd_cwd(runtmp):
     # check: manifest and sigs in cwd
-    prot_zip = utils.get_test_data('prot/all.zip')
+    prot_zip = utils.get_test_data("prot/all.zip")
 
-    shutil.copyfile(prot_zip, runtmp.output('prot.zip'))
+    shutil.copyfile(prot_zip, runtmp.output("prot.zip"))
 
     # generate a picklist, whatever
-    runtmp.sourmash('sig', 'manifest', 'prot.zip', '-o', 'picklist.csv')
-    assert os.path.exists(runtmp.output('picklist.csv'))
+    runtmp.sourmash("sig", "manifest", "prot.zip", "-o", "picklist.csv")
+    assert os.path.exists(runtmp.output("picklist.csv"))
 
     # use picklist with sig check to generate a manifest
-    runtmp.sourmash('sig', 'check', '-m', 'mf.csv',
-                    '--picklist', 'picklist.csv::manifest',
-                    'prot.zip')
+    runtmp.sourmash(
+        "sig",
+        "check",
+        "-m",
+        "mf.csv",
+        "--picklist",
+        "picklist.csv::manifest",
+        "prot.zip",
+    )
 
     # check that it all works
-    runtmp.sourmash('sig', 'cat', 'mf.csv')
+    runtmp.sourmash("sig", "cat", "mf.csv")
 
 
 def test_sig_check_4_manifest_subdir_cwd(runtmp):
     # check: manifest in subdir and sigs in cwd
-    prot_zip = utils.get_test_data('prot/all.zip')
+    prot_zip = utils.get_test_data("prot/all.zip")
 
-    shutil.copyfile(prot_zip, runtmp.output('prot.zip'))
-    os.mkdir(runtmp.output('mf_dir'))
+    shutil.copyfile(prot_zip, runtmp.output("prot.zip"))
+    os.mkdir(runtmp.output("mf_dir"))
 
     # generate a picklist, whatever
-    runtmp.sourmash('sig', 'manifest', 'prot.zip', '-o', 'picklist.csv')
-    assert os.path.exists(runtmp.output('picklist.csv'))
+    runtmp.sourmash("sig", "manifest", "prot.zip", "-o", "picklist.csv")
+    assert os.path.exists(runtmp.output("picklist.csv"))
 
     # use picklist with sig check to generate a manifest
-    runtmp.sourmash('sig', 'check', '-m', 'mf_dir/mf.csv',
-                    '--picklist', 'picklist.csv::manifest',
-                    'prot.zip')
+    runtmp.sourmash(
+        "sig",
+        "check",
+        "-m",
+        "mf_dir/mf.csv",
+        "--picklist",
+        "picklist.csv::manifest",
+        "prot.zip",
+    )
 
     # check that it all works
-    runtmp.sourmash('sig', 'cat', 'mf_dir/mf.csv')
+    runtmp.sourmash("sig", "cat", "mf_dir/mf.csv")
 
 
 def test_sig_check_4_manifest_cwd_subdir(runtmp):
     # check: manifest in cwd and sigs in subdir
-    prot_zip = utils.get_test_data('prot/all.zip')
+    prot_zip = utils.get_test_data("prot/all.zip")
 
-    os.mkdir(runtmp.output('zip_dir'))
-    shutil.copyfile(prot_zip, runtmp.output('zip_dir/prot.zip'))
+    os.mkdir(runtmp.output("zip_dir"))
+    shutil.copyfile(prot_zip, runtmp.output("zip_dir/prot.zip"))
 
     # generate a picklist, whatever
-    runtmp.sourmash('sig', 'manifest', 'zip_dir/prot.zip',
-                    '-o', 'picklist.csv')
-    assert os.path.exists(runtmp.output('picklist.csv'))
+    runtmp.sourmash("sig", "manifest", "zip_dir/prot.zip", "-o", "picklist.csv")
+    assert os.path.exists(runtmp.output("picklist.csv"))
 
     # use picklist with sig check to generate a manifest
-    runtmp.sourmash('sig', 'check', '-m', 'mf.csv',
-                    '--picklist', 'picklist.csv::manifest',
-                    'zip_dir/prot.zip')
+    runtmp.sourmash(
+        "sig",
+        "check",
+        "-m",
+        "mf.csv",
+        "--picklist",
+        "picklist.csv::manifest",
+        "zip_dir/prot.zip",
+    )
 
     # check that it all works
-    runtmp.sourmash('sig', 'cat', 'mf.csv')
+    runtmp.sourmash("sig", "cat", "mf.csv")
 
 
 def test_sig_check_4_manifest_subdir_subdir(runtmp):
     # check: manifest and sigs in subdir
-    prot_zip = utils.get_test_data('prot/all.zip')
+    prot_zip = utils.get_test_data("prot/all.zip")
 
-    os.mkdir(runtmp.output('zip_dir'))
-    shutil.copyfile(prot_zip, runtmp.output('zip_dir/prot.zip'))
-    os.mkdir(runtmp.output('mf_dir'))
+    os.mkdir(runtmp.output("zip_dir"))
+    shutil.copyfile(prot_zip, runtmp.output("zip_dir/prot.zip"))
+    os.mkdir(runtmp.output("mf_dir"))
 
     # generate a picklist, whatever
-    runtmp.sourmash('sig', 'manifest', 'zip_dir/prot.zip',
-                    '-o', 'picklist.csv')
-    assert os.path.exists(runtmp.output('picklist.csv'))
+    runtmp.sourmash("sig", "manifest", "zip_dir/prot.zip", "-o", "picklist.csv")
+    assert os.path.exists(runtmp.output("picklist.csv"))
 
     # use picklist with sig check to generate a manifest
-    runtmp.sourmash('sig', 'check', '-m', 'mf_dir/mf.csv',
-                    '--picklist', 'picklist.csv::manifest',
-                    'zip_dir/prot.zip')
+    runtmp.sourmash(
+        "sig",
+        "check",
+        "-m",
+        "mf_dir/mf.csv",
+        "--picklist",
+        "picklist.csv::manifest",
+        "zip_dir/prot.zip",
+    )
 
     # check that it all works
-    runtmp.sourmash('sig', 'cat', 'mf_dir/mf.csv')
+    runtmp.sourmash("sig", "cat", "mf_dir/mf.csv")

--- a/tests/test_cmd_signature.py
+++ b/tests/test_cmd_signature.py
@@ -5348,3 +5348,85 @@ def test_sig_check_3_no_manifest_ok(runtmp):
         "for given picklist, found 7 matches to 7 distinct values"
         in runtmp.last_result.err
     )
+
+
+def test_sig_check_4_manifest_cwd_cwd(runtmp):
+    # check: manifest and sigs in cwd
+    prot_zip = utils.get_test_data('prot/all.zip')
+
+    shutil.copyfile(prot_zip, runtmp.output('prot.zip'))
+
+    # generate a picklist, whatever
+    runtmp.sourmash('sig', 'manifest', 'prot.zip', '-o', 'picklist.csv')
+    assert os.path.exists(runtmp.output('picklist.csv'))
+
+    # use picklist with sig check to generate a manifest
+    runtmp.sourmash('sig', 'check', '-m', 'mf.csv',
+                    '--picklist', 'picklist.csv::manifest',
+                    'prot.zip')
+
+    # check that it all works
+    runtmp.sourmash('sig', 'cat', 'mf.csv')
+
+
+def test_sig_check_4_manifest_subdir_cwd(runtmp):
+    # check: manifest in subdir and sigs in cwd
+    prot_zip = utils.get_test_data('prot/all.zip')
+
+    shutil.copyfile(prot_zip, runtmp.output('prot.zip'))
+    os.mkdir(runtmp.output('mf_dir'))
+
+    # generate a picklist, whatever
+    runtmp.sourmash('sig', 'manifest', 'prot.zip', '-o', 'picklist.csv')
+    assert os.path.exists(runtmp.output('picklist.csv'))
+
+    # use picklist with sig check to generate a manifest
+    runtmp.sourmash('sig', 'check', '-m', 'mf_dir/mf.csv',
+                    '--picklist', 'picklist.csv::manifest',
+                    'prot.zip')
+
+    # check that it all works
+    runtmp.sourmash('sig', 'cat', 'mf_dir/mf.csv')
+
+
+def test_sig_check_4_manifest_cwd_subdir(runtmp):
+    # check: manifest in cwd and sigs in subdir
+    prot_zip = utils.get_test_data('prot/all.zip')
+
+    os.mkdir(runtmp.output('zip_dir'))
+    shutil.copyfile(prot_zip, runtmp.output('zip_dir/prot.zip'))
+
+    # generate a picklist, whatever
+    runtmp.sourmash('sig', 'manifest', 'zip_dir/prot.zip',
+                    '-o', 'picklist.csv')
+    assert os.path.exists(runtmp.output('picklist.csv'))
+
+    # use picklist with sig check to generate a manifest
+    runtmp.sourmash('sig', 'check', '-m', 'mf.csv',
+                    '--picklist', 'picklist.csv::manifest',
+                    'zip_dir/prot.zip')
+
+    # check that it all works
+    runtmp.sourmash('sig', 'cat', 'mf.csv')
+
+
+def test_sig_check_4_manifest_subdir_subdir(runtmp):
+    # check: manifest and sigs in subdir
+    prot_zip = utils.get_test_data('prot/all.zip')
+
+    os.mkdir(runtmp.output('zip_dir'))
+    shutil.copyfile(prot_zip, runtmp.output('zip_dir/prot.zip'))
+    os.mkdir(runtmp.output('mf_dir'))
+
+    # generate a picklist, whatever
+    runtmp.sourmash('sig', 'manifest', 'zip_dir/prot.zip',
+                    '-o', 'picklist.csv')
+    assert os.path.exists(runtmp.output('picklist.csv'))
+
+    # use picklist with sig check to generate a manifest
+    runtmp.sourmash('sig', 'check', '-m', 'mf_dir/mf.csv',
+                    '--picklist', 'picklist.csv::manifest',
+                    'zip_dir/prot.zip')
+
+    # check that it all works
+    runtmp.sourmash('sig', 'cat', 'mf_dir/mf.csv')

--- a/tests/test_cmd_signature.py
+++ b/tests/test_cmd_signature.py
@@ -4833,6 +4833,43 @@ def test_sig_check_1(runtmp, abspath_relpath_v4):
     assert 31 in ksizes
 
 
+def test_sig_check_1_fail_abspath_relpath(runtmp):
+    # basic check functionality
+    sigfiles = glob.glob(utils.get_test_data("gather/GCF*.sig"))
+    picklist = utils.get_test_data("gather/salmonella-picklist.csv")
+
+    with pytest.raises(SourmashCommandFailed,
+                       match="Cannot specify both --abspath and --relpath; pick one!"):
+        runtmp.sourmash(
+            "sig",
+            "check",
+            *sigfiles,
+            "--picklist",
+            f"{picklist}::manifest",
+            "-m",
+            "mf.csv",
+            "--abspath", "--relpath"
+        )
+
+
+def test_sig_check_1_warn_abspath_relpath(runtmp, abspath_or_relpath):
+    # warn that without -m, --abspath/--relpath are not helpful
+    sigfiles = glob.glob(utils.get_test_data("gather/GCF*.sig"))
+    picklist = utils.get_test_data("gather/salmonella-picklist.csv")
+
+    runtmp.sourmash(
+        "sig",
+        "check",
+        *sigfiles,
+        "--picklist",
+        f"{picklist}::manifest",
+        abspath_or_relpath,
+    )
+
+    err = runtmp.last_result.err
+    assert " WARNING: --abspath and --relpath only have effects when saving a manifest" in err
+
+
 def test_sig_check_1_mf_csv_gz(runtmp, abspath_relpath_v4):
     # basic check functionality, with gzipped manifest output
     sigfiles = glob.glob(utils.get_test_data("gather/GCF*.sig"))

--- a/tests/test_cmd_signature.py
+++ b/tests/test_cmd_signature.py
@@ -30,19 +30,6 @@ def _write_file(runtmp, basename, lines, *, gz=False):
         fp.write("\n".join(lines))
     return loc
 
-# these should both always succeed for 'sig check' and 'sig collect' output
-# manifests.
-@pytest.fixture(params=["--abspath", "--relpath"])
-def abspath_or_relpath(request):
-    return request.param
-
-# this will fail if subdirs used; see #3008. but ths ensures v4 behavior of
-# sig collect/sig check works, where manifest paths interpreted relative
-# to cwd.
-@pytest.fixture(params=["--no-abspath", "--abspath", "--relpath"])
-def abspath_relpath_v4(request):
-    return request.param
-
 
 def test_run_sourmash_signature_cmd():
     status, out, err = utils.runscript("sourmash", ["signature"], fail_ok=True)

--- a/tests/test_cmd_signature.py
+++ b/tests/test_cmd_signature.py
@@ -5494,13 +5494,13 @@ def test_sig_check_5_relpath(runtmp):
     sigfiles = glob.glob(utils.get_test_data("gather/GCF*.sig"))
     picklist = utils.get_test_data("gather/salmonella-picklist.csv")
 
-    os.mkdir(runtmp.output('mf_dir'))
+    os.mkdir(runtmp.output("mf_dir"))
 
-    os.mkdir(runtmp.output('sigs_dir'))
+    os.mkdir(runtmp.output("sigs_dir"))
     new_names = []
     for f in sigfiles:
         basename = os.path.basename(f)
-        filename = os.path.join('sigs_dir', basename)
+        filename = os.path.join("sigs_dir", basename)
 
         shutil.copyfile(f, runtmp.output(filename))
         new_names.append(filename)
@@ -5513,7 +5513,7 @@ def test_sig_check_5_relpath(runtmp):
         f"{picklist}::manifest",
         "-m",
         "mf_dir/mf.csv",
-        "--relpath"
+        "--relpath",
     )
 
     out_mf = runtmp.output("mf_dir/mf.csv")
@@ -5524,8 +5524,8 @@ def test_sig_check_5_relpath(runtmp):
         mf = CollectionManifest.load_from_csv(fp)
     assert len(mf) == 24
 
-    locations = [ row['internal_location'] for row in mf.rows ]
-    expected_names = [ '../' + f for f in new_names ]
+    locations = [row["internal_location"] for row in mf.rows]
+    expected_names = ["../" + f for f in new_names]
     assert set(locations).issubset(expected_names), (locations, expected_names)
 
 
@@ -5535,11 +5535,11 @@ def test_sig_check_5_relpath_subdir(runtmp):
     sigfiles = glob.glob(utils.get_test_data("gather/GCF*.sig"))
     picklist = utils.get_test_data("gather/salmonella-picklist.csv")
 
-    os.mkdir(runtmp.output('sigs_dir'))
+    os.mkdir(runtmp.output("sigs_dir"))
     new_names = []
     for f in sigfiles:
         basename = os.path.basename(f)
-        filename = os.path.join('sigs_dir', basename)
+        filename = os.path.join("sigs_dir", basename)
 
         shutil.copyfile(f, runtmp.output(filename))
         new_names.append(filename)
@@ -5552,7 +5552,7 @@ def test_sig_check_5_relpath_subdir(runtmp):
         f"{picklist}::manifest",
         "-m",
         "mf.csv",
-        "--relpath"
+        "--relpath",
     )
 
     out_mf = runtmp.output("mf.csv")
@@ -5563,10 +5563,10 @@ def test_sig_check_5_relpath_subdir(runtmp):
         mf = CollectionManifest.load_from_csv(fp)
     assert len(mf) == 24
 
-    locations = [ row['internal_location'] for row in mf.rows ]
-    print('XXX', locations)
-    print('YYY', new_names)
-    expected_names = [ './' + f for f in new_names ]
+    locations = [row["internal_location"] for row in mf.rows]
+    print("XXX", locations)
+    print("YYY", new_names)
+    expected_names = ["./" + f for f in new_names]
     assert set(locations).issubset(expected_names), (locations, expected_names)
 
 
@@ -5579,7 +5579,7 @@ def test_sig_check_5_abspath(runtmp):
         shutil.copyfile(f, runtmp.output(os.path.basename(f)))
 
     # strip off abspath
-    sigfiles = [ os.path.basename(f) for f in sigfiles ]
+    sigfiles = [os.path.basename(f) for f in sigfiles]
 
     runtmp.sourmash(
         "sig",
@@ -5589,7 +5589,7 @@ def test_sig_check_5_abspath(runtmp):
         f"{picklist}::manifest",
         "-m",
         "mf.csv",
-        "--abspath"
+        "--abspath",
     )
 
     out_mf = runtmp.output("mf.csv")
@@ -5600,10 +5600,10 @@ def test_sig_check_5_abspath(runtmp):
         mf = CollectionManifest.load_from_csv(fp)
     assert len(mf) == 24
 
-    locations = [ row['internal_location'] for row in mf.rows ]
+    locations = [row["internal_location"] for row in mf.rows]
     for k in locations:
-        assert k.startswith('/') # absolute
-        assert os.path.basename(k) in sigfiles # converts back to basic
+        assert k.startswith("/")  # absolute
+        assert os.path.basename(k) in sigfiles  # converts back to basic
 
 
 def test_sig_check_5_no_abspath(runtmp):
@@ -5616,7 +5616,7 @@ def test_sig_check_5_no_abspath(runtmp):
         shutil.copyfile(f, runtmp.output(os.path.basename(f)))
 
     # strip off abspath
-    sigfiles = [ os.path.basename(f) for f in sigfiles ]
+    sigfiles = [os.path.basename(f) for f in sigfiles]
 
     runtmp.sourmash(
         "sig",
@@ -5637,6 +5637,6 @@ def test_sig_check_5_no_abspath(runtmp):
         mf = CollectionManifest.load_from_csv(fp)
     assert len(mf) == 24
 
-    locations = [ row['internal_location'] for row in mf.rows ]
+    locations = [row["internal_location"] for row in mf.rows]
     # no rewriting
     assert set(locations).issubset(sigfiles)

--- a/tests/test_cmd_signature.py
+++ b/tests/test_cmd_signature.py
@@ -31,7 +31,7 @@ def _write_file(runtmp, basename, lines, *, gz=False):
     return loc
 
 
-@pytest.fixture(params=['--no-abspath', '--abspath'])
+@pytest.fixture(params=["--no-abspath", "--abspath"])
 def abspath(request):
     return request.param
 
@@ -4811,7 +4811,14 @@ def test_sig_check_1(runtmp, abspath):
     picklist = utils.get_test_data("gather/salmonella-picklist.csv")
 
     runtmp.sourmash(
-        "sig", "check", *sigfiles, "--picklist", f"{picklist}::manifest", "-m", "mf.csv", abspath
+        "sig",
+        "check",
+        *sigfiles,
+        "--picklist",
+        f"{picklist}::manifest",
+        "-m",
+        "mf.csv",
+        abspath,
     )
 
     out_mf = runtmp.output("mf.csv")
@@ -4845,7 +4852,7 @@ def test_sig_check_1_mf_csv_gz(runtmp, abspath):
         f"{picklist}::manifest",
         "-m",
         "mf.csv.gz",
-        abspath
+        abspath,
     )
 
     out_mf = runtmp.output("mf.csv.gz")
@@ -4884,7 +4891,7 @@ def test_sig_check_1_gz(runtmp, abspath):
         "salmonella.csv.gz::manifest",
         "-m",
         "mf.csv",
-        abspath
+        abspath,
     )
 
     out_mf = runtmp.output("mf.csv")
@@ -4919,7 +4926,7 @@ def test_sig_check_1_nofail(runtmp, abspath):
         "-m",
         "mf.csv",
         "--fail-if-missing",
-        abspath
+        abspath,
     )
 
     out_mf = runtmp.output("mf.csv")
@@ -4976,7 +4983,7 @@ def test_sig_check_1_column(runtmp, column, coltype, abspath):
         "mf.csv",
         "-o",
         "missing.csv",
-        abspath
+        abspath,
     )
 
     out_mf = runtmp.output("mf.csv")
@@ -5012,7 +5019,7 @@ def test_sig_check_1_diff_col_name(runtmp, abspath):
         "missing.csv",
         "-m",
         "mf.csv",
-        abspath
+        abspath,
     )
 
     out_mf = runtmp.output("mf.csv")
@@ -5114,7 +5121,7 @@ def test_sig_check_1_diff_col_name_exclude(runtmp, abspath):
         f"{picklist}:name2:name:exclude",
         "-m",
         "mf.csv",
-        abspath
+        abspath,
     )
 
     out_mf = runtmp.output("mf.csv")
@@ -5186,7 +5193,7 @@ def test_sig_check_1_ksize_output_sql(runtmp, abspath):
         "mf.mfsql",
         "-F",
         "sql",
-        abspath
+        abspath,
     )
 
     out_mf = runtmp.output("mf.mfsql")
@@ -5294,7 +5301,7 @@ def test_sig_check_2_output_missing_column(runtmp, column, coltype, abspath):
         f"{picklist}::manifest",
         "-o",
         "missing.csv",
-        abspath
+        abspath,
     )
 
     out_csv = runtmp.output("missing.csv")
@@ -5422,6 +5429,7 @@ def test_sig_check_4_manifest_subdir_cwd(runtmp):
 
     # check that it all works
     runtmp.sourmash("sig", "cat", "mf_dir/mf.csv")
+
 
 def test_sig_check_4_manifest_cwd_subdir(runtmp, abspath):
     # check: manifest in cwd and sigs in subdir

--- a/tests/test_cmd_signature.py
+++ b/tests/test_cmd_signature.py
@@ -4838,8 +4838,10 @@ def test_sig_check_1_fail_abspath_relpath(runtmp):
     sigfiles = glob.glob(utils.get_test_data("gather/GCF*.sig"))
     picklist = utils.get_test_data("gather/salmonella-picklist.csv")
 
-    with pytest.raises(SourmashCommandFailed,
-                       match="Cannot specify both --abspath and --relpath; pick one!"):
+    with pytest.raises(
+        SourmashCommandFailed,
+        match="Cannot specify both --abspath and --relpath; pick one!",
+    ):
         runtmp.sourmash(
             "sig",
             "check",
@@ -4848,7 +4850,8 @@ def test_sig_check_1_fail_abspath_relpath(runtmp):
             f"{picklist}::manifest",
             "-m",
             "mf.csv",
-            "--abspath", "--relpath"
+            "--abspath",
+            "--relpath",
         )
 
 
@@ -4867,7 +4870,10 @@ def test_sig_check_1_warn_abspath_relpath(runtmp, abspath_or_relpath):
     )
 
     err = runtmp.last_result.err
-    assert " WARNING: --abspath and --relpath only have effects when saving a manifest" in err
+    assert (
+        " WARNING: --abspath and --relpath only have effects when saving a manifest"
+        in err
+    )
 
 
 def test_sig_check_1_mf_csv_gz(runtmp, abspath_relpath_v4):

--- a/tests/test_cmd_signature_collect.py
+++ b/tests/test_cmd_signature_collect.py
@@ -449,3 +449,81 @@ def test_sig_collect_5_no_manifest_sbt_succeed(runtmp, manifest_db_format, abspa
     locations = set([row["internal_location"] for row in manifest.rows])
     assert len(locations) == 1, locations
     assert sbt_zip in locations
+
+
+def test_sig_collect_6_path_cwd_cwd(runtmp, manifest_db_format, abspath_relpath_v4):
+    # check: manifest and sigs in cwd
+    protzip = utils.get_test_data("prot/protein.zip")
+
+    ext = "sqlmf" if manifest_db_format == "sql" else "csv"
+
+    protzip_path = "protein.zip"
+    shutil.copyfile(protzip, runtmp.output(protzip_path))
+
+    mf_path = f"mf.{ext}"
+
+    runtmp.sourmash(
+        "sig", "collect", protzip_path, "-o", mf_path, "-F", manifest_db_format, abspath_relpath_v4
+    )
+
+    runtmp.sourmash("sig", "cat", mf_path)
+
+
+def test_sig_collect_6_path_cwd_subdir(runtmp, manifest_db_format, abspath_relpath_v4):
+    # check: manifest in cwd, sigs in subdir
+    protzip = utils.get_test_data("prot/protein.zip")
+
+    ext = "sqlmf" if manifest_db_format == "sql" else "csv"
+
+    os.mkdir(runtmp.output("sigs_dir"))
+    protzip_path = "sigs_dir/protein.zip"
+    shutil.copyfile(protzip, runtmp.output(protzip_path))
+
+    mf_path = f"mf.{ext}"
+
+    runtmp.sourmash(
+        "sig", "collect", protzip_path, "-o", mf_path, "-F", manifest_db_format, abspath_relpath_v4
+    )
+
+    runtmp.sourmash("sig", "cat", mf_path)
+
+
+def test_sig_collect_6_path_subdir_cwd(runtmp, manifest_db_format, abspath_or_relpath):
+    # check: manifest in cwd, sigs in subdir.  note, fails with default v4
+    # behavior. see #3008.
+    protzip = utils.get_test_data("prot/protein.zip")
+
+    ext = "sqlmf" if manifest_db_format == "sql" else "csv"
+
+    protzip_path = "protein.zip"
+    shutil.copyfile(protzip, runtmp.output(protzip_path))
+
+    os.mkdir(runtmp.output("mf_dir"))
+    mf_path = f"mf_dir/mf.{ext}"
+
+    runtmp.sourmash(
+        "sig", "collect", protzip_path, "-o", mf_path, "-F", manifest_db_format, abspath_or_relpath,
+    )
+
+    runtmp.sourmash("sig", "cat", mf_path)
+
+
+def test_sig_collect_6_path_subdir_subdir(runtmp, manifest_db_format, abspath_or_relpath):
+    # check: manifest and sigs in subdir.  note, fails with default v4
+    # behavior. see #3008.
+    protzip = utils.get_test_data("prot/protein.zip")
+
+    ext = "sqlmf" if manifest_db_format == "sql" else "csv"
+
+    os.mkdir(runtmp.output("sigs_dir"))
+    protzip_path = "sigs_dir/protein.zip"
+    shutil.copyfile(protzip, runtmp.output(protzip_path))
+
+    os.mkdir(runtmp.output("mf_dir"))
+    mf_path = f"mf_dir/mf.{ext}"
+
+    runtmp.sourmash(
+        "sig", "collect", protzip_path, "-o", mf_path, "-F", manifest_db_format, abspath_or_relpath,
+    )
+
+    runtmp.sourmash("sig", "cat", mf_path)

--- a/tests/test_cmd_signature_collect.py
+++ b/tests/test_cmd_signature_collect.py
@@ -499,7 +499,14 @@ def test_sig_collect_6_path_cwd_cwd(runtmp, manifest_db_format, abspath_relpath_
     mf_path = f"mf.{ext}"
 
     runtmp.sourmash(
-        "sig", "collect", protzip_path, "-o", mf_path, "-F", manifest_db_format, abspath_relpath_v4
+        "sig",
+        "collect",
+        protzip_path,
+        "-o",
+        mf_path,
+        "-F",
+        manifest_db_format,
+        abspath_relpath_v4,
     )
 
     runtmp.sourmash("sig", "cat", mf_path)
@@ -518,7 +525,14 @@ def test_sig_collect_6_path_cwd_subdir(runtmp, manifest_db_format, abspath_relpa
     mf_path = f"mf.{ext}"
 
     runtmp.sourmash(
-        "sig", "collect", protzip_path, "-o", mf_path, "-F", manifest_db_format, abspath_relpath_v4
+        "sig",
+        "collect",
+        protzip_path,
+        "-o",
+        mf_path,
+        "-F",
+        manifest_db_format,
+        abspath_relpath_v4,
     )
 
     runtmp.sourmash("sig", "cat", mf_path)
@@ -538,13 +552,22 @@ def test_sig_collect_6_path_subdir_cwd(runtmp, manifest_db_format, abspath_or_re
     mf_path = f"mf_dir/mf.{ext}"
 
     runtmp.sourmash(
-        "sig", "collect", protzip_path, "-o", mf_path, "-F", manifest_db_format, abspath_or_relpath,
+        "sig",
+        "collect",
+        protzip_path,
+        "-o",
+        mf_path,
+        "-F",
+        manifest_db_format,
+        abspath_or_relpath,
     )
 
     runtmp.sourmash("sig", "cat", mf_path)
 
 
-def test_sig_collect_6_path_subdir_subdir(runtmp, manifest_db_format, abspath_or_relpath):
+def test_sig_collect_6_path_subdir_subdir(
+    runtmp, manifest_db_format, abspath_or_relpath
+):
     # check: manifest and sigs in subdir.  note, fails with default v4
     # behavior. see #3008.
     protzip = utils.get_test_data("prot/protein.zip")
@@ -559,7 +582,14 @@ def test_sig_collect_6_path_subdir_subdir(runtmp, manifest_db_format, abspath_or
     mf_path = f"mf_dir/mf.{ext}"
 
     runtmp.sourmash(
-        "sig", "collect", protzip_path, "-o", mf_path, "-F", manifest_db_format, abspath_or_relpath,
+        "sig",
+        "collect",
+        protzip_path,
+        "-o",
+        mf_path,
+        "-F",
+        manifest_db_format,
+        abspath_or_relpath,
     )
 
     runtmp.sourmash("sig", "cat", mf_path)

--- a/tests/test_cmd_signature_collect.py
+++ b/tests/test_cmd_signature_collect.py
@@ -455,12 +455,12 @@ def test_sig_collect_4_multiple_subdir_subdir_no_abspath(runtmp, manifest_db_for
     sig63 = utils.get_test_data("63.fa.sig")
 
     # copy files to tmp, where they will not have full paths
-    os.mkdir(runtmp.output('sigs_dir'))
+    os.mkdir(runtmp.output("sigs_dir"))
     shutil.copyfile(sig43, runtmp.output("sigs_dir/47.fa.sig"))
     shutil.copyfile(sig63, runtmp.output("sigs_dir/63.fa.sig"))
 
     # put manifest in subdir too.
-    os.mkdir(runtmp.output('mf_dir'))
+    os.mkdir(runtmp.output("mf_dir"))
 
     ext = "sqlmf" if manifest_db_format == "sql" else "csv"
 
@@ -473,7 +473,7 @@ def test_sig_collect_4_multiple_subdir_subdir_no_abspath(runtmp, manifest_db_for
         f"mf_dir/mf.{ext}",
         "-F",
         manifest_db_format,
-        "--relpath"
+        "--relpath",
     )
 
     manifest_fn = runtmp.output(f"mf_dir/mf.{ext}")
@@ -500,7 +500,7 @@ def test_sig_collect_4_multiple_cwd_subdir_no_abspath(runtmp, manifest_db_format
     sig63 = utils.get_test_data("63.fa.sig")
 
     # copy files to tmp, where they will not have full paths
-    os.mkdir(runtmp.output('sigs_dir'))
+    os.mkdir(runtmp.output("sigs_dir"))
     shutil.copyfile(sig43, runtmp.output("sigs_dir/47.fa.sig"))
     shutil.copyfile(sig63, runtmp.output("sigs_dir/63.fa.sig"))
 

--- a/tests/test_cmd_signature_collect.py
+++ b/tests/test_cmd_signature_collect.py
@@ -19,7 +19,15 @@ def test_sig_collect_0_nothing(runtmp, manifest_db_format, abspath_relpath_v4):
     if manifest_db_format != "sql":
         return
 
-    runtmp.sourmash("sig", "collect", "-o", f"mf.{ext}", "-F", manifest_db_format, abspath_relpath_v4)
+    runtmp.sourmash(
+        "sig",
+        "collect",
+        "-o",
+        f"mf.{ext}",
+        "-F",
+        manifest_db_format,
+        abspath_relpath_v4,
+    )
 
     manifest_fn = runtmp.output(f"mf.{ext}")
     manifest = BaseCollectionManifest.load_from_filename(manifest_fn)
@@ -34,7 +42,14 @@ def test_sig_collect_1_zipfile(runtmp, manifest_db_format, abspath_relpath_v4):
     ext = "sqlmf" if manifest_db_format == "sql" else "csv"
 
     runtmp.sourmash(
-        "sig", "collect", protzip, "-o", f"mf.{ext}", "-F", manifest_db_format, abspath_relpath_v4
+        "sig",
+        "collect",
+        protzip,
+        "-o",
+        f"mf.{ext}",
+        "-F",
+        manifest_db_format,
+        abspath_relpath_v4,
     )
 
     manifest_fn = runtmp.output(f"mf.{ext}")
@@ -50,7 +65,9 @@ def test_sig_collect_1_zipfile_csv_gz(runtmp, abspath_relpath_v4):
     # collect a manifest from a .zip file, save to csv.gz
     protzip = utils.get_test_data("prot/protein.zip")
 
-    runtmp.sourmash("sig", "collect", protzip, "-o", "mf.csv.gz", "-F", "csv", abspath_relpath_v4)
+    runtmp.sourmash(
+        "sig", "collect", protzip, "-o", "mf.csv.gz", "-F", "csv", abspath_relpath_v4
+    )
 
     manifest_fn = runtmp.output("mf.csv.gz")
 
@@ -71,7 +88,9 @@ def test_sig_collect_1_zipfile_csv_gz_roundtrip(runtmp, abspath_relpath_v4):
     # collect a manifest from a .zip file, save to csv.gz; then load again
     protzip = utils.get_test_data("prot/protein.zip")
 
-    runtmp.sourmash("sig", "collect", protzip, "-o", "mf.csv.gz", "-F", "csv", abspath_relpath_v4)
+    runtmp.sourmash(
+        "sig", "collect", protzip, "-o", "mf.csv.gz", "-F", "csv", abspath_relpath_v4
+    )
 
     manifest_fn = runtmp.output("mf.csv.gz")
 
@@ -133,7 +152,14 @@ def test_sig_collect_2_exists_merge(runtmp, manifest_db_format, abspath_relpath_
     ext = "sqlmf" if manifest_db_format == "sql" else "csv"
 
     runtmp.sourmash(
-        "sig", "collect", protzip, "-o", f"mf.{ext}", "-F", manifest_db_format, abspath_relpath_v4,
+        "sig",
+        "collect",
+        protzip,
+        "-o",
+        f"mf.{ext}",
+        "-F",
+        manifest_db_format,
+        abspath_relpath_v4,
     )
 
     manifest_fn = runtmp.output(f"mf.{ext}")
@@ -215,7 +241,15 @@ def test_sig_collect_2_no_exists_merge(runtmp, manifest_db_format, abspath_relpa
 
     # run with --merge but no previous:
     runtmp.sourmash(
-        "sig", "collect", allzip, "-o", manifest_fn, "-F", manifest_db_format, "--merge", abspath_relpath_v4,
+        "sig",
+        "collect",
+        allzip,
+        "-o",
+        manifest_fn,
+        "-F",
+        manifest_db_format,
+        "--merge",
+        abspath_relpath_v4,
     )
 
     manifest = BaseCollectionManifest.load_from_filename(manifest_fn)
@@ -424,7 +458,9 @@ def test_sig_collect_5_no_manifest_sbt_fail(runtmp, manifest_db_format):
         )
 
 
-def test_sig_collect_5_no_manifest_sbt_succeed(runtmp, manifest_db_format, abspath_relpath_v4):
+def test_sig_collect_5_no_manifest_sbt_succeed(
+    runtmp, manifest_db_format, abspath_relpath_v4
+):
     # generate a manifest from files that don't have one when --no-require
     sbt_zip = utils.get_test_data("v6.sbt.zip")
 
@@ -439,7 +475,7 @@ def test_sig_collect_5_no_manifest_sbt_succeed(runtmp, manifest_db_format, abspa
         f"mf.{ext}",
         "-F",
         manifest_db_format,
-        abspath_relpath_v4
+        abspath_relpath_v4,
     )
 
     manifest_fn = runtmp.output(f"mf.{ext}")

--- a/tests/test_cmd_signature_collect.py
+++ b/tests/test_cmd_signature_collect.py
@@ -41,8 +41,10 @@ def test_sig_collect_0_fail_abspath_relpath(runtmp, manifest_db_format):
     if manifest_db_format != "sql":
         return
 
-    with pytest.raises(SourmashCommandFailed,
-                       match="Cannot specify both --abspath and --relpath; pick one!"):
+    with pytest.raises(
+        SourmashCommandFailed,
+        match="Cannot specify both --abspath and --relpath; pick one!",
+    ):
         runtmp.sourmash(
             "sig",
             "collect",
@@ -50,7 +52,8 @@ def test_sig_collect_0_fail_abspath_relpath(runtmp, manifest_db_format):
             f"mf.{ext}",
             "-F",
             manifest_db_format,
-            "--abspath", "--relpath"
+            "--abspath",
+            "--relpath",
         )
 
 

--- a/tests/test_cmd_signature_collect.py
+++ b/tests/test_cmd_signature_collect.py
@@ -445,6 +445,94 @@ def test_sig_collect_4_multiple_no_abspath(runtmp, manifest_db_format):
     assert "47.fa.sig" in locations
     assert "63.fa.sig" in locations
 
+    runtmp.sourmash("sig", "cat", f"mf.{ext}")
+
+
+def test_sig_collect_4_multiple_subdir_subdir_no_abspath(runtmp, manifest_db_format):
+    # collect a manifest from sig files, no abspath; use a subdir for sketches
+    # this should work with default behavior.
+    sig43 = utils.get_test_data("47.fa.sig")
+    sig63 = utils.get_test_data("63.fa.sig")
+
+    # copy files to tmp, where they will not have full paths
+    os.mkdir(runtmp.output('sigs_dir'))
+    shutil.copyfile(sig43, runtmp.output("sigs_dir/47.fa.sig"))
+    shutil.copyfile(sig63, runtmp.output("sigs_dir/63.fa.sig"))
+
+    # put manifest in subdir too.
+    os.mkdir(runtmp.output('mf_dir'))
+
+    ext = "sqlmf" if manifest_db_format == "sql" else "csv"
+
+    runtmp.sourmash(
+        "sig",
+        "collect",
+        "sigs_dir/47.fa.sig",
+        "sigs_dir/63.fa.sig",
+        "-o",
+        f"mf_dir/mf.{ext}",
+        "-F",
+        manifest_db_format,
+        "--relpath"
+    )
+
+    manifest_fn = runtmp.output(f"mf_dir/mf.{ext}")
+    manifest = BaseCollectionManifest.load_from_filename(manifest_fn)
+
+    assert len(manifest) == 2
+    md5_list = [row["md5"] for row in manifest.rows]
+    assert "09a08691ce52952152f0e866a59f6261" in md5_list
+    assert "38729c6374925585db28916b82a6f513" in md5_list
+
+    locations = set([row["internal_location"] for row in manifest.rows])
+    print(locations)
+    assert len(locations) == 2, locations
+    assert "../sigs_dir/47.fa.sig" in locations
+    assert "../sigs_dir/63.fa.sig" in locations
+
+    runtmp.sourmash("sig", "cat", f"mf_dir/mf.{ext}")
+
+
+def test_sig_collect_4_multiple_cwd_subdir_no_abspath(runtmp, manifest_db_format):
+    # collect a manifest from sig files, no abspath; use a subdir for sketches
+    # this should work with default behavior.
+    sig43 = utils.get_test_data("47.fa.sig")
+    sig63 = utils.get_test_data("63.fa.sig")
+
+    # copy files to tmp, where they will not have full paths
+    os.mkdir(runtmp.output('sigs_dir'))
+    shutil.copyfile(sig43, runtmp.output("sigs_dir/47.fa.sig"))
+    shutil.copyfile(sig63, runtmp.output("sigs_dir/63.fa.sig"))
+
+    ext = "sqlmf" if manifest_db_format == "sql" else "csv"
+
+    runtmp.sourmash(
+        "sig",
+        "collect",
+        "sigs_dir/47.fa.sig",
+        "sigs_dir/63.fa.sig",
+        "-o",
+        f"mf.{ext}",
+        "-F",
+        manifest_db_format,
+    )
+
+    manifest_fn = runtmp.output(f"mf.{ext}")
+    manifest = BaseCollectionManifest.load_from_filename(manifest_fn)
+
+    assert len(manifest) == 2
+    md5_list = [row["md5"] for row in manifest.rows]
+    assert "09a08691ce52952152f0e866a59f6261" in md5_list
+    assert "38729c6374925585db28916b82a6f513" in md5_list
+
+    locations = set([row["internal_location"] for row in manifest.rows])
+    print(locations)
+    assert len(locations) == 2, locations
+    assert "sigs_dir/47.fa.sig" in locations
+    assert "sigs_dir/63.fa.sig" in locations
+
+    runtmp.sourmash("sig", "cat", f"mf.{ext}")
+
 
 def test_sig_collect_5_no_manifest_sbt_fail(runtmp, manifest_db_format):
     # collect a manifest from files that don't have one

--- a/tests/test_cmd_signature_collect.py
+++ b/tests/test_cmd_signature_collect.py
@@ -35,6 +35,25 @@ def test_sig_collect_0_nothing(runtmp, manifest_db_format, abspath_relpath_v4):
     assert len(manifest) == 0
 
 
+def test_sig_collect_0_fail_abspath_relpath(runtmp, manifest_db_format):
+    # check that it complains if both --abspath and --relpath are specified
+    ext = "sqlmf" if manifest_db_format == "sql" else "csv"
+    if manifest_db_format != "sql":
+        return
+
+    with pytest.raises(SourmashCommandFailed,
+                       match="Cannot specify both --abspath and --relpath; pick one!"):
+        runtmp.sourmash(
+            "sig",
+            "collect",
+            "-o",
+            f"mf.{ext}",
+            "-F",
+            manifest_db_format,
+            "--abspath", "--relpath"
+        )
+
+
 def test_sig_collect_1_zipfile(runtmp, manifest_db_format, abspath_relpath_v4):
     # collect a manifest from a .zip file
     protzip = utils.get_test_data("prot/protein.zip")

--- a/tests/test_cmd_signature_collect.py
+++ b/tests/test_cmd_signature_collect.py
@@ -13,13 +13,13 @@ import sourmash_tst_utils as utils
 from sourmash_tst_utils import SourmashCommandFailed
 
 
-def test_sig_collect_0_nothing(runtmp, manifest_db_format):
+def test_sig_collect_0_nothing(runtmp, manifest_db_format, abspath_relpath_v4):
     # run with just output
     ext = "sqlmf" if manifest_db_format == "sql" else "csv"
     if manifest_db_format != "sql":
         return
 
-    runtmp.sourmash("sig", "collect", "-o", f"mf.{ext}", "-F", manifest_db_format)
+    runtmp.sourmash("sig", "collect", "-o", f"mf.{ext}", "-F", manifest_db_format, abspath_relpath_v4)
 
     manifest_fn = runtmp.output(f"mf.{ext}")
     manifest = BaseCollectionManifest.load_from_filename(manifest_fn)
@@ -27,14 +27,14 @@ def test_sig_collect_0_nothing(runtmp, manifest_db_format):
     assert len(manifest) == 0
 
 
-def test_sig_collect_1_zipfile(runtmp, manifest_db_format):
+def test_sig_collect_1_zipfile(runtmp, manifest_db_format, abspath_relpath_v4):
     # collect a manifest from a .zip file
     protzip = utils.get_test_data("prot/protein.zip")
 
     ext = "sqlmf" if manifest_db_format == "sql" else "csv"
 
     runtmp.sourmash(
-        "sig", "collect", protzip, "-o", f"mf.{ext}", "-F", manifest_db_format
+        "sig", "collect", protzip, "-o", f"mf.{ext}", "-F", manifest_db_format, abspath_relpath_v4
     )
 
     manifest_fn = runtmp.output(f"mf.{ext}")
@@ -46,11 +46,11 @@ def test_sig_collect_1_zipfile(runtmp, manifest_db_format):
     assert "120d311cc785cc9d0df9dc0646b2b857" in md5_list
 
 
-def test_sig_collect_1_zipfile_csv_gz(runtmp):
+def test_sig_collect_1_zipfile_csv_gz(runtmp, abspath_relpath_v4):
     # collect a manifest from a .zip file, save to csv.gz
     protzip = utils.get_test_data("prot/protein.zip")
 
-    runtmp.sourmash("sig", "collect", protzip, "-o", "mf.csv.gz", "-F", "csv")
+    runtmp.sourmash("sig", "collect", protzip, "-o", "mf.csv.gz", "-F", "csv", abspath_relpath_v4)
 
     manifest_fn = runtmp.output("mf.csv.gz")
 
@@ -67,11 +67,11 @@ def test_sig_collect_1_zipfile_csv_gz(runtmp):
     assert "120d311cc785cc9d0df9dc0646b2b857" in md5_list
 
 
-def test_sig_collect_1_zipfile_csv_gz_roundtrip(runtmp):
+def test_sig_collect_1_zipfile_csv_gz_roundtrip(runtmp, abspath_relpath_v4):
     # collect a manifest from a .zip file, save to csv.gz; then load again
     protzip = utils.get_test_data("prot/protein.zip")
 
-    runtmp.sourmash("sig", "collect", protzip, "-o", "mf.csv.gz", "-F", "csv")
+    runtmp.sourmash("sig", "collect", protzip, "-o", "mf.csv.gz", "-F", "csv", abspath_relpath_v4)
 
     manifest_fn = runtmp.output("mf.csv.gz")
 
@@ -125,7 +125,7 @@ def test_sig_collect_2_exists_fail(runtmp, manifest_db_format):
         )
 
 
-def test_sig_collect_2_exists_merge(runtmp, manifest_db_format):
+def test_sig_collect_2_exists_merge(runtmp, manifest_db_format, abspath_relpath_v4):
     # collect a manifest from two .zip files
     protzip = utils.get_test_data("prot/protein.zip")
     allzip = utils.get_test_data("prot/all.zip")
@@ -133,7 +133,7 @@ def test_sig_collect_2_exists_merge(runtmp, manifest_db_format):
     ext = "sqlmf" if manifest_db_format == "sql" else "csv"
 
     runtmp.sourmash(
-        "sig", "collect", protzip, "-o", f"mf.{ext}", "-F", manifest_db_format
+        "sig", "collect", protzip, "-o", f"mf.{ext}", "-F", manifest_db_format, abspath_relpath_v4,
     )
 
     manifest_fn = runtmp.output(f"mf.{ext}")
@@ -205,7 +205,7 @@ def test_sig_collect_2_exists_csv_merge_sql(runtmp):
     assert "ERROR loading" in runtmp.last_result.err
 
 
-def test_sig_collect_2_no_exists_merge(runtmp, manifest_db_format):
+def test_sig_collect_2_no_exists_merge(runtmp, manifest_db_format, abspath_relpath_v4):
     # test 'merge' when args.output doesn't already exist => warning
     utils.get_test_data("prot/protein.zip")
     allzip = utils.get_test_data("prot/all.zip")
@@ -215,7 +215,7 @@ def test_sig_collect_2_no_exists_merge(runtmp, manifest_db_format):
 
     # run with --merge but no previous:
     runtmp.sourmash(
-        "sig", "collect", allzip, "-o", manifest_fn, "-F", manifest_db_format, "--merge"
+        "sig", "collect", allzip, "-o", manifest_fn, "-F", manifest_db_format, "--merge", abspath_relpath_v4,
     )
 
     manifest = BaseCollectionManifest.load_from_filename(manifest_fn)
@@ -424,7 +424,7 @@ def test_sig_collect_5_no_manifest_sbt_fail(runtmp, manifest_db_format):
         )
 
 
-def test_sig_collect_5_no_manifest_sbt_succeed(runtmp, manifest_db_format):
+def test_sig_collect_5_no_manifest_sbt_succeed(runtmp, manifest_db_format, abspath_relpath_v4):
     # generate a manifest from files that don't have one when --no-require
     sbt_zip = utils.get_test_data("v6.sbt.zip")
 
@@ -439,6 +439,7 @@ def test_sig_collect_5_no_manifest_sbt_succeed(runtmp, manifest_db_format):
         f"mf.{ext}",
         "-F",
         manifest_db_format,
+        abspath_relpath_v4
     )
 
     manifest_fn = runtmp.output(f"mf.{ext}")


### PR DESCRIPTION
This PR updates `sig collect` and `sig check` so that they can produce standalone manifests that work properly with default sourmash loading behavior. The default behavior produces broken manifests in some situations and is not changed, but will be deprecated in v5.

## Details

Currently, `sig collect` and `sig check` default to producing standalone manifests with internal path locations relative to the current working directory. This conflicts with the default `StandaloneManifest` behavior implemented in `save_load.py` that loads path locations relative to the manifest location. As a result, whenever the manifest was in a subdirectory, the standalone manifests output by `sig check` and `sig collect` were broken. The only way to make good manifests in this situation was to use `sig collect --abspath`, but `sig check` didn't support `--abspath`, and using absolute paths is brittle in situations where you want to distribute manifests.

This PR adds `--relpath` to both `sig check` and `sig collect`, and adds `--abspath` to `sig check`. It also demonstrates the bad behavior in tests and annotates the tests appropriately.

See https://github.com/sourmash-bio/sourmash/issues/3008#issuecomment-1975174211 for more detailed discussion of why I think `--relpath` is the right behavior for the future.

- [x] adds `--abspath` and `--relpath` to `sig check`, to properly support relative paths;
- [x] adds `--relpath` to `sig collect`, to properly support relative paths;
- [x] documents this behavior properly for creating standalone manifests;
- [x] create issue to change default `sig check` and `sig collect` behavior for v4, and disable cwd behavior.

Techie TODO:
- [x] explicitly test `relpath` and `abspath` behavior in `sig check`;
- [x] explicitly test `relpath` behavior in `sig collect`
- [x] write some tests for `sig check` and `sig collect` to explore the relative path loading issue, with all three combinations of relpath: mf in cwd, sigs in subdir; mf in subdir, sigs in cwd; mf in subdir, sigs in subdir.

Related issues:
* Addresses #3008
* Addresses issues in https://github.com/sourmash-bio/sourmash/issues/3048 by updating `sig check` to support `--relpath`;
* Fixes https://github.com/sourmash-bio/sourmash/issues/3053 - `--relpath` again