### PR TITLE
Remove methods that allocate, prefer iterators instead

### DIFF
--- a/src/core/src/ffi/minhash.rs
+++ b/src/core/src/ffi/minhash.rs
@@ -434,7 +434,7 @@ unsafe fn kmerminhash_intersection(ptr: *const SourmashKmerMinHash, other: *cons
     let isect = mh.intersection(other_mh)?;
     let mut new_mh = mh.clone();
     new_mh.clear();
-    new_mh.add_many(&isect.0)?;
+    new_mh.add_many(isect.0.iter().copied())?;
 
     Ok(SourmashKmerMinHash::from_rust(new_mh))
 }

--- a/src/core/src/ffi/minhash.rs
+++ b/src/core/src/ffi/minhash.rs
@@ -8,6 +8,7 @@ use crate::ffi::HashFunctions;
 use crate::signature::SeqToHashes;
 use crate::signature::SigsTrait;
 use crate::sketch::minhash::KmerMinHash;
+use crate::HashIntoType;
 
 pub struct SourmashKmerMinHash;
 
@@ -206,7 +207,7 @@ pub unsafe extern "C" fn kmerminhash_remove_many(
 ffi_fn! {
 unsafe fn kmerminhash_get_mins(ptr: *const SourmashKmerMinHash, size: *mut usize) -> Result<*const u64> {
     let mh = SourmashKmerMinHash::as_rust(ptr);
-    let output = mh.mins();
+    let output: Vec<HashIntoType> = mh.iter_mins().copied().collect();
     *size = output.len();
 
     // FIXME: make a SourmashSlice_u64 type?

--- a/src/core/src/ffi/signature.rs
+++ b/src/core/src/ffi/signature.rs
@@ -202,7 +202,7 @@ ffi_fn! {
 unsafe fn signature_get_mhs(ptr: *const SourmashSignature, size: *mut usize) -> Result<*mut *mut SourmashKmerMinHash> {
     let sig = SourmashSignature::as_rust(ptr);
 
-    let output = sig.sketches();
+    let output = sig.iter();
 
     // FIXME: how to fit this into the ForeignObject trait?
     let ptr_sigs: Vec<*mut Signature> = output.into_iter().map(|x| {

--- a/src/core/src/from.rs
+++ b/src/core/src/from.rs
@@ -65,7 +65,7 @@ mod test {
 
         let b_hashes = b.to_vec();
 
-        let s1: HashSet<_> = a.mins().into_iter().collect();
+        let s1: HashSet<_> = a.iter_mins().copied().collect();
         let s2: HashSet<_> = b_hashes.iter().map(|x| x.hash).collect();
         let i1 = &s1 & &s2;
 
@@ -73,8 +73,7 @@ mod test {
         assert!(i1.len() == b_hashes.len());
 
         if let Some(abunds) = a.abunds() {
-            let mins = a.mins();
-            let smap: HashMap<_, _> = mins.iter().zip(abunds.iter()).collect();
+            let smap: HashMap<_, _> = a.iter_mins().zip(abunds.iter()).collect();
             println!("{:?}", smap);
             for item in b_hashes.iter() {
                 assert!(smap.contains_key(&{ item.hash }));
@@ -101,19 +100,17 @@ mod test {
 
         let c = KmerMinHash::from(b);
 
-        let s1: HashSet<_> = a.mins().into_iter().collect();
-        let s2: HashSet<_> = c.mins().into_iter().collect();
+        let s1: HashSet<_> = a.iter_mins().collect();
+        let s2: HashSet<_> = c.iter_mins().collect();
         let i1 = &s1 & &s2;
 
-        assert!(i1.len() == a.mins().len());
-        assert!(i1.len() == c.mins().len());
+        assert!(i1.len() == a.iter_mins().count());
+        assert!(i1.len() == c.iter_mins().count());
 
         if let Some(a_abunds) = a.abunds() {
             if let Some(c_abunds) = c.abunds() {
-                let a_mins = a.mins();
-                let a_smap: HashMap<_, _> = a_mins.iter().zip(a_abunds.iter()).collect();
-                let c_mins = c.mins();
-                let c_smap: HashMap<_, _> = c_mins.iter().zip(c_abunds.iter()).collect();
+                let a_smap: HashMap<_, _> = a.iter_mins().zip(a_abunds.iter()).collect();
+                let c_smap: HashMap<_, _> = c.iter_mins().zip(c_abunds.iter()).collect();
                 for item in a_smap.iter() {
                     assert!(c_smap.contains_key(*item.0));
                     assert!(c_smap.get(*item.0).unwrap() == item.1);

--- a/src/core/src/from.rs
+++ b/src/core/src/from.rs
@@ -16,7 +16,7 @@ impl From<MashSketcher> for KmerMinHash {
 
         let mut new_mh = KmerMinHash::new(
             0,
-            values.get(0).unwrap().kmer.len() as u32,
+            values.first().unwrap().kmer.len() as u32,
             HashFunctions::Murmur64Dna,
             42,
             true,

--- a/src/core/src/index/linear.rs
+++ b/src/core/src/index/linear.rs
@@ -25,7 +25,7 @@ pub struct LinearIndex {
 impl LinearIndex {
     pub fn from_collection(collection: CollectionSet) -> Self {
         let sig = collection.sig_for_dataset(0).unwrap();
-        let template = sig.sketches().swap_remove(0);
+        let template = sig.iter().next().unwrap().clone();
         Self {
             collection,
             template,

--- a/src/core/src/index/revindex/disk_revindex.rs
+++ b/src/core/src/index/revindex/disk_revindex.rs
@@ -191,7 +191,7 @@ impl RevIndex {
             .collection
             .sig_for_dataset(dataset_id)
             .expect("Couldn't find a compatible Signature");
-        let search_mh = &search_sig.sketches()[0];
+        let search_mh = search_sig.iter().next().unwrap();
 
         let colors = Datasets::new(&[dataset_id]).as_bytes().unwrap();
 

--- a/src/core/src/index/revindex/disk_revindex.rs
+++ b/src/core/src/index/revindex/disk_revindex.rs
@@ -197,9 +197,9 @@ impl RevIndex {
 
         let cf_hashes = self.db.cf_handle(HASHES).unwrap();
 
-        let hashes = match search_mh {
-            Sketch::MinHash(mh) => mh.mins(),
-            Sketch::LargeMinHash(mh) => mh.mins(),
+        let hashes: Vec<_> = match search_mh {
+            Sketch::MinHash(mh) => mh.iter_mins().copied().collect(),
+            Sketch::LargeMinHash(mh) => mh.iter_mins().copied().collect(),
             _ => unimplemented!(),
         };
 

--- a/src/core/src/index/revindex/mem_revindex.rs
+++ b/src/core/src/index/revindex/mem_revindex.rs
@@ -175,7 +175,7 @@ impl RevIndex {
                 }
             }
         } else {
-            let matched = search_mh.mins();
+            let matched: Vec<_> = search_mh.iter_mins().copied().collect();
             let size = matched.len() as u64;
             if !matched.is_empty() || size > threshold as u64 {
                 hash_to_color.add_to(&mut colors, dataset_id, matched);

--- a/src/core/src/index/revindex/mod.rs
+++ b/src/core/src/index/revindex/mod.rs
@@ -19,7 +19,6 @@ use crate::index::{GatherResult, SigCounter};
 use crate::prelude::*;
 use crate::signature::Signature;
 use crate::sketch::minhash::KmerMinHash;
-use crate::sketch::Sketch;
 use crate::HashIntoType;
 use crate::Result;
 
@@ -225,13 +224,7 @@ impl RevIndex {
 pub fn prepare_query(search_sig: Signature, selection: &Selection) -> Option<KmerMinHash> {
     let sig = search_sig.select(selection).ok();
 
-    sig.and_then(|sig| {
-        if let Sketch::MinHash(mh) = sig.sketches().swap_remove(0) {
-            Some(mh)
-        } else {
-            None
-        }
-    })
+    sig.and_then(|sig| sig.minhash().cloned())
 }
 
 #[derive(Debug, Default, Clone)]

--- a/src/core/src/signature.rs
+++ b/src/core/src/signature.rs
@@ -475,10 +475,6 @@ impl Signature {
         self.signatures.len()
     }
 
-    pub fn sketches(&self) -> Vec<Sketch> {
-        self.signatures.clone()
-    }
-
     pub fn reset_sketches(&mut self) {
         self.signatures = vec![];
     }

--- a/src/core/src/sketch/hyperloglog/mod.rs
+++ b/src/core/src/sketch/hyperloglog/mod.rs
@@ -214,8 +214,8 @@ impl SigsTrait for HyperLogLog {
 
 impl Update<HyperLogLog> for KmerMinHash {
     fn update(&self, other: &mut HyperLogLog) -> Result<(), Error> {
-        for h in self.mins() {
-            other.add_hash(h);
+        for h in self.iter_mins() {
+            other.add_hash(*h);
         }
         Ok(())
     }

--- a/src/core/src/sketch/minhash.rs
+++ b/src/core/src/sketch/minhash.rs
@@ -522,9 +522,9 @@ impl KmerMinHash {
         Ok(())
     }
 
-    pub fn add_many(&mut self, hashes: &[u64]) -> Result<(), Error> {
+    pub fn add_many<T: IntoIterator<Item = u64>>(&mut self, hashes: T) -> Result<(), Error> {
         for min in hashes {
-            self.add_hash(*min);
+            self.add_hash(min);
         }
         Ok(())
     }
@@ -735,7 +735,7 @@ impl KmerMinHash {
         if self.abunds.is_some() {
             new_mh.add_many_with_abund(&self.to_vec_abunds())?;
         } else {
-            new_mh.add_many(&self.mins)?;
+            new_mh.add_many(self.mins.iter().copied())?;
         }
         Ok(new_mh)
     }
@@ -1341,9 +1341,9 @@ impl KmerMinHashBTree {
         Ok(())
     }
 
-    pub fn add_many(&mut self, hashes: &[u64]) -> Result<(), Error> {
+    pub fn add_many<T: IntoIterator<Item = u64>>(&mut self, hashes: T) -> Result<(), Error> {
         for min in hashes {
-            self.add_hash(*min);
+            self.add_hash(min);
         }
         Ok(())
     }
@@ -1543,7 +1543,7 @@ impl KmerMinHashBTree {
         if self.abunds.is_some() {
             new_mh.add_many_with_abund(&self.to_vec_abunds())?;
         } else {
-            new_mh.add_many(&self.mins())?;
+            new_mh.add_many(self.mins.iter().copied())?;
         }
         Ok(new_mh)
     }

--- a/src/core/src/sketch/minhash.rs
+++ b/src/core/src/sketch/minhash.rs
@@ -940,6 +940,15 @@ impl<T: Ord, I: Iterator<Item = T>> Iterator for Intersection<T, I> {
             }
         }
     }
+    #[inline(always)]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let min = match (self.iter.size_hint().1, self.other.size_hint().1) {
+            (Some(a), Some(b)) => Some(std::cmp::min(a, b)),
+            (Some(a), None) | (None, Some(a)) => Some(a),
+            (None, None) => None,
+        };
+        (0, min)
+    }
 }
 
 //#############

--- a/src/core/src/sketch/minhash.rs
+++ b/src/core/src/sketch/minhash.rs
@@ -708,10 +708,6 @@ impl KmerMinHash {
         self.hash_function == HashFunctions::Murmur64Hp
     }
 
-    pub fn mins(&self) -> Vec<u64> {
-        self.mins.clone()
-    }
-
     pub fn iter_mins(&self) -> impl Iterator<Item = &u64> {
         self.mins.iter()
     }
@@ -1523,10 +1519,6 @@ impl KmerMinHashBTree {
         self.hash_function.clone()
     }
 
-    pub fn mins(&self) -> Vec<u64> {
-        self.mins.iter().cloned().collect()
-    }
-
     pub fn iter_mins(&self) -> impl Iterator<Item = &u64> {
         self.mins.iter()
     }
@@ -1590,7 +1582,7 @@ impl SigsTrait for KmerMinHashBTree {
     }
 
     fn to_vec(&self) -> Vec<u64> {
-        self.mins()
+        self.iter_mins().copied().collect()
     }
 
     fn ksize(&self) -> usize {

--- a/src/core/src/sketch/nodegraph.rs
+++ b/src/core/src/sketch/nodegraph.rs
@@ -51,8 +51,8 @@ impl Update<Nodegraph> for Nodegraph {
 
 impl Update<Nodegraph> for KmerMinHash {
     fn update(&self, other: &mut Nodegraph) -> Result<(), Error> {
-        for h in self.mins() {
-            other.count(h);
+        for h in self.iter_mins() {
+            other.count(*h);
         }
         Ok(())
     }
@@ -60,8 +60,8 @@ impl Update<Nodegraph> for KmerMinHash {
 
 impl Update<Nodegraph> for KmerMinHashBTree {
     fn update(&self, other: &mut Nodegraph) -> Result<(), Error> {
-        for h in self.mins() {
-            other.count(h);
+        for h in self.iter_mins() {
+            other.count(*h);
         }
         Ok(())
     }

--- a/src/core/tests/minhash.rs
+++ b/src/core/tests/minhash.rs
@@ -242,8 +242,8 @@ fn oracle_mins_scaled(hashes in vec(u64::ANY, 1..10000)) {
         }
     }
 
-    c.add_many(&hashes).unwrap();
-    d.add_many(&hashes).unwrap();
+    c.add_many(hashes.iter().copied()).unwrap();
+    d.add_many(hashes.iter().copied()).unwrap();
 
     c.remove_many(to_remove.iter().copied()).unwrap();
     d.remove_many(to_remove.iter().copied()).unwrap();

--- a/src/core/tests/minhash.rs
+++ b/src/core/tests/minhash.rs
@@ -11,7 +11,6 @@ use sourmash::signature::{Signature, SigsTrait};
 use sourmash::sketch::minhash::{
     max_hash_for_scaled, scaled_for_max_hash, KmerMinHash, KmerMinHashBTree,
 };
-use sourmash::sketch::Sketch;
 
 // TODO: use f64::EPSILON when we bump MSRV
 const EPSILON: f64 = 0.01;
@@ -58,11 +57,11 @@ fn invalid_dna() {
     let mut a = KmerMinHash::new(0, 3, HashFunctions::Murmur64Dna, 42, false, 20);
 
     a.add_sequence(b"AAANNCCCTN", true).unwrap();
-    assert_eq!(a.mins().len(), 3);
+    assert_eq!(a.iter_mins().count(), 3);
 
     let mut b = KmerMinHash::new(0, 3, HashFunctions::Murmur64Dna, 42, false, 20);
     b.add_sequence(b"NAAA", true).unwrap();
-    assert_eq!(b.mins().len(), 1);
+    assert_eq!(b.iter_mins().count(), 1);
 }
 
 #[test]
@@ -209,8 +208,8 @@ fn oracle_mins(hashes in vec(u64::ANY, 1..10000)) {
     d.add_from(&b).unwrap();
     d.remove_many(to_remove.iter().copied()).unwrap();
 
-    assert_eq!(a.mins(), b.mins());
-    assert_eq!(c.mins(), d.mins());
+    assert!(a.iter_mins().zip(b.iter_mins()).all(|(a, b)| a == b));
+    assert!(c.iter_mins().zip(d.iter_mins()).all(|(a, b)| a == b));
 
     assert_eq!(a.count_common(&c, false).unwrap(), b.count_common(&d, false).unwrap());
     assert_eq!(a.count_common(&c, true).unwrap(), b.count_common(&d, true).unwrap());
@@ -251,8 +250,8 @@ fn oracle_mins_scaled(hashes in vec(u64::ANY, 1..10000)) {
     a.remove_hash(hashes[0]);
     b.remove_hash(hashes[0]);
 
-    assert_eq!(a.mins(), b.mins());
-    assert_eq!(c.mins(), d.mins());
+    assert!(a.iter_mins().zip(b.iter_mins()).all(|(a, b)| a == b));
+    assert!(c.iter_mins().zip(d.iter_mins()).all(|(a, b)| a == b));
 
     assert_eq!(a.md5sum(), b.md5sum());
     assert_eq!(c.md5sum(), d.md5sum());
@@ -343,8 +342,8 @@ fn prop_merge(seq1 in "[ACGT]{6,100}", seq2 in "[ACGT]{6,200}") {
     a.merge(&c).unwrap();
     b.merge(&d).unwrap();
 
-    assert_eq!(a.mins(), b.mins());
-    assert_eq!(c.mins(), d.mins());
+    assert!(a.iter_mins().zip(b.iter_mins()).all(|(a, b)| a == b));
+    assert!(c.iter_mins().zip(d.iter_mins()).all(|(a, b)| a == b));
 
     assert_eq!(a.abunds(), b.abunds());
     assert_eq!(c.abunds(), d.abunds());
@@ -402,10 +401,13 @@ fn load_save_minhash_sketches() {
     assert_eq!(bmh.md5sum(), new_mh.md5sum());
     assert_eq!(mh.md5sum(), new_bmh.md5sum());
 
-    assert_eq!(mh.mins(), new_mh.mins());
-    assert_eq!(bmh.mins(), new_bmh.mins());
-    assert_eq!(bmh.mins(), new_mh.mins());
-    assert_eq!(mh.mins(), new_bmh.mins());
+    assert!(mh.iter_mins().zip(new_mh.iter_mins()).all(|(a, b)| a == b));
+    assert!(bmh
+        .iter_mins()
+        .zip(new_bmh.iter_mins())
+        .all(|(a, b)| a == b));
+    assert!(bmh.iter_mins().zip(new_mh.iter_mins()).all(|(a, b)| a == b));
+    assert!(mh.iter_mins().zip(new_bmh.iter_mins()).all(|(a, b)| a == b));
 
     assert_eq!(mh.abunds(), new_mh.abunds());
     assert_eq!(bmh.abunds(), new_bmh.abunds());
@@ -440,10 +442,13 @@ fn load_save_minhash_sketches() {
     assert_eq!(bmh.md5sum(), new_mh.md5sum());
     assert_eq!(mh.md5sum(), new_bmh.md5sum());
 
-    assert_eq!(mh.mins(), new_mh.mins());
-    assert_eq!(bmh.mins(), new_bmh.mins());
-    assert_eq!(bmh.mins(), new_mh.mins());
-    assert_eq!(mh.mins(), new_bmh.mins());
+    assert!(mh.iter_mins().zip(new_mh.iter_mins()).all(|(a, b)| a == b));
+    assert!(bmh
+        .iter_mins()
+        .zip(new_bmh.iter_mins())
+        .all(|(a, b)| a == b));
+    assert!(bmh.iter_mins().zip(new_mh.iter_mins()).all(|(a, b)| a == b));
+    assert!(mh.iter_mins().zip(new_bmh.iter_mins()).all(|(a, b)| a == b));
 
     assert_eq!(mh.abunds(), new_mh.abunds());
     assert_eq!(bmh.abunds(), new_bmh.abunds());
@@ -501,10 +506,13 @@ fn load_save_minhash_sketches_abund() {
     assert_eq!(bmh.md5sum(), new_mh.md5sum());
     assert_eq!(mh.md5sum(), new_bmh.md5sum());
 
-    assert_eq!(mh.mins(), new_mh.mins());
-    assert_eq!(bmh.mins(), new_bmh.mins());
-    assert_eq!(bmh.mins(), new_mh.mins());
-    assert_eq!(mh.mins(), new_bmh.mins());
+    assert!(mh.iter_mins().zip(new_mh.iter_mins()).all(|(a, b)| a == b));
+    assert!(bmh
+        .iter_mins()
+        .zip(new_bmh.iter_mins())
+        .all(|(a, b)| a == b));
+    assert!(bmh.iter_mins().zip(new_mh.iter_mins()).all(|(a, b)| a == b));
+    assert!(mh.iter_mins().zip(new_bmh.iter_mins()).all(|(a, b)| a == b));
 
     assert_eq!(mh.abunds(), new_mh.abunds());
     assert_eq!(bmh.abunds(), new_bmh.abunds());
@@ -549,10 +557,13 @@ fn load_save_minhash_sketches_abund() {
     assert_eq!(bmh.md5sum(), new_mh.md5sum());
     assert_eq!(mh.md5sum(), new_bmh.md5sum());
 
-    assert_eq!(mh.mins(), new_mh.mins());
-    assert_eq!(bmh.mins(), new_bmh.mins());
-    assert_eq!(bmh.mins(), new_mh.mins());
-    assert_eq!(mh.mins(), new_bmh.mins());
+    assert!(mh.iter_mins().zip(new_mh.iter_mins()).all(|(a, b)| a == b));
+    assert!(bmh
+        .iter_mins()
+        .zip(new_bmh.iter_mins())
+        .all(|(a, b)| a == b));
+    assert!(bmh.iter_mins().zip(new_mh.iter_mins()).all(|(a, b)| a == b));
+    assert!(mh.iter_mins().zip(new_bmh.iter_mins()).all(|(a, b)| a == b));
 
     assert_eq!(mh.abunds(), new_mh.abunds());
     assert_eq!(bmh.abunds(), new_bmh.abunds());
@@ -755,10 +766,12 @@ fn seq_to_hashes(seq in "ACGTGTAGCTAGACACTGACTGACTGAC") {
         }
     }
 
-    mh.mins().sort_unstable();
     hashes.sort_unstable();
-    assert_eq!(mh.mins(), hashes);
+    assert!(mh.iter_mins().zip(hashes.iter()).all(|(a, b)| a == b));
 
+    let mut mins: Vec<_> = mh.iter_mins().copied().collect();
+    mins.sort_unstable();
+    assert!(mins.iter().zip(hashes.iter()).all(|(a, b)| a == b));
 }
 
 #[test]
@@ -778,10 +791,12 @@ fn seq_to_hashes_2(seq in "QRMTHINK") {
         }
     }
 
-    mh.mins().sort_unstable();
     hashes.sort_unstable();
-    assert_eq!(mh.mins(), hashes);
+    assert!(mh.iter_mins().zip(hashes.iter()).all(|(a, b)| a == b));
 
+    let mut mins: Vec<_> = mh.iter_mins().copied().collect();
+    mins.sort_unstable();
+    assert!(mins.iter().zip(hashes.iter()).all(|(a, b)| a == b));
 }
 
 }

--- a/src/core/tests/minhash.rs
+++ b/src/core/tests/minhash.rs
@@ -389,90 +389,90 @@ fn load_save_minhash_sketches() {
     let mh = sig.minhash().unwrap();
     let mut buffer = vec![];
 
-        let bmh: KmerMinHashBTree = mh.clone().into();
-        {
-            serde_json::to_writer(&mut buffer, &bmh).unwrap();
-        }
+    let bmh: KmerMinHashBTree = mh.clone().into();
+    {
+        serde_json::to_writer(&mut buffer, &bmh).unwrap();
+    }
 
-        let new_mh: KmerMinHash = serde_json::from_reader(&buffer[..]).unwrap();
-        let new_bmh: KmerMinHashBTree = serde_json::from_reader(&buffer[..]).unwrap();
+    let new_mh: KmerMinHash = serde_json::from_reader(&buffer[..]).unwrap();
+    let new_bmh: KmerMinHashBTree = serde_json::from_reader(&buffer[..]).unwrap();
 
-        assert_eq!(mh.md5sum(), new_mh.md5sum());
-        assert_eq!(bmh.md5sum(), new_bmh.md5sum());
-        assert_eq!(bmh.md5sum(), new_mh.md5sum());
-        assert_eq!(mh.md5sum(), new_bmh.md5sum());
+    assert_eq!(mh.md5sum(), new_mh.md5sum());
+    assert_eq!(bmh.md5sum(), new_bmh.md5sum());
+    assert_eq!(bmh.md5sum(), new_mh.md5sum());
+    assert_eq!(mh.md5sum(), new_bmh.md5sum());
 
-        assert_eq!(mh.mins(), new_mh.mins());
-        assert_eq!(bmh.mins(), new_bmh.mins());
-        assert_eq!(bmh.mins(), new_mh.mins());
-        assert_eq!(mh.mins(), new_bmh.mins());
+    assert_eq!(mh.mins(), new_mh.mins());
+    assert_eq!(bmh.mins(), new_bmh.mins());
+    assert_eq!(bmh.mins(), new_mh.mins());
+    assert_eq!(mh.mins(), new_bmh.mins());
 
-        assert_eq!(mh.abunds(), new_mh.abunds());
-        assert_eq!(bmh.abunds(), new_bmh.abunds());
-        assert_eq!(bmh.abunds(), new_mh.abunds());
-        assert_eq!(mh.abunds(), new_bmh.abunds());
+    assert_eq!(mh.abunds(), new_mh.abunds());
+    assert_eq!(bmh.abunds(), new_bmh.abunds());
+    assert_eq!(bmh.abunds(), new_mh.abunds());
+    assert_eq!(mh.abunds(), new_bmh.abunds());
 
-        assert!(
-            (mh.similarity(&new_mh, false, false).unwrap()
-                - bmh.similarity(&new_bmh, false, false).unwrap())
-            .abs()
-                < EPSILON
-        );
+    assert!(
+        (mh.similarity(&new_mh, false, false).unwrap()
+            - bmh.similarity(&new_bmh, false, false).unwrap())
+        .abs()
+            < EPSILON
+    );
 
-        assert!(
-            (mh.similarity(&new_mh, true, false).unwrap()
-                - bmh.similarity(&new_bmh, true, false).unwrap())
-            .abs()
-                < EPSILON
-        );
+    assert!(
+        (mh.similarity(&new_mh, true, false).unwrap()
+            - bmh.similarity(&new_bmh, true, false).unwrap())
+        .abs()
+            < EPSILON
+    );
 
-        buffer.clear();
-        let imh: KmerMinHash = bmh.clone().into();
-        {
-            serde_json::to_writer(&mut buffer, &imh).unwrap();
-        }
+    buffer.clear();
+    let imh: KmerMinHash = bmh.clone().into();
+    {
+        serde_json::to_writer(&mut buffer, &imh).unwrap();
+    }
 
-        let new_mh: KmerMinHash = serde_json::from_reader(&buffer[..]).unwrap();
-        let new_bmh: KmerMinHashBTree = serde_json::from_reader(&buffer[..]).unwrap();
+    let new_mh: KmerMinHash = serde_json::from_reader(&buffer[..]).unwrap();
+    let new_bmh: KmerMinHashBTree = serde_json::from_reader(&buffer[..]).unwrap();
 
-        assert_eq!(mh.md5sum(), new_mh.md5sum());
-        assert_eq!(bmh.md5sum(), new_bmh.md5sum());
-        assert_eq!(bmh.md5sum(), new_mh.md5sum());
-        assert_eq!(mh.md5sum(), new_bmh.md5sum());
+    assert_eq!(mh.md5sum(), new_mh.md5sum());
+    assert_eq!(bmh.md5sum(), new_bmh.md5sum());
+    assert_eq!(bmh.md5sum(), new_mh.md5sum());
+    assert_eq!(mh.md5sum(), new_bmh.md5sum());
 
-        assert_eq!(mh.mins(), new_mh.mins());
-        assert_eq!(bmh.mins(), new_bmh.mins());
-        assert_eq!(bmh.mins(), new_mh.mins());
-        assert_eq!(mh.mins(), new_bmh.mins());
+    assert_eq!(mh.mins(), new_mh.mins());
+    assert_eq!(bmh.mins(), new_bmh.mins());
+    assert_eq!(bmh.mins(), new_mh.mins());
+    assert_eq!(mh.mins(), new_bmh.mins());
 
-        assert_eq!(mh.abunds(), new_mh.abunds());
-        assert_eq!(bmh.abunds(), new_bmh.abunds());
-        assert_eq!(bmh.abunds(), new_mh.abunds());
-        assert_eq!(mh.abunds(), new_bmh.abunds());
+    assert_eq!(mh.abunds(), new_mh.abunds());
+    assert_eq!(bmh.abunds(), new_bmh.abunds());
+    assert_eq!(bmh.abunds(), new_mh.abunds());
+    assert_eq!(mh.abunds(), new_bmh.abunds());
 
-        assert_eq!(mh.to_vec(), new_mh.to_vec());
-        assert_eq!(bmh.to_vec(), new_bmh.to_vec());
-        assert_eq!(bmh.to_vec(), new_mh.to_vec());
-        assert_eq!(mh.to_vec(), new_bmh.to_vec());
+    assert_eq!(mh.to_vec(), new_mh.to_vec());
+    assert_eq!(bmh.to_vec(), new_bmh.to_vec());
+    assert_eq!(bmh.to_vec(), new_mh.to_vec());
+    assert_eq!(mh.to_vec(), new_bmh.to_vec());
 
-        assert_eq!(mh.to_vec_abunds(), new_mh.to_vec_abunds());
-        assert_eq!(bmh.to_vec_abunds(), new_bmh.to_vec_abunds());
-        assert_eq!(bmh.to_vec_abunds(), new_mh.to_vec_abunds());
-        assert_eq!(mh.to_vec_abunds(), new_bmh.to_vec_abunds());
+    assert_eq!(mh.to_vec_abunds(), new_mh.to_vec_abunds());
+    assert_eq!(bmh.to_vec_abunds(), new_bmh.to_vec_abunds());
+    assert_eq!(bmh.to_vec_abunds(), new_mh.to_vec_abunds());
+    assert_eq!(mh.to_vec_abunds(), new_bmh.to_vec_abunds());
 
-        assert!(
-            (mh.similarity(&new_mh, false, false).unwrap()
-                - bmh.similarity(&new_bmh, false, false).unwrap())
-            .abs()
-                < EPSILON
-        );
+    assert!(
+        (mh.similarity(&new_mh, false, false).unwrap()
+            - bmh.similarity(&new_bmh, false, false).unwrap())
+        .abs()
+            < EPSILON
+    );
 
-        assert!(
-            (mh.similarity(&new_mh, true, false).unwrap()
-                - bmh.similarity(&new_bmh, true, false).unwrap())
-            .abs()
-                < EPSILON
-        );
+    assert!(
+        (mh.similarity(&new_mh, true, false).unwrap()
+            - bmh.similarity(&new_bmh, true, false).unwrap())
+        .abs()
+            < EPSILON
+    );
 }
 
 #[test]
@@ -488,90 +488,90 @@ fn load_save_minhash_sketches_abund() {
     let mh = sig.minhash().unwrap();
     let mut buffer = vec![];
 
-        let bmh: KmerMinHashBTree = mh.clone().into();
-        {
-            serde_json::to_writer(&mut buffer, &bmh).unwrap();
-        }
+    let bmh: KmerMinHashBTree = mh.clone().into();
+    {
+        serde_json::to_writer(&mut buffer, &bmh).unwrap();
+    }
 
-        let new_mh: KmerMinHash = serde_json::from_reader(&buffer[..]).unwrap();
-        let new_bmh: KmerMinHashBTree = serde_json::from_reader(&buffer[..]).unwrap();
+    let new_mh: KmerMinHash = serde_json::from_reader(&buffer[..]).unwrap();
+    let new_bmh: KmerMinHashBTree = serde_json::from_reader(&buffer[..]).unwrap();
 
-        assert_eq!(mh.md5sum(), new_mh.md5sum());
-        assert_eq!(bmh.md5sum(), new_bmh.md5sum());
-        assert_eq!(bmh.md5sum(), new_mh.md5sum());
-        assert_eq!(mh.md5sum(), new_bmh.md5sum());
+    assert_eq!(mh.md5sum(), new_mh.md5sum());
+    assert_eq!(bmh.md5sum(), new_bmh.md5sum());
+    assert_eq!(bmh.md5sum(), new_mh.md5sum());
+    assert_eq!(mh.md5sum(), new_bmh.md5sum());
 
-        assert_eq!(mh.mins(), new_mh.mins());
-        assert_eq!(bmh.mins(), new_bmh.mins());
-        assert_eq!(bmh.mins(), new_mh.mins());
-        assert_eq!(mh.mins(), new_bmh.mins());
+    assert_eq!(mh.mins(), new_mh.mins());
+    assert_eq!(bmh.mins(), new_bmh.mins());
+    assert_eq!(bmh.mins(), new_mh.mins());
+    assert_eq!(mh.mins(), new_bmh.mins());
 
-        assert_eq!(mh.abunds(), new_mh.abunds());
-        assert_eq!(bmh.abunds(), new_bmh.abunds());
-        assert_eq!(bmh.abunds(), new_mh.abunds());
-        assert_eq!(mh.abunds(), new_bmh.abunds());
+    assert_eq!(mh.abunds(), new_mh.abunds());
+    assert_eq!(bmh.abunds(), new_bmh.abunds());
+    assert_eq!(bmh.abunds(), new_mh.abunds());
+    assert_eq!(mh.abunds(), new_bmh.abunds());
 
-        assert_eq!(mh.to_vec(), new_mh.to_vec());
-        assert_eq!(bmh.to_vec(), new_bmh.to_vec());
-        assert_eq!(bmh.to_vec(), new_mh.to_vec());
-        assert_eq!(mh.to_vec(), new_bmh.to_vec());
+    assert_eq!(mh.to_vec(), new_mh.to_vec());
+    assert_eq!(bmh.to_vec(), new_bmh.to_vec());
+    assert_eq!(bmh.to_vec(), new_mh.to_vec());
+    assert_eq!(mh.to_vec(), new_bmh.to_vec());
 
-        assert_eq!(mh.to_vec_abunds(), new_mh.to_vec_abunds());
-        assert_eq!(bmh.to_vec_abunds(), new_bmh.to_vec_abunds());
-        assert_eq!(bmh.to_vec_abunds(), new_mh.to_vec_abunds());
-        assert_eq!(mh.to_vec_abunds(), new_bmh.to_vec_abunds());
+    assert_eq!(mh.to_vec_abunds(), new_mh.to_vec_abunds());
+    assert_eq!(bmh.to_vec_abunds(), new_bmh.to_vec_abunds());
+    assert_eq!(bmh.to_vec_abunds(), new_mh.to_vec_abunds());
+    assert_eq!(mh.to_vec_abunds(), new_bmh.to_vec_abunds());
 
-        assert!(
-            (mh.similarity(&new_mh, false, false).unwrap()
-                - bmh.similarity(&new_bmh, false, false).unwrap())
-            .abs()
-                < EPSILON
-        );
+    assert!(
+        (mh.similarity(&new_mh, false, false).unwrap()
+            - bmh.similarity(&new_bmh, false, false).unwrap())
+        .abs()
+            < EPSILON
+    );
 
-        assert!(
-            (mh.similarity(&new_mh, true, false).unwrap()
-                - bmh.similarity(&new_bmh, true, false).unwrap())
-            .abs()
-                < EPSILON
-        );
+    assert!(
+        (mh.similarity(&new_mh, true, false).unwrap()
+            - bmh.similarity(&new_bmh, true, false).unwrap())
+        .abs()
+            < EPSILON
+    );
 
-        buffer.clear();
-        let imh: KmerMinHash = bmh.clone().into();
-        {
-            serde_json::to_writer(&mut buffer, &imh).unwrap();
-        }
+    buffer.clear();
+    let imh: KmerMinHash = bmh.clone().into();
+    {
+        serde_json::to_writer(&mut buffer, &imh).unwrap();
+    }
 
-        let new_mh: KmerMinHash = serde_json::from_reader(&buffer[..]).unwrap();
-        let new_bmh: KmerMinHashBTree = serde_json::from_reader(&buffer[..]).unwrap();
+    let new_mh: KmerMinHash = serde_json::from_reader(&buffer[..]).unwrap();
+    let new_bmh: KmerMinHashBTree = serde_json::from_reader(&buffer[..]).unwrap();
 
-        assert_eq!(mh.md5sum(), new_mh.md5sum());
-        assert_eq!(bmh.md5sum(), new_bmh.md5sum());
-        assert_eq!(bmh.md5sum(), new_mh.md5sum());
-        assert_eq!(mh.md5sum(), new_bmh.md5sum());
+    assert_eq!(mh.md5sum(), new_mh.md5sum());
+    assert_eq!(bmh.md5sum(), new_bmh.md5sum());
+    assert_eq!(bmh.md5sum(), new_mh.md5sum());
+    assert_eq!(mh.md5sum(), new_bmh.md5sum());
 
-        assert_eq!(mh.mins(), new_mh.mins());
-        assert_eq!(bmh.mins(), new_bmh.mins());
-        assert_eq!(bmh.mins(), new_mh.mins());
-        assert_eq!(mh.mins(), new_bmh.mins());
+    assert_eq!(mh.mins(), new_mh.mins());
+    assert_eq!(bmh.mins(), new_bmh.mins());
+    assert_eq!(bmh.mins(), new_mh.mins());
+    assert_eq!(mh.mins(), new_bmh.mins());
 
-        assert_eq!(mh.abunds(), new_mh.abunds());
-        assert_eq!(bmh.abunds(), new_bmh.abunds());
-        assert_eq!(bmh.abunds(), new_mh.abunds());
-        assert_eq!(mh.abunds(), new_bmh.abunds());
+    assert_eq!(mh.abunds(), new_mh.abunds());
+    assert_eq!(bmh.abunds(), new_bmh.abunds());
+    assert_eq!(bmh.abunds(), new_mh.abunds());
+    assert_eq!(mh.abunds(), new_bmh.abunds());
 
-        assert!(
-            (mh.similarity(&new_mh, false, false).unwrap()
-                - bmh.similarity(&new_bmh, false, false).unwrap())
-            .abs()
-                < EPSILON
-        );
+    assert!(
+        (mh.similarity(&new_mh, false, false).unwrap()
+            - bmh.similarity(&new_bmh, false, false).unwrap())
+        .abs()
+            < EPSILON
+    );
 
-        assert!(
-            (mh.similarity(&new_mh, true, false).unwrap()
-                - bmh.similarity(&new_bmh, true, false).unwrap())
-            .abs()
-                < EPSILON
-        );
+    assert!(
+        (mh.similarity(&new_mh, true, false).unwrap()
+            - bmh.similarity(&new_bmh, true, false).unwrap())
+        .abs()
+            < EPSILON
+    );
 }
 
 #[test]

--- a/src/core/tests/minhash.rs
+++ b/src/core/tests/minhash.rs
@@ -386,10 +386,9 @@ fn load_save_minhash_sketches() {
     let sigs: Vec<Signature> = serde_json::from_reader(reader).expect("Loading error");
 
     let sig = sigs.get(0).unwrap();
-    let sketches = sig.sketches();
+    let mh = sig.minhash().unwrap();
     let mut buffer = vec![];
 
-    if let Sketch::MinHash(mh) = &sketches[0] {
         let bmh: KmerMinHashBTree = mh.clone().into();
         {
             serde_json::to_writer(&mut buffer, &bmh).unwrap();
@@ -474,7 +473,6 @@ fn load_save_minhash_sketches() {
             .abs()
                 < EPSILON
         );
-    }
 }
 
 #[test]
@@ -487,10 +485,9 @@ fn load_save_minhash_sketches_abund() {
     let sigs: Vec<Signature> = serde_json::from_reader(reader).expect("Loading error");
 
     let sig = sigs.get(0).unwrap();
-    let sketches = sig.sketches();
+    let mh = sig.minhash().unwrap();
     let mut buffer = vec![];
 
-    if let Sketch::MinHash(mh) = &sketches[0] {
         let bmh: KmerMinHashBTree = mh.clone().into();
         {
             serde_json::to_writer(&mut buffer, &bmh).unwrap();
@@ -575,7 +572,6 @@ fn load_save_minhash_sketches_abund() {
             .abs()
                 < EPSILON
         );
-    }
 }
 
 #[test]

--- a/src/core/tests/storage.rs
+++ b/src/core/tests/storage.rs
@@ -51,6 +51,8 @@ fn zipstorage_list_sbts() -> Result<(), Box<dyn std::error::Error>> {
 fn zipstorage_parallel_access() -> Result<(), Box<dyn std::error::Error>> {
     use rayon::prelude::*;
 
+    use sourmash::signature::SigsTrait;
+
     let mut filename = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     filename.push("../../tests/test-data/v6.sbt.zip");
 

--- a/src/core/tests/storage.rs
+++ b/src/core/tests/storage.rs
@@ -50,7 +50,6 @@ fn zipstorage_list_sbts() -> Result<(), Box<dyn std::error::Error>> {
 #[test]
 fn zipstorage_parallel_access() -> Result<(), Box<dyn std::error::Error>> {
     use rayon::prelude::*;
-    use sourmash::signature::SigsTrait;
 
     let mut filename = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     filename.push("../../tests/test-data/v6.sbt.zip");
@@ -71,7 +70,7 @@ fn zipstorage_parallel_access() -> Result<(), Box<dyn std::error::Error>> {
         let data = zs.load(path).unwrap();
         let sigs: Vec<Signature> = serde_json::from_reader(&data[..]).expect("Loading error");
         sigs.iter()
-            .map(|v| v.sketches().iter().map(|mh| mh.size()).sum::<usize>())
+            .map(|v| v.iter().map(|mh| mh.size()).sum::<usize>())
             .sum::<usize>()
     })
     .sum();


### PR DESCRIPTION
#3047 will need a new version bump, bringing in these changes because they also need a version bump

- Remove sketches method from Signature, use iter method instead -> #2977
- Remove mins method from MinHash, use iter_mins method instead
- Add benchmarks for jaccard and count_common
- add_many takes an iterator now, similar to remove_many
- Add size_hint for Intersection iterator