### PR TITLE
MRG: tell dependabot to ignore upgrades to `byteorder`, `chrono`, `once_cell`, and `wasm-bindgen`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,11 @@ updates:
   allow:
     - dependency-type: "direct"
   open-pull-requests-limit: 10
+  ignore:
+    - dependency-name: "byteorder"
+    - dependency-name: "wasm-bindgen"
+    - dependency-name: "once_cell"
+    - dependency-name: "chrono"
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:


### PR DESCRIPTION
This uses dependabot `ignore` per [docs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates) to pin the packages needed for `sourmash_plugin_branchwater compatibility per #2944`.

Motivation:
* embarrassment from https://github.com/sourmash-bio/sourmash/pull/3060 and then https://github.com/sourmash-bio/sourmash/pull/3064

Related issues:
* Fixes https://github.com/sourmash-bio/sourmash/issues/2944

