### PR TITLE
MRG: bump screed req to 1.1.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ classifiers = [
 ]
 
 dependencies = [
-  "screed>=1.1.2,<2",
+  "screed>=1.1.3,<2",
   "cffi>=1.14.0",
   "numpy",
   "matplotlib",


### PR DESCRIPTION
Fixes https://github.com/sourmash-bio/sourmash/issues/2869

Screed release: https://github.com/dib-lab/screed/releases

The only really interesting/important update between 1.1.2 and 1.1.3 is https://github.com/dib-lab/screed/pull/106, which removes an unnecessary warning when running tests.
