### PR TITLE
MRG: 4.8.8 release branch

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -68,7 +68,7 @@
 
           sourmash = python.buildPythonPackage ( commonArgs // rec {
             pname = "sourmash";
-            version = "4.8.7";
+            version = "4.8.8";
             format = "pyproject";
 
             cargoDeps = rustPlatform.importCargoLock {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = 'maturin'
 name = "sourmash"
 description = "tools for comparing biological sequences with k-mer sketches"
 readme = "README.md"
-version = "4.8.7"
+version = "4.8.8"
 
 authors = [
   { name="Luiz Irber", orcid="0000-0003-4371-9659" },


### PR DESCRIPTION
Release candidate testing:
- [x] Command line tests pass for a release candidate
- [x] All eight release candidate wheels are built

Releasing to PyPI:

- [x] RC tag(s)s deleted on github
- [x] Release tag cut
- [x] Release notes written
- [x] All eight release wheels built
- [x] Release wheels uploaded to pypi
- [x] tar.gz distribution uploaded to pypi

After release to PyPI and conda-forge/bioconda packages built:

- [x] [PyPI page](https://pypi.org/project/sourmash/) updated
- [x] Zenodo DOI successfully minted upon new github release - [see search results](https://zenodo.org/search?page=1&size=20&q=sourmash&sort=mostrecent)
- [x] `pip install sourmash` installs the correct version
- [x] [conda-forge sourmash-minimal-feedstock](https://github.com/conda-forge/sourmash-minimal-feedstock) has updated `sourmash-minimal` to the correct version 
- [x] `mamba create -n smash-release -y sourmash` installs the correct version

Optional but recommended:

- [x] PR submitted to update pyodide version
- [ ] PR submitted to update spack version

---

## Release notes:

We are proud to report that v4.8.8 has been accepted after peer review by pyOpenSci! See [the review here!](https://github.com/pyOpenSci/software-submission/issues/129)

Major new features:

- Add pyopensci review badge (#3105)
- Implement file parsing for webassembly (#3047)

Dependabot updates:

- Bump histogram from 0.9.1 to 0.10.0 (#3109)
- Bump getrandom from 0.2.12 to 0.2.14 (#3108)
- Bump enum_dispatch from 0.3.12 to 0.3.13 (#3102)
- Bump serde_json from 1.0.114 to 1.0.115 (#3101)
- Update pytest-cov requirement from <5.0,>=4 to >=4,<6.0 (#3097)
- Bump rayon from 1.9.0 to 1.10.0 (#3098)
