### PR TITLE
MRG: allow get/set record.filename

### DIFF
--- a/src/core/src/manifest.rs
+++ b/src/core/src/manifest.rs
@@ -41,6 +41,7 @@ pub struct Record {
     #[getset(get = "pub", set = "pub")]
     name: String,
 
+    #[getset(get = "pub", set = "pub")]
     filename: String,
 }
 


### PR DESCRIPTION
I need to be able to access a record's `filename` from branchwater to reproduce full gather results. I think this should allow that.

any thoughts/objections, @luizirber? Should I make it `get` only?