### PR TITLE
Add collection method to RevIndex

### DIFF
--- a/src/core/src/index/revindex/disk_revindex.rs
+++ b/src/core/src/index/revindex/disk_revindex.rs
@@ -428,6 +428,10 @@ impl RevIndexOps for RevIndex {
         Ok(module::RevIndex::Plain(self))
     }
 
+    fn collection(&self) -> &CollectionSet {
+        &self.collection
+    }
+
     fn check(&self, quick: bool) -> DbStats {
         stats_for_cf(self.db.clone(), HASHES, true, quick)
     }

--- a/src/core/src/index/revindex/mod.rs
+++ b/src/core/src/index/revindex/mod.rs
@@ -66,6 +66,8 @@ pub trait RevIndexOps {
     where
         Self: Sized;
 
+    fn collection(&self) -> &CollectionSet;
+
     fn compact(&self);
 
     fn flush(&self) -> Result<()>;


### PR DESCRIPTION
While working on https://github.com/sourmash-bio/branchwater/issues/24 I needed a way to extract the manifest for an existing RevIndex, and there was no way to do it...