### PR TITLE
MRG: fix clippy warnings about max_value

### DIFF
--- a/src/core/src/index/linear.rs
+++ b/src/core/src/index/linear.rs
@@ -240,7 +240,7 @@ impl LinearIndex {
         threshold: usize,
         query: &KmerMinHash,
     ) -> std::result::Result<Vec<GatherResult>, Box<dyn std::error::Error>> {
-        let mut match_size = usize::max_value();
+        let mut match_size = usize::MAX;
         let mut matches = vec![];
         let template = self.template();
 

--- a/src/core/src/sketch/hyperloglog/estimators.rs
+++ b/src/core/src/sketch/hyperloglog/estimators.rs
@@ -16,7 +16,7 @@ pub fn counts(registers: &[CounterType], q: usize) -> Vec<u16> {
 pub fn mle(counts: &[u16], p: usize, q: usize, relerr: f64) -> f64 {
     let m = 1 << p;
     if counts[q + 1] == m {
-        return std::f64::INFINITY;
+        return f64::INFINITY;
     }
 
     let (k_min, _) = counts.iter().enumerate().find(|(_, v)| **v != 0).unwrap();

--- a/src/core/src/sketch/minhash.rs
+++ b/src/core/src/sketch/minhash.rs
@@ -21,15 +21,15 @@ use crate::Error;
 pub fn max_hash_for_scaled(scaled: u64) -> u64 {
     match scaled {
         0 => 0,
-        1 => u64::max_value(),
-        _ => (u64::max_value() as f64 / scaled as f64) as u64,
+        1 => u64::MAX,
+        _ => (u64::MAX as f64 / scaled as f64) as u64,
     }
 }
 
 pub fn scaled_for_max_hash(max_hash: u64) -> u64 {
     match max_hash {
         0 => 0,
-        _ => (u64::max_value() as f64 / max_hash as f64) as u64,
+        _ => (u64::MAX as f64 / max_hash as f64) as u64,
     }
 }
 
@@ -48,7 +48,7 @@ pub struct KmerMinHash {
     #[builder(default = 42u64)]
     seed: u64,
 
-    #[builder(default = u64::max_value())]
+    #[builder(default = u64::MAX)]
     max_hash: u64,
 
     #[builder(default)]
@@ -313,7 +313,7 @@ impl KmerMinHash {
     pub fn add_hash_with_abundance(&mut self, hash: u64, abundance: u64) {
         let current_max = match self.mins.last() {
             Some(&x) => x,
-            None => u64::max_value(),
+            None => u64::MAX,
         };
 
         if hash > self.max_hash && self.max_hash != 0 {
@@ -960,7 +960,7 @@ pub struct KmerMinHashBTree {
     #[builder(default = 42u64)]
     seed: u64,
 
-    #[builder(default = u64::max_value())]
+    #[builder(default = u64::MAX)]
     max_hash: u64,
 
     #[builder(default)]
@@ -1309,7 +1309,7 @@ impl KmerMinHashBTree {
         let union = self.mins.union(&other.mins);
 
         let to_take = if self.num == 0 {
-            usize::max_value()
+            usize::MAX
         } else {
             self.num as usize
         };


### PR DESCRIPTION
clippy lints (beta) is throwing lots of errors -
```
 error: usage of a legacy numeric method
Error:     --> src/core/src/sketch/minhash.rs:1312:20
     |
1312 |             usize::max_value()
     |                    ^^^^^^^^^^^
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#legacy_numeric_constants
help: use the associated constant instead
     |
1312 |             usize::MAX
     |       
```
ref https://rust-lang.github.io/rust-clippy/master/index.html#/legacy_numeric_constants

This PR fixes `max_value()` calls to `::MAX`.