### PR TITLE
Replace serde_json with simd_json

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,10 +20,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aliasable"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android-tzdata"
@@ -628,6 +646,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -671,12 +698,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
+name = "halfbrown"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8588661a8607108a5ca69cab034063441a0413a0b041c13618a7dd348021ef6f"
+dependencies = [
+ "hashbrown 0.14.5",
+ "serde",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db0d4cf898abf0081f964436dc980e96670a0f36863e4b83aaacdb65c9d7ccc3"
 dependencies = [
- "ahash",
+ "ahash 0.7.8",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash 0.8.11",
+ "allocator-api2",
 ]
 
 [[package]]
@@ -1387,6 +1434,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf0a6f84d5f1d581da8b41b47ec8600871962f2a528115b542b362d4b744931"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcc303e793d3734489387d205e9b186fac9c6cfacedd98cbb2e8a5943595f3e6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
 name = "regex"
 version = "1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1425,7 +1492,7 @@ dependencies = [
  "bitvec",
  "bytecheck",
  "bytes",
- "hashbrown",
+ "hashbrown 0.12.1",
  "ptr_meta",
  "rend",
  "rkyv_derive",
@@ -1610,6 +1677,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-json"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa2bcf6c6e164e81bc7a5d49fc6988b3d515d9e8c07457d7b74ffb9324b9cd40"
+dependencies = [
+ "getrandom",
+ "halfbrown",
+ "ref-cast",
+ "serde",
+ "serde_json",
+ "simdutf8",
+ "value-trait",
+]
+
+[[package]]
 name = "simdutf8"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1668,7 +1750,7 @@ dependencies = [
  "rocksdb",
  "roots",
  "serde",
- "serde_json",
+ "simd-json",
  "statrs",
  "streaming-stats",
  "tempfile",
@@ -1883,6 +1965,18 @@ name = "uuid"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e395fcf16a7a3d8127ec99782007af141946b4795001f876d54fb0d55978560"
+
+[[package]]
+name = "value-trait"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9170e001f458781e92711d2ad666110f153e4e50bfd5cbd02db6547625714187"
+dependencies = [
+ "float-cmp",
+ "halfbrown",
+ "itoa",
+ "ryu",
+]
 
 [[package]]
 name = "vcpkg"
@@ -2242,6 +2336,26 @@ name = "yansi"
 version = "1.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1367295b8f788d371ce2dbc842c7b709c73ee1364d30351dd300ec2203b12377"
+
+[[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
 
 [[package]]
 name = "zstd-sys"

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -55,8 +55,8 @@ rayon = { version = "1.10.0", optional = true }
 rkyv = { version = "0.7.44", optional = true }
 roaring = "0.10.9"
 roots = "0.0.8"
+simd-json = "0.14.3"
 serde = { version = "1.0.216", features = ["derive"] }
-serde_json = "1.0.133"
 statrs = "0.18.0"
 streaming-stats = "0.2.3"
 thiserror = "2.0"

--- a/src/core/src/errors.rs
+++ b/src/core/src/errors.rs
@@ -68,7 +68,7 @@ pub enum SourmashError {
     StorageError(#[from] crate::storage::StorageError),
 
     #[error(transparent)]
-    SerdeError(#[from] serde_json::error::Error),
+    SerdeError(#[from] simd_json::Error),
 
     #[error(transparent)]
     NifflerError(#[from] niffler::Error),

--- a/src/core/src/signature.rs
+++ b/src/core/src/signature.rs
@@ -576,7 +576,7 @@ impl Signature {
     {
         let (rdr, _format) = niffler::get_reader(Box::new(rdr))?;
 
-        let sigs: Vec<Signature> = serde_json::from_reader(rdr)?;
+        let sigs: Vec<Signature> = simd_json::from_reader(rdr)?;
         Ok(sigs)
     }
 
@@ -787,7 +787,7 @@ impl ToWriter for Signature {
     where
         W: io::Write,
     {
-        serde_json::to_writer(writer, &vec![&self])?;
+        simd_json::to_writer(writer, &vec![&self])?;
         Ok(())
     }
 }
@@ -797,7 +797,7 @@ impl ToWriter for Vec<&Signature> {
     where
         W: io::Write,
     {
-        serde_json::to_writer(writer, &self)?;
+        simd_json::to_writer(writer, &self)?;
         Ok(())
     }
 }

--- a/src/core/src/sketch/minhash.rs
+++ b/src/core/src/sketch/minhash.rs
@@ -190,7 +190,7 @@ impl ToWriter for KmerMinHash {
     where
         W: io::Write,
     {
-        serde_json::to_writer(writer, &self)?;
+        simd_json::to_writer(writer, &self)?;
         Ok(())
     }
 }
@@ -875,7 +875,7 @@ impl KmerMinHash {
     {
         let (rdr, _format) = niffler::get_reader(Box::new(rdr))?;
 
-        let mh: KmerMinHash = serde_json::from_reader(rdr)?;
+        let mh: KmerMinHash = simd_json::from_reader(rdr)?;
         Ok(mh)
     }
 }
@@ -1140,7 +1140,7 @@ impl ToWriter for KmerMinHashBTree {
     where
         W: io::Write,
     {
-        serde_json::to_writer(writer, &self)?;
+        simd_json::to_writer(writer, &self)?;
         Ok(())
     }
 }
@@ -1633,7 +1633,7 @@ impl KmerMinHashBTree {
     {
         let (rdr, _format) = niffler::get_reader(Box::new(rdr))?;
 
-        let mh: KmerMinHashBTree = serde_json::from_reader(rdr)?;
+        let mh: KmerMinHashBTree = simd_json::from_reader(rdr)?;
         Ok(mh)
     }
 }

--- a/src/core/src/wasm.rs
+++ b/src/core/src/wasm.rs
@@ -178,7 +178,7 @@ pub enum JsErrors {
     SourmashError(#[from] crate::Error),
 
     #[error(transparent)]
-    SerdeError(#[from] serde_json::error::Error),
+    SerdeError(#[from] simd_json::Error),
 
     #[error(transparent)]
     NifflerError(#[from] niffler::Error),

--- a/src/core/tests/minhash.rs
+++ b/src/core/tests/minhash.rs
@@ -14,7 +14,6 @@ use sourmash::sketch::minhash::{
 };
 use sourmash::sketch::Sketch;
 use sourmash::ScaledType;
-use sourmash::prelude::ToWriter;
 
 // TODO: use f64::EPSILON when we bump MSRV
 const EPSILON: f64 = 0.01;

--- a/src/core/tests/minhash.rs
+++ b/src/core/tests/minhash.rs
@@ -14,6 +14,7 @@ use sourmash::sketch::minhash::{
 };
 use sourmash::sketch::Sketch;
 use sourmash::ScaledType;
+use sourmash::prelude::ToWriter;
 
 // TODO: use f64::EPSILON when we bump MSRV
 const EPSILON: f64 = 0.01;

--- a/src/core/tests/storage.rs
+++ b/src/core/tests/storage.rs
@@ -12,9 +12,9 @@ fn zipstorage_load_file() -> Result<(), Box<dyn std::error::Error>> {
 
     let zs = ZipStorage::from_file(filename.to_str().unwrap())?;
 
-    let data = zs.load("v6.sbt.json")?;
+    let mut data = zs.load("v6.sbt.json")?;
 
-    let description: serde_json::Value = serde_json::from_slice(&data[..])?;
+    let description: simd_json::borrowed::Value = simd_json::from_slice(&mut data[..])?;
     assert_eq!(description["version"], 6);
 
     Ok(())


### PR DESCRIPTION
I found out the [simd-json](https://lib.rs/crates/simd-json) crate supports the same interface as `serde_json`, so it is an easy swap for potentially much better perf.

~Drawbacks are only supported on `x86_64`, so need to keep `serde_json`  for all other archs.~ this is now supported on ARM and wasm too, with (slower) fallbacks when conditions are not met.

~This PR also shows how spread the use of `serde_json::from_reader` across the codebase is, should probably consolidate into a method on signatures...~ rebased on top of #3443, which greatly limited changes