### PR TITLE
MRG: fix RocksDB-based gather & other rust-based infelicities revealed by plugins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1615,7 +1615,7 @@ checksum = "9f1341053f34bb13b5e9590afb7d94b48b48d4b87467ec28e3c238693bb553de"
 
 [[package]]
 name = "sourmash"
-version = "0.13.1"
+version = "0.14.0"
 dependencies = [
  "az",
  "byteorder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,6 +20,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "aliasable"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -47,10 +56,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
-name = "anstyle"
-version = "1.0.0"
+name = "anstream"
+version = "0.6.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41ed9a86bf92ae6580e0a31281f65a1b1d867c0cc68d5346e2ae128dddfa6a7d"
+checksum = "418c75fa768af9c03be99d17643f93f79bbba589895012a80e3452a19ddda15b"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c03a11a9034d92058ceb6ee011ce58af4a9bf61491aa7e1e59ecd24bd40d22d4"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad186efb764318d35165f1758e7dcef3b10628e26d41a44bc5550652e6804391"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61a38449feb7068f52bb06c12759005cf459ee52bb4adc1d5a7c4322d716fb19"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "approx"
@@ -359,6 +411,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "colorchoice"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
+
+[[package]]
 name = "console_error_panic_hook"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -546,6 +604,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a009aa4810eb158359dda09d0c87378e4bbb89b5a801f016885a4707ba24f7ea"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b35839ba51819680ba087cd351788c9a3c476841207e0b8cee0b04722343b9"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "humantime",
+ "log",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -670,6 +751,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -724,6 +811,12 @@ dependencies = [
  "rustix 0.37.25",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
 
 [[package]]
 name = "itertools"
@@ -1379,6 +1472,8 @@ version = "1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d83f127d94bdbcda4c8cc2e50f6f84f4b611f69c902699ca385a39c3a75f9ff1"
 dependencies = [
+ "aho-corasick",
+ "memchr",
  "regex-syntax 0.6.26",
 ]
 
@@ -1626,6 +1721,7 @@ dependencies = [
  "criterion",
  "csv",
  "enum_dispatch",
+ "env_logger",
  "finch",
  "fixedbitset",
  "getrandom",
@@ -1842,6 +1938,12 @@ name = "unicode-width"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,15 +20,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aho-corasick"
-version = "0.7.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "aliasable"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -56,53 +47,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
-name = "anstream"
-version = "0.6.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418c75fa768af9c03be99d17643f93f79bbba589895012a80e3452a19ddda15b"
-dependencies = [
- "anstyle",
- "anstyle-parse",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is_terminal_polyfill",
- "utf8parse",
-]
-
-[[package]]
 name = "anstyle"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
-
-[[package]]
-name = "anstyle-parse"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c03a11a9034d92058ceb6ee011ce58af4a9bf61491aa7e1e59ecd24bd40d22d4"
-dependencies = [
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle-query"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad186efb764318d35165f1758e7dcef3b10628e26d41a44bc5550652e6804391"
-dependencies = [
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "anstyle-wincon"
-version = "3.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61a38449feb7068f52bb06c12759005cf459ee52bb4adc1d5a7c4322d716fb19"
-dependencies = [
- "anstyle",
- "windows-sys 0.52.0",
-]
 
 [[package]]
 name = "approx"
@@ -411,12 +359,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "colorchoice"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
-
-[[package]]
 name = "console_error_panic_hook"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -604,29 +546,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_filter"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a009aa4810eb158359dda09d0c87378e4bbb89b5a801f016885a4707ba24f7ea"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b35839ba51819680ba087cd351788c9a3c476841207e0b8cee0b04722343b9"
-dependencies = [
- "anstream",
- "anstyle",
- "env_filter",
- "humantime",
- "log",
-]
-
-[[package]]
 name = "errno"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -751,12 +670,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
-
-[[package]]
 name = "iana-time-zone"
 version = "0.1.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -811,12 +724,6 @@ dependencies = [
  "rustix 0.37.25",
  "windows-sys 0.48.0",
 ]
-
-[[package]]
-name = "is_terminal_polyfill"
-version = "1.70.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
 
 [[package]]
 name = "itertools"
@@ -1472,8 +1379,6 @@ version = "1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d83f127d94bdbcda4c8cc2e50f6f84f4b611f69c902699ca385a39c3a75f9ff1"
 dependencies = [
- "aho-corasick",
- "memchr",
  "regex-syntax 0.6.26",
 ]
 
@@ -1721,7 +1626,6 @@ dependencies = [
  "criterion",
  "csv",
  "enum_dispatch",
- "env_logger",
  "finch",
  "fixedbitset",
  "getrandom",
@@ -1938,12 +1842,6 @@ name = "unicode-width"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
-
-[[package]]
-name = "utf8parse"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -65,6 +65,7 @@ typed-builder = "0.18.0"
 vec-collections = "0.4.3"
 
 [dev-dependencies]
+env_logger = "0.11.3"
 proptest = { version = "1.4.0", default-features = false, features = ["std"]}
 rand = "0.8.2"
 tempfile = "3.10.1"

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -65,7 +65,6 @@ typed-builder = "0.18.0"
 vec-collections = "0.4.3"
 
 [dev-dependencies]
-env_logger = "0.11.3"
 proptest = { version = "1.4.0", default-features = false, features = ["std"]}
 rand = "0.8.2"
 tempfile = "3.10.1"

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sourmash"
-version = "0.13.1"
+version = "0.14.0"
 authors = ["Luiz Irber <luiz@sourmash.bio>", "N. Tessa Pierce-Ward <tessa@sourmash.bio>"]
 description = "tools for comparing biological sequences with k-mer sketches"
 repository = "https://github.com/sourmash-bio/sourmash"

--- a/src/core/src/encodings.rs
+++ b/src/core/src/encodings.rs
@@ -58,7 +58,7 @@ impl std::fmt::Display for HashFunctions {
             f,
             "{}",
             match self {
-                HashFunctions::Murmur64Dna => "dna",
+                HashFunctions::Murmur64Dna => "DNA",
                 HashFunctions::Murmur64Protein => "protein",
                 HashFunctions::Murmur64Dayhoff => "dayhoff",
                 HashFunctions::Murmur64Hp => "hp",

--- a/src/core/src/index/mod.rs
+++ b/src/core/src/index/mod.rs
@@ -14,10 +14,10 @@ pub mod search;
 use std::path::Path;
 
 use getset::{CopyGetters, Getters, Setters};
+use log::trace;
 use serde::{Deserialize, Serialize};
 use stats::{median, stddev};
 use typed_builder::TypedBuilder;
-use log::trace;
 
 use crate::ani_utils::{ani_ci_from_containment, ani_from_containment};
 use crate::encodings::Idx;

--- a/src/core/src/index/mod.rs
+++ b/src/core/src/index/mod.rs
@@ -17,6 +17,7 @@ use getset::{CopyGetters, Getters, Setters};
 use serde::{Deserialize, Serialize};
 use stats::{median, stddev};
 use typed_builder::TypedBuilder;
+use log::trace;
 
 use crate::ani_utils::{ani_ci_from_containment, ani_from_containment};
 use crate::encodings::Idx;
@@ -220,8 +221,14 @@ pub fn calculate_gather_stats(
 ) -> Result<GatherResult> {
     // get match_mh
     let match_mh = match_sig.minhash().unwrap();
+
+    // calculate intersection
+    let isect = match_mh.intersection(&query)?;
+    let isect_size = isect.0.len();
+    trace!("isect_size: {}", isect_size);
+
     //bp remaining in subtracted query
-    let remaining_bp = (query.size() - match_size) * query.scaled() as usize;
+    let remaining_bp = (query.size() - isect_size) * query.scaled() as usize;
 
     // stats for this match vs original query
     let (intersect_orig, _) = match_mh.intersection_size(orig_query).unwrap();
@@ -231,8 +238,8 @@ pub fn calculate_gather_stats(
 
     // stats for this match vs current (subtracted) query
     let f_match = match_size as f64 / match_mh.size() as f64;
-    let unique_intersect_bp = match_mh.scaled() as usize * match_size;
-    let f_unique_to_query = match_size as f64 / orig_query.size() as f64;
+    let unique_intersect_bp = match_mh.scaled() as usize * isect_size;
+    let f_unique_to_query = isect_size as f64 / orig_query.size() as f64;
 
     // // get ANI values
     let ksize = match_mh.ksize() as f64;

--- a/src/core/src/index/mod.rs
+++ b/src/core/src/index/mod.rs
@@ -226,6 +226,7 @@ pub fn calculate_gather_stats(
     let isect = match_mh.intersection(&query)?;
     let isect_size = isect.0.len();
     trace!("isect_size: {}", isect_size);
+    trace!("query.size: {}", query.size());
 
     //bp remaining in subtracted query
     let remaining_bp = (query.size() - isect_size) * query.scaled() as usize;

--- a/src/core/src/index/revindex/disk_revindex.rs
+++ b/src/core/src/index/revindex/disk_revindex.rs
@@ -328,6 +328,17 @@ impl RevIndexOps for RevIndex {
             trace!("counter len: {}", counter.len());
             trace!("match size: {}", match_size);
 
+            let (dataset_id, size) = counter.k_most_common_ordered(3)[0];
+            trace!("counter0: {}, {}", dataset_id, size);
+            if counter.len() > 1 {
+                let (dataset_id, size) = counter.k_most_common_ordered(3)[1];
+                trace!("counter1: {}, {}", dataset_id, size);
+            }
+            if counter.len() > 2 {
+                let (dataset_id, size) = counter.k_most_common_ordered(3)[2];
+                trace!("counter2: {}, {}", dataset_id, size);
+            }
+
             let (dataset_id, size) = counter.k_most_common_ordered(1)[0];
             match_size = if size >= threshold { size } else { break };
             // handle special case where threshold was set to 0
@@ -345,6 +356,9 @@ impl RevIndexOps for RevIndex {
 
             // just calculate essentials here
             let gather_result_rank = matches.len();
+
+            let query_mh = KmerMinHash::from(query.clone());
+            let isect = match_mh.intersection(&query_mh)?;
 
             // Calculate stats
             let gather_result = calculate_gather_stats(
@@ -369,10 +383,23 @@ impl RevIndexOps for RevIndex {
             // TODO: not used at the moment, so just skip.
             query.remove_many(match_mh.iter_mins().copied())?; // is there a better way?
 
+            if counter.len() > 0 {
+                let (dataset_id, size) = counter.k_most_common_ordered(3)[0];
+                trace!("counter0 mark 1: {}, {}", dataset_id, size);
+            }
+            if counter.len() > 1 {
+                let (dataset_id, size) = counter.k_most_common_ordered(3)[1];
+                trace!("counter1 mark 1: {}, {}", dataset_id, size);
+            }
+            if counter.len() > 2 {
+                let (dataset_id, size) = counter.k_most_common_ordered(3)[2];
+                trace!("counter2 mark 1: {}, {}", dataset_id, size);
+            }
+
             // TODO: Use HashesToColors here instead. If not initialized,
             //       build it.
-            match_mh
-                .iter_mins()
+            isect.0
+                .iter()
                 .filter_map(|hash| hash_to_color.get(hash))
                 .flat_map(|color| {
                     // TODO: remove this clone
@@ -388,7 +415,32 @@ impl RevIndexOps for RevIndex {
                     });
                 });
 
+            if counter.len() > 0 {
+                let (dataset_id, size) = counter.k_most_common_ordered(3)[0];
+                trace!("counter0 mark 2: {}, {}", dataset_id, size);
+            }
+            if counter.len() > 1 {
+                let (dataset_id, size) = counter.k_most_common_ordered(3)[1];
+                trace!("counter1 mark 2: {}, {}", dataset_id, size);
+            }
+            if counter.len() > 2 {
+                let (dataset_id, size) = counter.k_most_common_ordered(3)[2];
+                trace!("counter2 mark 2: {}, {}", dataset_id, size);
+            }
+
             counter.remove(&dataset_id);
+            if counter.len() > 0 {
+                let (dataset_id, size) = counter.k_most_common_ordered(3)[0];
+                trace!("counter0 mark 3: {}, {}", dataset_id, size);
+            }
+            if counter.len() > 1 {
+                let (dataset_id, size) = counter.k_most_common_ordered(3)[1];
+                trace!("counter1 mark 3: {}, {}", dataset_id, size);
+            }
+            if counter.len() > 2 {
+                let (dataset_id, size) = counter.k_most_common_ordered(3)[2];
+                trace!("counter2 mark 3: {}, {}", dataset_id, size);
+            }
         }
         Ok(matches)
     }

--- a/src/core/src/index/revindex/disk_revindex.rs
+++ b/src/core/src/index/revindex/disk_revindex.rs
@@ -347,7 +347,12 @@ impl RevIndexOps for RevIndex {
             let gather_result_rank = matches.len();
 
             let query_mh = KmerMinHash::from(query.clone());
+
+            // grab the specific intersection:
             let isect = match_mh.intersection(&query_mh)?;
+            let mut isect_mh = match_mh.clone();
+            isect_mh.clear();
+            isect_mh.add_many(&isect.0)?;
 
             // Calculate stats
             let gather_result = calculate_gather_stats(

--- a/src/core/src/index/revindex/disk_revindex.rs
+++ b/src/core/src/index/revindex/disk_revindex.rs
@@ -379,7 +379,8 @@ impl RevIndexOps for RevIndex {
 
             // TODO: Use HashesToColors here instead. If not initialized,
             //       build it.
-            isect.0
+            isect
+                .0
                 .iter()
                 .filter_map(|hash| hash_to_color.get(hash))
                 .flat_map(|color| {

--- a/src/core/src/index/revindex/disk_revindex.rs
+++ b/src/core/src/index/revindex/disk_revindex.rs
@@ -328,17 +328,6 @@ impl RevIndexOps for RevIndex {
             trace!("counter len: {}", counter.len());
             trace!("match size: {}", match_size);
 
-            let (dataset_id, size) = counter.k_most_common_ordered(3)[0];
-            trace!("counter0: {}, {}", dataset_id, size);
-            if counter.len() > 1 {
-                let (dataset_id, size) = counter.k_most_common_ordered(3)[1];
-                trace!("counter1: {}, {}", dataset_id, size);
-            }
-            if counter.len() > 2 {
-                let (dataset_id, size) = counter.k_most_common_ordered(3)[2];
-                trace!("counter2: {}, {}", dataset_id, size);
-            }
-
             let (dataset_id, size) = counter.k_most_common_ordered(1)[0];
             match_size = if size >= threshold { size } else { break };
             // handle special case where threshold was set to 0
@@ -383,19 +372,6 @@ impl RevIndexOps for RevIndex {
             // TODO: not used at the moment, so just skip.
             query.remove_many(match_mh.iter_mins().copied())?; // is there a better way?
 
-            if counter.len() > 0 {
-                let (dataset_id, size) = counter.k_most_common_ordered(3)[0];
-                trace!("counter0 mark 1: {}, {}", dataset_id, size);
-            }
-            if counter.len() > 1 {
-                let (dataset_id, size) = counter.k_most_common_ordered(3)[1];
-                trace!("counter1 mark 1: {}, {}", dataset_id, size);
-            }
-            if counter.len() > 2 {
-                let (dataset_id, size) = counter.k_most_common_ordered(3)[2];
-                trace!("counter2 mark 1: {}, {}", dataset_id, size);
-            }
-
             // TODO: Use HashesToColors here instead. If not initialized,
             //       build it.
             isect.0
@@ -415,32 +391,7 @@ impl RevIndexOps for RevIndex {
                     });
                 });
 
-            if counter.len() > 0 {
-                let (dataset_id, size) = counter.k_most_common_ordered(3)[0];
-                trace!("counter0 mark 2: {}, {}", dataset_id, size);
-            }
-            if counter.len() > 1 {
-                let (dataset_id, size) = counter.k_most_common_ordered(3)[1];
-                trace!("counter1 mark 2: {}, {}", dataset_id, size);
-            }
-            if counter.len() > 2 {
-                let (dataset_id, size) = counter.k_most_common_ordered(3)[2];
-                trace!("counter2 mark 2: {}, {}", dataset_id, size);
-            }
-
             counter.remove(&dataset_id);
-            if counter.len() > 0 {
-                let (dataset_id, size) = counter.k_most_common_ordered(3)[0];
-                trace!("counter0 mark 3: {}, {}", dataset_id, size);
-            }
-            if counter.len() > 1 {
-                let (dataset_id, size) = counter.k_most_common_ordered(3)[1];
-                trace!("counter1 mark 3: {}, {}", dataset_id, size);
-            }
-            if counter.len() > 2 {
-                let (dataset_id, size) = counter.k_most_common_ordered(3)[2];
-                trace!("counter2 mark 3: {}, {}", dataset_id, size);
-            }
         }
         Ok(matches)
     }

--- a/src/core/src/index/revindex/disk_revindex.rs
+++ b/src/core/src/index/revindex/disk_revindex.rs
@@ -390,11 +390,7 @@ impl RevIndexOps for RevIndex {
                 .for_each(|dataset| {
                     // TODO: collect the flat_map into a Counter, and remove more
                     //       than one at a time...
-                    counter.entry(dataset).and_modify(|e| {
-                        if *e > 0 {
-                            *e -= 1
-                        }
-                    });
+                    counter.entry(dataset).and_modify(|e| { *e -= 1 });
                 });
 
             counter.remove(&dataset_id);

--- a/src/core/src/index/revindex/mod.rs
+++ b/src/core/src/index/revindex/mod.rs
@@ -711,6 +711,99 @@ mod test {
     }
 
     #[test]
+    fn revindex_load_and_gather_3() -> Result<()> {
+        let _ = env_logger::try_init();
+
+        let mut basedir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        basedir.push("../../tests/test-data/gather/");
+
+        let against = vec![
+            "GCF_000016785.1_ASM1678v1_genomic.fna.gz.sig",
+            "GCF_000018945.1_ASM1894v1_genomic.fna.gz.sig",
+            "GCF_000008545.1_ASM854v1_genomic.fna.gz.sig",
+        ];
+        let against: Vec<_> = against
+            .iter()
+            .map(|sig| {
+                let mut filename = basedir.clone();
+                filename.push(sig);
+                filename
+            })
+            .collect();
+
+        // build 'against' sketches into a revindex
+        let selection = Selection::builder().ksize(21).scaled(10000).build();
+        let output = TempDir::new()?;
+
+        let collection = Collection::from_paths(&against)?.select(&selection)?;
+        let _index = RevIndex::create(output.path(), collection.try_into()?, false);
+
+        let index = RevIndex::open(output.path(), true, None)?;
+
+        let mut query = None;
+        let mut query_filename = basedir.clone();
+        query_filename.push("combined.sig");
+        let query_sig = Signature::from_path(query_filename)?
+            .swap_remove(0)
+            .select(&selection)?;
+
+        if let Some(q) = prepare_query(query_sig, &selection) {
+            query = Some(q);
+        }
+        let query = query.unwrap();
+
+        let (counter, query_colors, hash_to_color) = index.prepare_gather_counters(&query);
+
+        let matches = index.gather(
+            counter,
+            query_colors,
+            hash_to_color,
+            0,
+            &query,
+            Some(selection),
+        )?;
+
+        // should be 3.
+        // see sourmash#3193.
+        assert_eq!(matches.len(), 3);
+
+        fn round5(a: f64) -> f64 {
+            (a * 1e5).round() / 1e5
+        }
+
+        let match_ = &matches[0];
+        let names: Vec<&str> = match_.name().split(' ').take(1).collect();
+        assert_eq!(names[0], "NC_000853.1");
+        assert_eq!(match_.f_match(), 1.0);
+        assert_eq!(round5(match_.f_unique_to_query()), round5(0.13096862));
+
+        let match_ = &matches[1];
+        let names: Vec<&str> = match_.name().split(' ').take(1).collect();
+        assert_eq!(names[0], "NC_011978.1");
+        assert_eq!(match_.f_match(), 0.898936170212766);
+        assert_eq!(round5(match_.f_unique_to_query()), round5(0.115279));
+
+        let match_ = &matches[2];
+        dbg!(match_);
+        let names: Vec<&str> = match_.name().split(' ').take(1).collect();
+        assert_eq!(names[0], "NC_009486.1");
+
+        // @CTB this fails: 0.43158 != 0.48421
+        assert_eq!(round5(match_.f_match()), round5(0.4842105));
+
+        // @CTB this fails: 0.05593 != 0.06276
+        // assert_eq!(round5(match_.f_unique_to_query()), round5(0.0627557));
+
+        // @CTB fails
+        // assert_eq!(match_.unique_intersect_bp, 820000);
+
+        // @CTB fails
+        // assert_eq!(match_.remaining_bp, 2170000);
+
+        Ok(())
+    }
+
+    #[test]
     fn revindex_move() -> Result<()> {
         let basedir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
 

--- a/src/core/src/index/revindex/mod.rs
+++ b/src/core/src/index/revindex/mod.rs
@@ -647,13 +647,12 @@ mod test {
             counter,
             query_colors,
             hash_to_color,
-            0,
+            5,                  // 50kb threshold
             &query,
             Some(selection),
         )?;
 
-        // should be 11, based on test_gather_metagenome_num_results @CTB.
-        // see sourmash#3139 and sourmash_plugin_branchwater#322.
+        // should be 11, based on test_gather_metagenome_num_results
         assert_eq!(matches.len(), 11);
 
         fn round5(a: f64) -> f64 {
@@ -694,23 +693,50 @@ mod test {
         dbg!(match_);
         let names: Vec<&str> = match_.name().split(' ').take(1).collect();
         assert_eq!(names[0], "NC_009486.1");
+        assert_eq!(round5(match_.f_match()), round5(0.4842105));
+        assert_eq!(round5(match_.f_unique_to_query()), round5(0.0627557));
 
-        // @CTB this fails: 0.43158 != 0.48421
-        // assert_eq!(round5(match_.f_match()), round5(0.4842105));
+        let match_ = &matches[6];
+        dbg!(match_);
+        let names: Vec<&str> = match_.name().split(' ').take(1).collect();
+        assert_eq!(names[0], "NC_006905.1");
+        assert_eq!(round5(match_.f_match()), round5(0.161016949152542));
+        assert_eq!(round5(match_.f_unique_to_query()), round5(0.0518417462482947));
 
-        // @CTB this fails: 0.05593 != 0.06276
-        // assert_eq!(round5(match_.f_unique_to_query()), round5(0.0627557));
+        let match_ = &matches[7];
+        dbg!(match_);
+        let names: Vec<&str> = match_.name().split(' ').take(1).collect();
+        assert_eq!(names[0], "NC_011080.1");
+        assert_eq!(round5(match_.f_match()), round5(0.125799573560768));
+        assert_eq!(round5(match_.f_unique_to_query()), round5(0.04024556616643930));
 
-        // @CTB fails
-        // assert_eq!(match_.unique_intersect_bp, 820000);
+        let match_ = &matches[8];
+        dbg!(match_);
+        let names: Vec<&str> = match_.name().split(' ').take(1).collect();
+        assert_eq!(names[0], "NC_011274.1");
+        assert_eq!(round5(match_.f_match()), round5(0.0919037199124727));
+        assert_eq!(round5(match_.f_unique_to_query()), round5(0.0286493860845839));
 
-        // @CTB fails
-        // assert_eq!(match_.remaining_bp, 2170000);
+        let match_ = &matches[9];
+        dbg!(match_);
+        let names: Vec<&str> = match_.name().split(' ').take(1).collect();
+        assert_eq!(names[0], "NC_006511.1");
+        assert_eq!(round5(match_.f_match()), round5(0.0725995316159251));
+        assert_eq!(round5(match_.f_unique_to_query()), round5(0.021145975443383400));
+
+        let match_ = &matches[10];
+        dbg!(match_);
+        let names: Vec<&str> = match_.name().split(' ').take(1).collect();
+        assert_eq!(names[0], "NC_011294.1");
+        assert_eq!(round5(match_.f_match()), round5(0.0148619957537155));
+        assert_eq!(round5(match_.f_unique_to_query()), round5(0.0047748976807639800));
 
         Ok(())
     }
 
     #[test]
+    // a more detailed/focused version of revindex_load_and_gather_2,
+    // added in sourmash#3193 for debugging purposes.
     fn revindex_load_and_gather_3() -> Result<()> {
         let _ = env_logger::try_init();
 
@@ -787,18 +813,10 @@ mod test {
         dbg!(match_);
         let names: Vec<&str> = match_.name().split(' ').take(1).collect();
         assert_eq!(names[0], "NC_009486.1");
-
-        // @CTB this fails: 0.43158 != 0.48421
         assert_eq!(round5(match_.f_match()), round5(0.4842105));
-
-        // @CTB this fails: 0.05593 != 0.06276
-        // assert_eq!(round5(match_.f_unique_to_query()), round5(0.0627557));
-
-        // @CTB fails
-        // assert_eq!(match_.unique_intersect_bp, 820000);
-
-        // @CTB fails
-        // assert_eq!(match_.remaining_bp, 2170000);
+        assert_eq!(round5(match_.f_unique_to_query()), round5(0.0627557));
+        assert_eq!(match_.unique_intersect_bp, 820000);
+        assert_eq!(match_.remaining_bp, 2170000);
 
         Ok(())
     }

--- a/src/core/src/index/revindex/mod.rs
+++ b/src/core/src/index/revindex/mod.rs
@@ -591,8 +591,6 @@ mod test {
 
     #[test]
     fn revindex_load_and_gather_2() -> Result<()> {
-        let _ = env_logger::try_init();
-
         let mut basedir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         basedir.push("../../tests/test-data/gather/");
 
@@ -752,8 +750,6 @@ mod test {
     // a more detailed/focused version of revindex_load_and_gather_2,
     // added in sourmash#3193 for debugging purposes.
     fn revindex_load_and_gather_3() -> Result<()> {
-        let _ = env_logger::try_init();
-
         let mut basedir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         basedir.push("../../tests/test-data/gather/");
 

--- a/src/core/src/index/revindex/mod.rs
+++ b/src/core/src/index/revindex/mod.rs
@@ -813,6 +813,7 @@ mod test {
         assert_eq!(match_.f_match(), 1.0);
         assert_eq!(round5(match_.f_unique_to_query()), round5(0.13096862));
         assert_eq!(match_.unique_intersect_bp, 1920000);
+        assert_eq!(match_.remaining_bp, 12740000);
 
         let match_ = &matches[1];
         let names: Vec<&str> = match_.name().split(' ').take(1).collect();
@@ -820,6 +821,7 @@ mod test {
         assert_eq!(match_.f_match(), 0.898936170212766);
         assert_eq!(round5(match_.f_unique_to_query()), round5(0.115279));
         assert_eq!(match_.unique_intersect_bp, 1690000);
+        assert_eq!(match_.remaining_bp, 11050000);
 
         let match_ = &matches[2];
         dbg!(match_);
@@ -828,6 +830,7 @@ mod test {
         assert_eq!(round5(match_.f_match()), round5(0.4842105));
         assert_eq!(round5(match_.f_unique_to_query()), round5(0.0627557));
         assert_eq!(match_.unique_intersect_bp, 920000);
+        assert_eq!(match_.remaining_bp, 10130000);
 
         Ok(())
     }

--- a/src/core/src/index/revindex/mod.rs
+++ b/src/core/src/index/revindex/mod.rs
@@ -445,7 +445,6 @@ fn stats_for_cf(db: Arc<DB>, cf_name: &str, deep_check: bool, quick: bool) -> Db
 
 #[cfg(test)]
 mod test {
-    use env_logger::try_init;
     use camino::Utf8PathBuf as PathBuf;
     use tempfile::TempDir;
 
@@ -802,12 +801,14 @@ mod test {
         assert_eq!(names[0], "NC_000853.1");
         assert_eq!(match_.f_match(), 1.0);
         assert_eq!(round5(match_.f_unique_to_query()), round5(0.13096862));
+        assert_eq!(match_.unique_intersect_bp, 1920000);
 
         let match_ = &matches[1];
         let names: Vec<&str> = match_.name().split(' ').take(1).collect();
         assert_eq!(names[0], "NC_011978.1");
         assert_eq!(match_.f_match(), 0.898936170212766);
         assert_eq!(round5(match_.f_unique_to_query()), round5(0.115279));
+        assert_eq!(match_.unique_intersect_bp, 1690000);
 
         let match_ = &matches[2];
         dbg!(match_);
@@ -816,7 +817,6 @@ mod test {
         assert_eq!(round5(match_.f_match()), round5(0.4842105));
         assert_eq!(round5(match_.f_unique_to_query()), round5(0.0627557));
         assert_eq!(match_.unique_intersect_bp, 920000);
-        assert_eq!(match_.remaining_bp, 2170000);
 
         Ok(())
     }

--- a/src/core/src/index/revindex/mod.rs
+++ b/src/core/src/index/revindex/mod.rs
@@ -646,7 +646,7 @@ mod test {
             counter,
             query_colors,
             hash_to_color,
-            5,                  // 50kb threshold
+            5, // 50kb threshold
             &query,
             Some(selection),
         )?;
@@ -700,35 +700,50 @@ mod test {
         let names: Vec<&str> = match_.name().split(' ').take(1).collect();
         assert_eq!(names[0], "NC_006905.1");
         assert_eq!(round5(match_.f_match()), round5(0.161016949152542));
-        assert_eq!(round5(match_.f_unique_to_query()), round5(0.0518417462482947));
+        assert_eq!(
+            round5(match_.f_unique_to_query()),
+            round5(0.0518417462482947)
+        );
 
         let match_ = &matches[7];
         dbg!(match_);
         let names: Vec<&str> = match_.name().split(' ').take(1).collect();
         assert_eq!(names[0], "NC_011080.1");
         assert_eq!(round5(match_.f_match()), round5(0.125799573560768));
-        assert_eq!(round5(match_.f_unique_to_query()), round5(0.04024556616643930));
+        assert_eq!(
+            round5(match_.f_unique_to_query()),
+            round5(0.04024556616643930)
+        );
 
         let match_ = &matches[8];
         dbg!(match_);
         let names: Vec<&str> = match_.name().split(' ').take(1).collect();
         assert_eq!(names[0], "NC_011274.1");
         assert_eq!(round5(match_.f_match()), round5(0.0919037199124727));
-        assert_eq!(round5(match_.f_unique_to_query()), round5(0.0286493860845839));
+        assert_eq!(
+            round5(match_.f_unique_to_query()),
+            round5(0.0286493860845839)
+        );
 
         let match_ = &matches[9];
         dbg!(match_);
         let names: Vec<&str> = match_.name().split(' ').take(1).collect();
         assert_eq!(names[0], "NC_006511.1");
         assert_eq!(round5(match_.f_match()), round5(0.0725995316159251));
-        assert_eq!(round5(match_.f_unique_to_query()), round5(0.021145975443383400));
+        assert_eq!(
+            round5(match_.f_unique_to_query()),
+            round5(0.021145975443383400)
+        );
 
         let match_ = &matches[10];
         dbg!(match_);
         let names: Vec<&str> = match_.name().split(' ').take(1).collect();
         assert_eq!(names[0], "NC_011294.1");
         assert_eq!(round5(match_.f_match()), round5(0.0148619957537155));
-        assert_eq!(round5(match_.f_unique_to_query()), round5(0.0047748976807639800));
+        assert_eq!(
+            round5(match_.f_unique_to_query()),
+            round5(0.0047748976807639800)
+        );
 
         Ok(())
     }

--- a/src/core/src/index/revindex/mod.rs
+++ b/src/core/src/index/revindex/mod.rs
@@ -445,6 +445,7 @@ fn stats_for_cf(db: Arc<DB>, cf_name: &str, deep_check: bool, quick: bool) -> Db
 
 #[cfg(test)]
 mod test {
+    use env_logger::try_init;
     use camino::Utf8PathBuf as PathBuf;
     use tempfile::TempDir;
 
@@ -591,6 +592,8 @@ mod test {
 
     #[test]
     fn revindex_load_and_gather_2() -> Result<()> {
+        let _ = env_logger::try_init();
+
         let mut basedir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         basedir.push("../../tests/test-data/gather/");
 
@@ -651,7 +654,7 @@ mod test {
 
         // should be 11, based on test_gather_metagenome_num_results @CTB.
         // see sourmash#3139 and sourmash_plugin_branchwater#322.
-        assert_eq!(matches.len(), 6);
+        assert_eq!(matches.len(), 11);
 
         fn round5(a: f64) -> f64 {
             (a * 1e5).round() / 1e5

--- a/src/core/src/index/revindex/mod.rs
+++ b/src/core/src/index/revindex/mod.rs
@@ -815,7 +815,7 @@ mod test {
         assert_eq!(names[0], "NC_009486.1");
         assert_eq!(round5(match_.f_match()), round5(0.4842105));
         assert_eq!(round5(match_.f_unique_to_query()), round5(0.0627557));
-        assert_eq!(match_.unique_intersect_bp, 820000);
+        assert_eq!(match_.unique_intersect_bp, 920000);
         assert_eq!(match_.remaining_bp, 2170000);
 
         Ok(())

--- a/src/core/src/manifest.rs
+++ b/src/core/src/manifest.rs
@@ -452,9 +452,7 @@ mod test {
     fn manifest_to_writer_moltype_dna() {
         let base_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
 
-        let test_sigs = vec![
-            PathBuf::from("../../tests/test-data/47.fa.sig"),
-        ];
+        let test_sigs = vec![PathBuf::from("../../tests/test-data/47.fa.sig")];
 
         let full_paths: Vec<PathBuf> = test_sigs
             .into_iter()

--- a/tests/test_sourmash_sketch.py
+++ b/tests/test_sourmash_sketch.py
@@ -353,7 +353,7 @@ def test_protein_override_bad_rust_foo():
     with pytest.raises(ValueError) as exc:
         sig.add_protein(record.sequence)
 
-    assert 'Invalid hash function: "dna"' in str(exc)
+    assert 'Invalid hash function: "DNA"' in str(exc)
 
 
 def test_dayhoff_defaults():


### PR DESCRIPTION
This PR fixes a bug in `disk_revindex.rs::RevIndexOps::gather` where RocksDB-based `gather` was 
incorrectly subtracting hashes multiple times from the counter in situations of high redundancy.

For example, consider this Venn diagram of the 3-way intersection between three sketches:

![image](https://github.com/sourmash-bio/sourmash/assets/51016/f98bf6a0-acc4-415f-bf39-1c48a599996a)

When a metagenome contains the union of all three of these sketches, the broken implementation would subtract the `10` at the center multiple times. This was caused by removing hashes from the matches, rather than the intersection, each pass through the counter.

Of note, this made RocksDB-based `fastmultigather` return incorrect results, ref https://github.com/sourmash-bio/sourmash_plugin_branchwater/issues/322; first discovered in https://github.com/sourmash-bio/sourmash/pull/3138#issuecomment-2104889751.

The PR fixes this, and adds a more complete pair of tests, based on `test_gather_metagenome_num_results` in the Python tests for sourmash.

This PR also adjusts the hash function string for DNA sketches in Rust to be uppercase `DNA` rather than lowercase `dna`, ref https://github.com/sourmash-bio/sourmash_plugin_directsketch/issues/49

And remember, it's not *just* the destination - it's the friends you make along the way, like `env_logger`.

* Fixes https://github.com/sourmash-bio/sourmash/issues/3139
* Fixes https://github.com/sourmash-bio/sourmash_plugin_directsketch/issues/49

For consideration:

Right now we are calculating the intersection twice, once in `disk_revindex.rs` and once in `calculate_gather_stats` in `revindex/mod.rs`. This is unnecessary, of course. But the function signature for `calculate_gather_stats` would need to change to take the intersection as an argument.  We could:
* keep calculating it twice, just for simplicity;
* change `calculate_gather_stats` to take an _optional_ intersection, and calculate it if not provided;
* change `calculate_gather_stats` to require an intersection.

TODO:
- [x] add at least one explicit test for the moltype fix

Other notes:

* there is a discrepancy between the Python (`sourmash gather`) and Rust (`sourmash_plugin_branchwater` results) calculations for `remaining_bp`. It seems to me like the Python one is definitely wrong; not yet sure about Rust. Viz https://github.com/sourmash-bio/sourmash/issues/3194.
