### PR TITLE
MRG: check `select` parameters; enforce types when building manifests

### DIFF
--- a/src/sourmash/commands.py
+++ b/src/sourmash/commands.py
@@ -1588,7 +1588,7 @@ def prefetch(args):
         if args.linear:
             db = LazyLinearIndex(db)
 
-        db = db.select(ksize=ksize, moltype=moltype, containment=True, scaled=True)
+        db = db.select(ksize=ksize, moltype=moltype, containment=True)
 
         sum_signatures_after_select += len(db)
 

--- a/src/sourmash/index/__init__.py
+++ b/src/sourmash/index/__init__.py
@@ -1229,15 +1229,16 @@ class StandaloneManifestIndex(Index):
 def _check_select_parameters(**kw):
     "Check 'select' parameters for types/conversion."
     params = set(kw)
-    params -= {'ksize', 'num', 'moltype', 'scaled', 'abund', 'picklist',
-               'containment'}
+    params -= {"ksize", "num", "moltype", "scaled", "abund", "picklist", "containment"}
     if params:
         raise ValueError(f"unknown 'select' parameters: {params}")
 
     ksize = kw.get("ksize")
     if ksize is not None:
         if type(ksize) != int:
-            raise ValueError(f"ksize value '{ksize}' must be an integer, is: {type(ksize)}")
+            raise ValueError(
+                f"ksize value '{ksize}' must be an integer, is: {type(ksize)}"
+            )
 
     moltype = kw.get("moltype")
     if moltype is not None:
@@ -1247,12 +1248,16 @@ def _check_select_parameters(**kw):
     scaled = kw.get("scaled")
     if scaled is not None:
         if type(scaled) != int:
-            raise ValueError(f"scaled value '{scaled}' must be an integer, is: {type(scaled)}")
+            raise ValueError(
+                f"scaled value '{scaled}' must be an integer, is: {type(scaled)}"
+            )
 
     containment = kw.get("containment")
     if containment is not None:
         if type(containment) != bool:
-            raise ValueError(f"containment value '{containment}' must be a bool, is: {type(containment)}")
+            raise ValueError(
+                f"containment value '{containment}' must be a bool, is: {type(containment)}"
+            )
 
     abund = kw.get("abund")
     if abund is not None:

--- a/src/sourmash/index/__init__.py
+++ b/src/sourmash/index/__init__.py
@@ -1228,27 +1228,38 @@ class StandaloneManifestIndex(Index):
 
 def _check_select_parameters(**kw):
     "Check 'select' parameters for types/conversion."
+    params = set(kw)
+    params -= {'ksize', 'num', 'moltype', 'scaled', 'abund', 'picklist',
+               'containment'}
+    if params:
+        raise ValueError(f"unknown 'select' parameters: {params}")
+
     ksize = kw.get("ksize")
     if ksize is not None:
         if type(ksize) != int:
-            raise ValueError(f"{type(ksize)}")
+            raise ValueError(f"ksize value '{ksize}' must be an integer, is: {type(ksize)}")
 
     moltype = kw.get("moltype")
     if moltype is not None:
         if moltype not in ["DNA", "protein", "dayhoff", "hp"]:
-            raise ValueError
+            raise ValueError(f"unknown moltype: {moltype}")
 
     scaled = kw.get("scaled")
     if scaled is not None:
-        if type(scaled) not in [bool, int]:
-            raise ValueError(f"{type(scaled)}")
+        if type(scaled) != int:
+            raise ValueError(f"scaled value '{scaled}' must be an integer, is: {type(scaled)}")
+
+    containment = kw.get("containment")
+    if containment is not None:
+        if type(containment) != bool:
+            raise ValueError(f"containment value '{containment}' must be a bool, is: {type(containment)}")
 
     abund = kw.get("abund")
     if abund is not None:
         if type(abund) != bool:
-            raise ValueError(f"{type(abund)}")
+            raise ValueError(f"abund value '{abund}' must be a bool is: {type(abund)}")
 
     num = kw.get("num")
     if num is not None:
         if type(num) != int:
-            raise ValueError(f"{type(num)}")
+            raise ValueError(f"num value '{num}' must be an integer, is: {type(num)}")

--- a/src/sourmash/index/__init__.py
+++ b/src/sourmash/index/__init__.py
@@ -443,6 +443,8 @@ class LinearIndex(Index):
 
         Does not raise ValueError, but may return an empty Index.
         """
+        _check_select_parameters(**kwargs)
+
         siglist = []
         for ss in self._signatures:
             if select_signature(ss, **kwargs):
@@ -512,6 +514,8 @@ class LazyLinearIndex(Index):
 
         Does not raise ValueError, but may return an empty Index.
         """
+        _check_select_parameters(**kwargs)
+
         selection_dict = dict(self.selection_dict)
         for k, v in kwargs.items():
             if k in selection_dict:
@@ -689,6 +693,7 @@ class ZipFileLinearIndex(Index):
 
     def select(self, **kwargs):
         "Select signatures in zip file based on ksize/moltype/etc."
+        _check_select_parameters(**kwargs)
 
         # if we have a manifest, run 'select' on the manifest.
         manifest = self.manifest
@@ -1101,6 +1106,7 @@ class MultiIndex(Index):
 
     def select(self, **kwargs):
         "Run 'select' on the manifest."
+        _check_select_parameters(**kwargs)
         new_manifest = self.manifest.select_to_manifest(**kwargs)
         return MultiIndex(
             new_manifest, self.parent, prepend_location=self.prepend_location
@@ -1215,5 +1221,28 @@ class StandaloneManifestIndex(Index):
 
     def select(self, **kwargs):
         "Run 'select' on the manifest."
+        _check_select_parameters(**kwargs)
         new_manifest = self.manifest.select_to_manifest(**kwargs)
         return StandaloneManifestIndex(new_manifest, self._location, prefix=self.prefix)
+
+
+def _check_select_parameters(**kw):
+    ksize = kw.get('ksize')
+    if ksize is not None:
+        if type(ksize) != int: raise ValueError(f"{type(ksize)}")
+
+    moltype = kw.get('moltype')
+    if moltype is not None:
+        if moltype not in ['DNA', 'protein', 'dayhoff', 'hp']: raise ValueError
+
+    scaled = kw.get('scaled')
+    if scaled is not None:
+        if type(scaled) not in [bool, int]: raise ValueError(f"{type(scaled)}")
+
+    abund = kw.get('abund')
+    if abund is not None:
+        if type(abund) != bool: raise ValueError(f"{type(abund)}")
+
+    num = kw.get('num')
+    if num is not None:
+        if type(num) != int: raise ValueError(f"{type(num)}")

--- a/src/sourmash/index/__init__.py
+++ b/src/sourmash/index/__init__.py
@@ -1227,22 +1227,27 @@ class StandaloneManifestIndex(Index):
 
 
 def _check_select_parameters(**kw):
-    ksize = kw.get('ksize')
+    ksize = kw.get("ksize")
     if ksize is not None:
-        if type(ksize) != int: raise ValueError(f"{type(ksize)}")
+        if type(ksize) != int:
+            raise ValueError(f"{type(ksize)}")
 
-    moltype = kw.get('moltype')
+    moltype = kw.get("moltype")
     if moltype is not None:
-        if moltype not in ['DNA', 'protein', 'dayhoff', 'hp']: raise ValueError
+        if moltype not in ["DNA", "protein", "dayhoff", "hp"]:
+            raise ValueError
 
-    scaled = kw.get('scaled')
+    scaled = kw.get("scaled")
     if scaled is not None:
-        if type(scaled) not in [bool, int]: raise ValueError(f"{type(scaled)}")
+        if type(scaled) not in [bool, int]:
+            raise ValueError(f"{type(scaled)}")
 
-    abund = kw.get('abund')
+    abund = kw.get("abund")
     if abund is not None:
-        if type(abund) != bool: raise ValueError(f"{type(abund)}")
+        if type(abund) != bool:
+            raise ValueError(f"{type(abund)}")
 
-    num = kw.get('num')
+    num = kw.get("num")
     if num is not None:
-        if type(num) != int: raise ValueError(f"{type(num)}")
+        if type(num) != int:
+            raise ValueError(f"{type(num)}")

--- a/src/sourmash/index/__init__.py
+++ b/src/sourmash/index/__init__.py
@@ -1262,7 +1262,7 @@ def _check_select_parameters(**kw):
     abund = kw.get("abund")
     if abund is not None:
         if type(abund) != bool:
-            raise ValueError(f"abund value '{abund}' must be a bool is: {type(abund)}")
+            raise ValueError(f"abund value '{abund}' must be a bool, is: {type(abund)}")
 
     num = kw.get("num")
     if num is not None:

--- a/src/sourmash/index/__init__.py
+++ b/src/sourmash/index/__init__.py
@@ -1235,7 +1235,7 @@ def _check_select_parameters(**kw):
 
     ksize = kw.get("ksize")
     if ksize is not None:
-        if type(ksize) != int:
+        if not isinstance(ksize, int):
             raise ValueError(
                 f"ksize value '{ksize}' must be an integer, is: {type(ksize)}"
             )
@@ -1247,24 +1247,24 @@ def _check_select_parameters(**kw):
 
     scaled = kw.get("scaled")
     if scaled is not None:
-        if type(scaled) != int:
+        if not isinstance(scaled, int):
             raise ValueError(
                 f"scaled value '{scaled}' must be an integer, is: {type(scaled)}"
             )
 
     containment = kw.get("containment")
     if containment is not None:
-        if type(containment) != bool:
+        if not isinstance(containment, bool):
             raise ValueError(
                 f"containment value '{containment}' must be a bool, is: {type(containment)}"
             )
 
     abund = kw.get("abund")
     if abund is not None:
-        if type(abund) != bool:
+        if not isinstance(abund, bool):
             raise ValueError(f"abund value '{abund}' must be a bool, is: {type(abund)}")
 
     num = kw.get("num")
     if num is not None:
-        if type(num) != int:
+        if not isinstance(num, int):
             raise ValueError(f"num value '{num}' must be an integer, is: {type(num)}")

--- a/src/sourmash/index/__init__.py
+++ b/src/sourmash/index/__init__.py
@@ -1227,6 +1227,7 @@ class StandaloneManifestIndex(Index):
 
 
 def _check_select_parameters(**kw):
+    "Check 'select' parameters for types/conversion."
     ksize = kw.get("ksize")
     if ksize is not None:
         if type(ksize) != int:

--- a/src/sourmash/index/sqlite_index.py
+++ b/src/sourmash/index/sqlite_index.py
@@ -896,7 +896,7 @@ class SqliteCollectionManifest(BaseCollectionManifest):
                 name=name,
                 filename=filename,
                 n_hashes=n_hashes,
-                with_abundance=0,
+                with_abundance=False,
                 ksize=ksize,
                 md5=md5sum,
                 internal_location=iloc,

--- a/src/sourmash/index/sqlite_index.py
+++ b/src/sourmash/index/sqlite_index.py
@@ -81,7 +81,7 @@ import itertools
 
 from bitstring import BitArray
 
-from sourmash.index import Index
+from sourmash.index import Index, _check_select_parameters
 from sourmash.exceptions import IndexNotSupported
 from sourmash import MinHash, SourmashSignature
 from sourmash.index import IndexSearchResult, StandaloneManifestIndex
@@ -428,6 +428,8 @@ class SqliteIndex(Index):
                         yield IndexSearchResult(score, subj, self.location)
 
     def _select(self, *, num=0, track_abundance=False, **kwargs):
+        _check_select_parameters(**kwargs)
+
         "Run a select! This just modifies the manifest."
         # check SqliteIndex specific conditions on the 'select'
         if num:

--- a/src/sourmash/lca/lca_db.py
+++ b/src/sourmash/lca/lca_db.py
@@ -8,7 +8,7 @@ import functools
 import sourmash
 from sourmash.minhash import _get_max_hash_for_scaled
 from sourmash.logging import notify, error, debug
-from sourmash.index import Index, IndexSearchResult
+from sourmash.index import Index, IndexSearchResult, _check_select_parameters
 from sourmash.picklist import passes_all_picklists
 
 
@@ -244,6 +244,7 @@ class LCA_Database(Index):
         abund=None,
         containment=False,
         picklist=None,
+        **kwargs,
     ):
         """Select a subset of signatures to search.
 
@@ -254,6 +255,10 @@ class LCA_Database(Index):
 
         Will always raise ValueError if a requirement cannot be met.
         """
+        _check_select_parameters(ksize=ksize, num=num, moltype=moltype,
+                                 scaled=scaled, containment=containment,
+                                 abund=abund, picklist=picklist, **kwargs)
+
         if num:
             raise ValueError("cannot use 'num' MinHashes to search LCA database")
 

--- a/src/sourmash/lca/lca_db.py
+++ b/src/sourmash/lca/lca_db.py
@@ -255,9 +255,16 @@ class LCA_Database(Index):
 
         Will always raise ValueError if a requirement cannot be met.
         """
-        _check_select_parameters(ksize=ksize, num=num, moltype=moltype,
-                                 scaled=scaled, containment=containment,
-                                 abund=abund, picklist=picklist, **kwargs)
+        _check_select_parameters(
+            ksize=ksize,
+            num=num,
+            moltype=moltype,
+            scaled=scaled,
+            containment=containment,
+            abund=abund,
+            picklist=picklist,
+            **kwargs,
+        )
 
         if num:
             raise ValueError("cannot use 'num' MinHashes to search LCA database")

--- a/src/sourmash/manifest.py
+++ b/src/sourmash/manifest.py
@@ -146,15 +146,17 @@ class BaseCollectionManifest:
     @classmethod
     def make_manifest_row(cls, ss, location, *, include_signature=True):
         "make a manifest row dictionary."
+        mh = ss.minhash
+
         row = {}
         row["md5"] = ss.md5sum()
         row["md5short"] = row["md5"][:8]
-        row["ksize"] = ss.minhash.ksize
-        row["moltype"] = ss.minhash.moltype
-        row["num"] = ss.minhash.num
-        row["scaled"] = ss.minhash.scaled
-        row["n_hashes"] = len(ss.minhash)
-        row["with_abundance"] = 1 if ss.minhash.track_abundance else 0
+        row["ksize"] = int(mh.ksize)
+        row["moltype"] = mh.moltype
+        row["num"] = int(mh.num)
+        row["scaled"] = int(mh.scaled)
+        row["n_hashes"] = len(mh)
+        row["with_abundance"] = mh.track_abundance
         row["name"] = ss.name
         row["filename"] = ss.filename
         row["internal_location"] = location
@@ -223,6 +225,17 @@ class BaseCollectionManifest:
     @abstractmethod
     def to_picklist(self):
         "Convert manifest to a picklist."
+
+    def _check_row_values(self):
+        "check that manifest rows have legit types/values."
+        for row in self.rows:
+            index._check_select_parameters(
+                num=row["num"],
+                ksize=row["ksize"],
+                moltype=row["moltype"],
+                scaled=row["scaled"],
+                abund=row["with_abundance"],
+            )
 
 
 class CollectionManifest(BaseCollectionManifest):

--- a/src/sourmash/manifest.py
+++ b/src/sourmash/manifest.py
@@ -8,7 +8,7 @@ import os.path
 from abc import abstractmethod
 import itertools
 
-from sourmash import picklist
+from sourmash import picklist, index
 
 
 class BaseCollectionManifest:
@@ -298,21 +298,11 @@ class CollectionManifest(BaseCollectionManifest):
 
         Internal method; call `select_to_manifest` instead.
         """
-        if ksize is not None:
-            if type(ksize) != int:
-                raise ValueError(f"{type(ksize)}")
-        if moltype is not None:
-            if moltype not in ["DNA", "protein", "dayhoff", "hp"]:
-                raise ValueError
-        if scaled is not None:
-            if type(scaled) not in [bool, int]:
-                raise ValueError(f"{type(scaled)}")
-        if abund is not None:
-            if type(abund) != bool:
-                raise ValueError(f"{type(abund)}")
-        if num is not None:
-            if type(num) != int:
-                raise ValueError(f"{type(num)}")
+        index._check_select_parameters(ksize=ksize,
+                                       num=num,
+                                       abund=abund,
+                                       moltype=moltype,
+                                       scaled=scaled)
 
         matching_rows = self.rows
         if ksize:
@@ -320,9 +310,6 @@ class CollectionManifest(BaseCollectionManifest):
         if moltype:
             matching_rows = (row for row in matching_rows if row["moltype"] == moltype)
         if scaled or containment:
-            if containment and not scaled:
-                raise ValueError("'containment' requires 'scaled' in Index.select'")
-
             matching_rows = (
                 row for row in matching_rows if row["scaled"] and not row["num"]
             )

--- a/src/sourmash/manifest.py
+++ b/src/sourmash/manifest.py
@@ -298,11 +298,9 @@ class CollectionManifest(BaseCollectionManifest):
 
         Internal method; call `select_to_manifest` instead.
         """
-        index._check_select_parameters(ksize=ksize,
-                                       num=num,
-                                       abund=abund,
-                                       moltype=moltype,
-                                       scaled=scaled)
+        index._check_select_parameters(
+            ksize=ksize, num=num, abund=abund, moltype=moltype, scaled=scaled
+        )
 
         matching_rows = self.rows
         if ksize:

--- a/src/sourmash/manifest.py
+++ b/src/sourmash/manifest.py
@@ -299,15 +299,20 @@ class CollectionManifest(BaseCollectionManifest):
         Internal method; call `select_to_manifest` instead.
         """
         if ksize is not None:
-            if type(ksize) != int: raise ValueError(f"{type(ksize)}")
+            if type(ksize) != int:
+                raise ValueError(f"{type(ksize)}")
         if moltype is not None:
-            if moltype not in ['DNA', 'protein', 'dayhoff', 'hp']: raise ValueError
+            if moltype not in ["DNA", "protein", "dayhoff", "hp"]:
+                raise ValueError
         if scaled is not None:
-            if type(scaled) not in [bool, int]: raise ValueError(f"{type(scaled)}")
+            if type(scaled) not in [bool, int]:
+                raise ValueError(f"{type(scaled)}")
         if abund is not None:
-            if type(abund) != bool: raise ValueError(f"{type(abund)}")
+            if type(abund) != bool:
+                raise ValueError(f"{type(abund)}")
         if num is not None:
-            if type(num) != int: raise ValueError(f"{type(num)}")
+            if type(num) != int:
+                raise ValueError(f"{type(num)}")
 
         matching_rows = self.rows
         if ksize:

--- a/src/sourmash/manifest.py
+++ b/src/sourmash/manifest.py
@@ -298,6 +298,17 @@ class CollectionManifest(BaseCollectionManifest):
 
         Internal method; call `select_to_manifest` instead.
         """
+        if ksize is not None:
+            if type(ksize) != int: raise ValueError(f"{type(ksize)}")
+        if moltype is not None:
+            if moltype not in ['DNA', 'protein', 'dayhoff', 'hp']: raise ValueError
+        if scaled is not None:
+            if type(scaled) not in [bool, int]: raise ValueError(f"{type(scaled)}")
+        if abund is not None:
+            if type(abund) != bool: raise ValueError(f"{type(abund)}")
+        if num is not None:
+            if type(num) != int: raise ValueError(f"{type(num)}")
+
         matching_rows = self.rows
         if ksize:
             matching_rows = (row for row in matching_rows if row["ksize"] == ksize)

--- a/src/sourmash/sbt.py
+++ b/src/sourmash/sbt.py
@@ -238,8 +238,6 @@ class SBT(Index):
 
         # containment requires 'scaled'.
         if containment:
-            if not scaled:
-                raise ValueError("'containment' requires 'scaled' in SBT.select'")
             if not db_mh.scaled:
                 raise ValueError(
                     "cannot search this SBT for containment; signatures are not calculated with scaled"

--- a/src/sourmash/sbt.py
+++ b/src/sourmash/sbt.py
@@ -20,8 +20,12 @@ from io import StringIO
 from .exceptions import IndexNotSupported
 from .sbt_storage import FSStorage, IPFSStorage, RedisStorage, ZipStorage
 from .logging import error, notify, debug
-from .index import (Index, IndexSearchResult, CollectionManifest,
-                    _check_select_parameters)
+from .index import (
+    Index,
+    IndexSearchResult,
+    CollectionManifest,
+    _check_select_parameters,
+)
 from .picklist import passes_all_picklists
 
 from .nodegraph import Nodegraph, extract_nodegraph_info, calc_expected_collisions
@@ -194,7 +198,8 @@ class SBT(Index):
             ss = k.data
             yield ss, k._path
 
-    def select(self,
+    def select(
+        self,
         ksize=None,
         moltype=None,
         num=0,
@@ -221,9 +226,16 @@ class SBT(Index):
           implicitly downsample or necessarily estimate similarity if
           the scaled values differ.
         """
-        _check_select_parameters(ksize=ksize, num=num, moltype=moltype,
-                                 scaled=scaled, containment=containment,
-                                 abund=abund, picklist=picklist, **kwargs)
+        _check_select_parameters(
+            ksize=ksize,
+            num=num,
+            moltype=moltype,
+            scaled=scaled,
+            containment=containment,
+            abund=abund,
+            picklist=picklist,
+            **kwargs,
+        )
 
         # pull out a signature from this collection -
         first_sig = next(iter(self.signatures()))

--- a/src/sourmash/sbt.py
+++ b/src/sourmash/sbt.py
@@ -20,7 +20,8 @@ from io import StringIO
 from .exceptions import IndexNotSupported
 from .sbt_storage import FSStorage, IPFSStorage, RedisStorage, ZipStorage
 from .logging import error, notify, debug
-from .index import Index, IndexSearchResult, CollectionManifest
+from .index import (Index, IndexSearchResult, CollectionManifest,
+                    _check_select_parameters)
 from .picklist import passes_all_picklists
 
 from .nodegraph import Nodegraph, extract_nodegraph_info, calc_expected_collisions
@@ -193,8 +194,7 @@ class SBT(Index):
             ss = k.data
             yield ss, k._path
 
-    def select(
-        self,
+    def select(self,
         ksize=None,
         moltype=None,
         num=0,
@@ -202,6 +202,7 @@ class SBT(Index):
         containment=False,
         abund=None,
         picklist=None,
+        **kwargs,
     ):
         """Make sure this database matches the requested requirements.
 
@@ -220,6 +221,10 @@ class SBT(Index):
           implicitly downsample or necessarily estimate similarity if
           the scaled values differ.
         """
+        _check_select_parameters(ksize=ksize, num=num, moltype=moltype,
+                                 scaled=scaled, containment=containment,
+                                 abund=abund, picklist=picklist, **kwargs)
+
         # pull out a signature from this collection -
         first_sig = next(iter(self.signatures()))
         db_mh = first_sig.minhash

--- a/src/sourmash/sig/__main__.py
+++ b/src/sourmash/sig/__main__.py
@@ -368,6 +368,7 @@ def manifest(args):
         debug("sig manifest: forcing rebuild.")
 
     manifest = sourmash_args.get_manifest(loader, require=True, rebuild=rebuild)
+    manifest._check_row_values()
 
     manifest.write_to_filename(
         args.output, database_format=args.manifest_format, ok_if_exists=args.force
@@ -1382,6 +1383,7 @@ def fileinfo(args):
     manifest = sourmash_args.get_manifest(
         idx, rebuild=args.rebuild_manifest, require=False
     )
+    manifest._check_row_values()
 
     if manifest is None:
         # actually can't find any file type to trigger this, but leaving it

--- a/tests/test_index_protocol.py
+++ b/tests/test_index_protocol.py
@@ -364,6 +364,18 @@ def test_index_select_fail(index_obj):
     with pytest.raises(ValueError):
         index_obj.select(scaled=1000.1)
 
+    # non-int num
+    with pytest.raises(ValueError):
+        index_obj.select(num=1000.1)
+
+    # non-bool abund
+    with pytest.raises(ValueError):
+        index_obj.select(abund=1)
+
+    # extra parameters
+    with pytest.raises(ValueError):
+        index_obj.select(plausible_extra_parameter=5)
+
 
 def test_index_select_nada(index_obj):
     # select works ok when nothing matches!

--- a/tests/test_index_protocol.py
+++ b/tests/test_index_protocol.py
@@ -343,6 +343,28 @@ def test_index_select_basic(index_obj):
     assert ss63.md5sum() in md5s
 
 
+def test_index_select_fail(index_obj):
+    # non-int ksize - str
+    with pytest.raises(ValueError):
+        index_obj.select(ksize='31')
+
+    # non-int ksize - float
+    with pytest.raises(ValueError):
+        index_obj.select(ksize=31.1)
+
+    # case sensitive moltype
+    with pytest.raises(ValueError):
+        index_obj.select(moltype='dna')
+
+    # unknown moltype
+    with pytest.raises(ValueError):
+        index_obj.select(moltype='foo')
+
+    # non-int scaled
+    with pytest.raises(ValueError):
+        index_obj.select(scaled=1000.1)
+
+
 def test_index_select_nada(index_obj):
     # select works ok when nothing matches!
 

--- a/tests/test_index_protocol.py
+++ b/tests/test_index_protocol.py
@@ -346,7 +346,7 @@ def test_index_select_basic(index_obj):
 def test_index_select_fail(index_obj):
     # non-int ksize - str
     with pytest.raises(ValueError):
-        index_obj.select(ksize='31')
+        index_obj.select(ksize="31")
 
     # non-int ksize - float
     with pytest.raises(ValueError):
@@ -354,11 +354,11 @@ def test_index_select_fail(index_obj):
 
     # case sensitive moltype
     with pytest.raises(ValueError):
-        index_obj.select(moltype='dna')
+        index_obj.select(moltype="dna")
 
     # unknown moltype
     with pytest.raises(ValueError):
-        index_obj.select(moltype='foo')
+        index_obj.select(moltype="foo")
 
     # non-int scaled
     with pytest.raises(ValueError):


### PR DESCRIPTION
This PR checks the types and values of parameters to `Index.select`. Specifically, it makes sure that:
* ksize, num, and scaled are ints
* containment is a bool
* abund is a bool
* moltype is 'DNA', 'protein', 'hp', or 'dayhoff'
* there are no other parameters other than 'picklist'

Also adds manifest column type enforcement in general, & explicit manifest content checking to `sig manifest` and `sig summarize`.

Related issues:
* Helps debug manifest issues per https://github.com/sourmash-bio/sourmash/issues/3191 - invalid manifest rows will be revealed by `sig manifest` and `sig summarize`
* Fixes https://github.com/sourmash-bio/sourmash/issues/3107