### PR TITLE
MRG: adjust how ANI is calculated in the revindex code.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,6 +20,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "aliasable"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -47,10 +56,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
+name = "anstream"
+version = "0.6.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418c75fa768af9c03be99d17643f93f79bbba589895012a80e3452a19ddda15b"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
 name = "anstyle"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c03a11a9034d92058ceb6ee011ce58af4a9bf61491aa7e1e59ecd24bd40d22d4"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad186efb764318d35165f1758e7dcef3b10628e26d41a44bc5550652e6804391"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61a38449feb7068f52bb06c12759005cf459ee52bb4adc1d5a7c4322d716fb19"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "approx"
@@ -359,6 +411,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "colorchoice"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
+
+[[package]]
 name = "console_error_panic_hook"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -546,6 +604,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a009aa4810eb158359dda09d0c87378e4bbb89b5a801f016885a4707ba24f7ea"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b35839ba51819680ba087cd351788c9a3c476841207e0b8cee0b04722343b9"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "humantime",
+ "log",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -670,6 +751,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -724,6 +811,12 @@ dependencies = [
  "rustix 0.37.25",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
 
 [[package]]
 name = "itertools"
@@ -1379,6 +1472,8 @@ version = "1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d83f127d94bdbcda4c8cc2e50f6f84f4b611f69c902699ca385a39c3a75f9ff1"
 dependencies = [
+ "aho-corasick",
+ "memchr",
  "regex-syntax 0.6.26",
 ]
 
@@ -1626,6 +1721,7 @@ dependencies = [
  "criterion",
  "csv",
  "enum_dispatch",
+ "env_logger",
  "finch",
  "fixedbitset",
  "getrandom",
@@ -1841,6 +1937,12 @@ name = "unicode-width"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,15 +20,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aho-corasick"
-version = "0.7.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "aliasable"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -56,53 +47,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
-name = "anstream"
-version = "0.6.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418c75fa768af9c03be99d17643f93f79bbba589895012a80e3452a19ddda15b"
-dependencies = [
- "anstyle",
- "anstyle-parse",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is_terminal_polyfill",
- "utf8parse",
-]
-
-[[package]]
 name = "anstyle"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
-
-[[package]]
-name = "anstyle-parse"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c03a11a9034d92058ceb6ee011ce58af4a9bf61491aa7e1e59ecd24bd40d22d4"
-dependencies = [
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle-query"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad186efb764318d35165f1758e7dcef3b10628e26d41a44bc5550652e6804391"
-dependencies = [
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "anstyle-wincon"
-version = "3.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61a38449feb7068f52bb06c12759005cf459ee52bb4adc1d5a7c4322d716fb19"
-dependencies = [
- "anstyle",
- "windows-sys 0.52.0",
-]
 
 [[package]]
 name = "approx"
@@ -411,12 +359,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "colorchoice"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
-
-[[package]]
 name = "console_error_panic_hook"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -604,29 +546,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_filter"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a009aa4810eb158359dda09d0c87378e4bbb89b5a801f016885a4707ba24f7ea"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b35839ba51819680ba087cd351788c9a3c476841207e0b8cee0b04722343b9"
-dependencies = [
- "anstream",
- "anstyle",
- "env_filter",
- "humantime",
- "log",
-]
-
-[[package]]
 name = "errno"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -751,12 +670,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
-
-[[package]]
 name = "iana-time-zone"
 version = "0.1.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -811,12 +724,6 @@ dependencies = [
  "rustix 0.37.25",
  "windows-sys 0.48.0",
 ]
-
-[[package]]
-name = "is_terminal_polyfill"
-version = "1.70.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
 
 [[package]]
 name = "itertools"
@@ -1472,8 +1379,6 @@ version = "1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d83f127d94bdbcda4c8cc2e50f6f84f4b611f69c902699ca385a39c3a75f9ff1"
 dependencies = [
- "aho-corasick",
- "memchr",
  "regex-syntax 0.6.26",
 ]
 
@@ -1721,7 +1626,6 @@ dependencies = [
  "criterion",
  "csv",
  "enum_dispatch",
- "env_logger",
  "finch",
  "fixedbitset",
  "getrandom",
@@ -1937,12 +1841,6 @@ name = "unicode-width"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
-
-[[package]]
-name = "utf8parse"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -33,7 +33,6 @@ cfg-if = "1.0"
 counter = "0.5.7"
 csv = "1.3.0"
 enum_dispatch = "0.3.13"
-env_logger = "0.11.3"
 finch = { version = "0.6.0", optional = true }
 fixedbitset = "0.4.0"
 getrandom = { version = "0.2", features = ["js"] }
@@ -45,7 +44,7 @@ md5 = "0.7.0"
 memmap2 = "0.9.4"
 murmurhash3 = "0.0.5"
 needletail = { version = "0.5.1", default-features = false }
-niffler = { version = "2.4.0", default-features = false, features = [ "gz" ] }
+niffler = { version = "2.6.0", default-features = false, features = [ "gz" ] }
 nohash-hasher = "0.2.0"
 num-iter = "0.1.45"
 once_cell = "1.18.0"

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -33,6 +33,7 @@ cfg-if = "1.0"
 counter = "0.5.7"
 csv = "1.3.0"
 enum_dispatch = "0.3.13"
+env_logger = "0.11.3"
 finch = { version = "0.6.0", optional = true }
 fixedbitset = "0.4.0"
 getrandom = { version = "0.2", features = ["js"] }
@@ -44,7 +45,7 @@ md5 = "0.7.0"
 memmap2 = "0.9.4"
 murmurhash3 = "0.0.5"
 needletail = { version = "0.5.1", default-features = false }
-niffler = { version = "2.6.0", default-features = false, features = [ "gz" ] }
+niffler = { version = "2.4.0", default-features = false, features = [ "gz" ] }
 nohash-hasher = "0.2.0"
 num-iter = "0.1.45"
 once_cell = "1.18.0"

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -44,7 +44,7 @@ md5 = "0.7.0"
 memmap2 = "0.9.4"
 murmurhash3 = "0.0.5"
 needletail = { version = "0.5.1", default-features = false }
-niffler = { version = "2.6.0", default-features = false, features = [ "gz" ] }
+niffler = { version = "2.4.0", default-features = false, features = [ "gz" ] }
 nohash-hasher = "0.2.0"
 num-iter = "0.1.45"
 once_cell = "1.18.0"

--- a/src/core/src/index/mod.rs
+++ b/src/core/src/index/mod.rs
@@ -244,8 +244,9 @@ pub fn calculate_gather_stats(
 
     // // get ANI values
     let ksize = match_mh.ksize() as f64;
-    let query_containment_ani = ani_from_containment(f_unique_to_query, ksize);
-    let match_containment_ani = ani_from_containment(f_match, ksize);
+    let query_containment_ani = ani_from_containment(f_orig_query, ksize);
+    // trace!("query_containment_ani: {}, {}", f_unique_to_query, query_containment_ani);
+    let match_containment_ani = ani_from_containment(f_match_orig, ksize);
     let mut query_containment_ani_ci_low = None;
     let mut query_containment_ani_ci_high = None;
     let mut match_containment_ani_ci_low = None;

--- a/src/core/src/index/mod.rs
+++ b/src/core/src/index/mod.rs
@@ -245,7 +245,6 @@ pub fn calculate_gather_stats(
     // // get ANI values
     let ksize = match_mh.ksize() as f64;
     let query_containment_ani = ani_from_containment(f_orig_query, ksize);
-    // trace!("query_containment_ani: {}, {}", f_unique_to_query, query_containment_ani);
     let match_containment_ani = ani_from_containment(f_match_orig, ksize);
     let mut query_containment_ani_ci_low = None;
     let mut query_containment_ani_ci_high = None;

--- a/src/core/src/index/revindex/mod.rs
+++ b/src/core/src/index/revindex/mod.rs
@@ -814,6 +814,7 @@ mod test {
         assert_eq!(round5(match_.f_unique_to_query()), round5(0.13096862));
         assert_eq!(match_.unique_intersect_bp, 1920000);
         assert_eq!(match_.remaining_bp, 12740000);
+        assert_eq!(round5(match_.query_containment_ani()), round5(0.90773763));
 
         let match_ = &matches[1];
         let names: Vec<&str> = match_.name().split(' ').take(1).collect();
@@ -822,6 +823,7 @@ mod test {
         assert_eq!(round5(match_.f_unique_to_query()), round5(0.115279));
         assert_eq!(match_.unique_intersect_bp, 1690000);
         assert_eq!(match_.remaining_bp, 11050000);
+        assert_eq!(round5(match_.query_containment_ani()), round5(0.9068280));
 
         let match_ = &matches[2];
         dbg!(match_);
@@ -831,6 +833,7 @@ mod test {
         assert_eq!(round5(match_.f_unique_to_query()), round5(0.0627557));
         assert_eq!(match_.unique_intersect_bp, 920000);
         assert_eq!(match_.remaining_bp, 10130000);
+        assert_eq!(round5(match_.query_containment_ani()), round5(0.90728512));
 
         Ok(())
     }


### PR DESCRIPTION
Calculate ANI of matches against original query with `f_orig_query` and `f_match_orig`, instead of against `f_unique_to_query` and `f_match`.

This fixes the ANI differences between `sourmash gather` and RocksDB branchwater gather for the columns `query_containment_ani`, `match_containment_ani`, `max_containment_ani`, and `average_containment_ani`.

Refs:
* Used by https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/361
* Fixes RocksDB-based calculations for https://github.com/sourmash-bio/sourmash_plugin_branchwater/issues/331
