### PR TITLE
MRG: bump sourmash core version to 0.14.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1615,7 +1615,7 @@ checksum = "9f1341053f34bb13b5e9590afb7d94b48b48d4b87467ec28e3c238693bb553de"
 
 [[package]]
 name = "sourmash"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "az",
  "byteorder",

--- a/src/core/CHANGELOG.md
+++ b/src/core/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.14.1] - 2024-06-19
+
+MSRV: 1.65
+
+Changes/additions:
+
+* adjust how ANI is calculated in the revindex code. (#3218)
+
+Updates:
+
+* Bump histogram from 0.10.2 to 0.11.0 (#3216)
+* Bump histogram from 0.10.1 to 0.10.2 (#3207)
+* Bump statrs from 0.16.1 to 0.17.1 (#3205)
+* Bump roaring from 0.10.4 to 0.10.5 (#3206)
+* Bump primal-check from 0.3.3 to 0.3.4 (#3208)
+* Bump niffler from 2.5.0 to 2.6.0 (#3204)
+
 ## [0.14.0] - 2024-06-10
 
 MSRV: 1.65

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sourmash"
-version = "0.14.0"
+version = "0.14.1"
 authors = ["Luiz Irber <luiz@sourmash.bio>", "N. Tessa Pierce-Ward <tessa@sourmash.bio>"]
 description = "tools for comparing biological sequences with k-mer sketches"
 repository = "https://github.com/sourmash-bio/sourmash"


### PR DESCRIPTION
## [0.14.1] - 2024-06-19

MSRV: 1.65

Changes/additions:

* adjust how ANI is calculated in the revindex code. (#3218)

Updates:

* Bump histogram from 0.10.2 to 0.11.0 (#3216)
* Bump histogram from 0.10.1 to 0.10.2 (#3207)
* Bump statrs from 0.16.1 to 0.17.1 (#3205)
* Bump roaring from 0.10.4 to 0.10.5 (#3206)
* Bump primal-check from 0.3.3 to 0.3.4 (#3208)
* Bump niffler from 2.5.0 to 2.6.0 (#3204)