### PR TITLE
MRG: 4.8.10 release branch

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -68,7 +68,7 @@
 
           sourmash = python.buildPythonPackage ( commonArgs // rec {
             pname = "sourmash";
-            version = "4.8.9";
+            version = "4.8.10";
             format = "pyproject";
 
             cargoDeps = rustPlatform.importCargoLock {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = 'maturin'
 name = "sourmash"
 description = "tools for comparing biological sequences with k-mer sketches"
 readme = "README.md"
-version = "4.8.10-dev"
+version = "4.8.10"
 
 authors = [
   { name="Luiz Irber", orcid="0000-0003-4371-9659" },


### PR DESCRIPTION
Release candidate testing:
- [x] Command line tests pass for a release candidate
- [x] All eight release candidate wheels are built

Releasing to PyPI:

- [x] RC tag(s)s deleted on github
- [x] Release tag cut
- [x] Release notes written
- [x] All eight release wheels built
- [x] Release wheels uploaded to pypi
- [x] tar.gz distribution uploaded to pypi

After release to PyPI and conda-forge/bioconda packages built:

- [x] [PyPI page](https://pypi.org/project/sourmash/) updated
- [x] Zenodo DOI successfully minted upon new github release - [see search results](https://zenodo.org/search?page=1&size=20&q=sourmash&sort=mostrecent)
- [x] `pip install sourmash` installs the correct version
- [x] [conda-forge sourmash-minimal-feedstock](https://github.com/conda-forge/sourmash-minimal-feedstock) has updated `sourmash-minimal` to the correct version 
- [x] `mamba create -n smash-release -y sourmash` installs the correct version

Optional but recommended:

- [ ] PR submitted to update pyodide version
- [ ] PR submitted to update spack version

---

## Release notes

Minor new features:

* check `select` parameters; enforce types when building manifests (#3212)
* patch-fix `sig extract` to no longer create empty zips (#3214)

Bug fixes:

* adjust how ANI is calculated in the revindex code. (#3218)

Cleanup and documentation updates:

* final updates for 2024 JOSS publication (#3225)
* Improve JOSS paper affiliations (#3224)
* fix DOI for Rahman Hera paper in JOSS pub. (#3221)
* upd citations, minor text (#3220)

Developer updates:

* bump sourmash core version to 0.14.1 (#3219)
* bump version to 4.8.10-dev (#3211)

Dependabot updates:

- Bump proptest from 1.4.0 to 1.5.0 (#3222)
- [pre-commit.ci] pre-commit autoupdate (#3223)
- [pre-commit.ci] pre-commit autoupdate (#3003)
- Bump histogram from 0.10.2 to 0.11.0 (#3216)
- Bump pypa/cibuildwheel from 2.19.0 to 2.19.1 (#3217)
- Bump histogram from 0.10.1 to 0.10.2 (#3207)
- Bump statrs from 0.16.1 to 0.17.1 (#3205)
- Bump roaring from 0.10.4 to 0.10.5 (#3206)
- Bump primal-check from 0.3.3 to 0.3.4 (#3208)
- Bump niffler from 2.5.0 to 2.6.0 (#3204)
- Bump pypa/cibuildwheel from 2.18.1 to 2.19.0 (#3202)