### PR TITLE
CI: bump cibuildwheel for linux fixes, move wasm to use cibuildwheel too

### DIFF
--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -46,7 +46,7 @@ jobs:
           python-version: '3.10'
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.19.1
+        uses: pypa/cibuildwheel@v2.19.2
         env:
           CIBW_ENVIRONMENT_MACOS: ${{ matrix.macos_target }}
           CIBW_ARCHS_LINUX: ${{ matrix.arch }}
@@ -59,32 +59,18 @@ jobs:
 
   build_wasm:
     runs-on: ubuntu-20.04
-    env:
-        PYODIDE_VERSION: "0.23.0"
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-           python-version: "3.11.2"
-      - run: |
-          pip install pyodide-build==${PYODIDE_VERSION} "pydantic<2"
-          pyodide config get emscripten_version  # trigger setup
-          echo EMSCRIPTEN_VERSION=$(pyodide config get emscripten_version) >> $GITHUB_ENV
-      - uses: mymindstorm/setup-emsdk@v14
-        with:
-           version: ${{ env.EMSCRIPTEN_VERSION }}
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          target: wasm32-unknown-emscripten
-      - run: |
-          export RUSTC_BOOTSTRAP=1
-          pyodide build
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.19.2
+        env:
+          CIBW_PLATFORM: pyodide 
 
       - uses: actions/upload-artifact@v4
         with:
           name: wheel-wasm
-          path: './dist/sourmash*.whl'
+          path: './wheelhouse/sourmash*.whl'
 
 
   release:

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -66,6 +66,7 @@ jobs:
         uses: pypa/cibuildwheel@v2.19.2
         env:
           CIBW_PLATFORM: pyodide 
+          CIBW_BUILD: 'cp312-pyodide_wasm32'
 
       - uses: actions/upload-artifact@v4
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -205,6 +205,11 @@ before-build = [
 # avoid needing a nightly compiler
 RUSTC_BOOTSTRAP=1
 
+[tool.cibuildwheel.pyodide]
+before-build = [
+  "rustup target add wasm32-unknown-emscripten"
+]
+
 [tool.cibuildwheel.linux.environment]
 CARGO_REGISTRIES_CRATES_IO_PROTOCOL="sparse"
 PATH="$HOME/.cargo/bin:$PATH"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -201,6 +201,10 @@ before-build = [
   "if [ -f /etc/system-release ]; then source scl_source enable devtoolset-10; fi",
 ]
 
+[tool.cibuildwheel.pyodide.environment]
+# avoid needing a nightly compiler
+RUSTC_BOOTSTRAP=1
+
 [tool.cibuildwheel.linux.environment]
 CARGO_REGISTRIES_CRATES_IO_PROTOCOL="sparse"
 PATH="$HOME/.cargo/bin:$PATH"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -193,7 +193,6 @@ PATH="$HOME/.cargo/bin:$PATH"
 before-all = [
   "curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain=stable",
   "cargo update --dry-run",
-  "if [ -f /etc/system-release ]; then yum -y install centos-release-scl; fi",
   "if [ -f /etc/system-release ]; then yum -y install llvm-toolset-7.0; fi",
 ]
 before-build = [


### PR DESCRIPTION
cibuildwheel `2.19.2` fixes a centos7 mirrorlist issue that broke wheel building this week.

Also move the wasm builds to use cibuildwheel, now that it is supported.