### PR TITLE
feat: RocksDB storage and self-contained RevIndex with internal storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1668,7 +1668,7 @@ checksum = "9f1341053f34bb13b5e9590afb7d94b48b48d4b87467ec28e3c238693bb553de"
 
 [[package]]
 name = "sourmash"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "az",
  "byteorder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,17 +62,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -393,13 +382,12 @@ dependencies = [
 
 [[package]]
 name = "colored"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
+checksum = "cbf2150cce219b664a8a70df7a1f933836724b503f8a413af9365b4dcc4d90b8"
 dependencies = [
- "atty",
  "lazy_static",
- "winapi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -700,15 +688,6 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
@@ -761,7 +740,7 @@ version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
- "hermit-abi 0.3.2",
+ "hermit-abi",
  "libc",
  "windows-sys 0.48.0",
 ]
@@ -772,7 +751,7 @@ version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
 dependencies = [
- "hermit-abi 0.3.2",
+ "hermit-abi",
  "io-lifetimes",
  "rustix 0.37.25",
  "windows-sys 0.48.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1953,8 +1953,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
 dependencies = [
  "cfg-if",
- "serde",
- "serde_json",
  "wasm-bindgen-macro",
 ]
 

--- a/flake.nix
+++ b/flake.nix
@@ -124,7 +124,7 @@
             cargo-deny
             cargo-wasi
             cargo-codspeed
-            #cargo-semver-checks
+            cargo-semver-checks
             nixpkgs-fmt
           ];
 

--- a/src/core/CHANGELOG.md
+++ b/src/core/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.15.0] - 2024-07-27
+
+MSRV: 1.65
+
+Changes/additions:
+
+* RocksDB storage and self-contained RevIndex with internal storage #3250
+* Enable codspeed for Rust perf tracking (#3231)
+
+Updates
+
+* Bump roaring from 0.10.5 to 0.10.6 (#3245)
+* Bump serde from 1.0.203 to 1.0.204 (#3244)
+* Bump counter from 0.5.7 to 0.6.0 (#3235)
+* Bump log from 0.4.21 to 0.4.22 (#3236)
+* Bump serde_json from 1.0.117 to 1.0.120 (#3234)
+* Bump proptest from 1.4.0 to 1.5.0 (#3222)
+
 ## [0.14.1] - 2024-06-19
 
 MSRV: 1.65

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -23,6 +23,7 @@ from-finch = ["dep:finch"]
 parallel = ["dep:rayon"]
 maturin = []
 branchwater = ["dep:rocksdb", "parallel"]
+rkyv = ["dep:rkyv"]
 default = []
 
 [dependencies]

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -19,10 +19,10 @@ crate-type = ["lib", "staticlib", "cdylib"]
 bench = false
 
 [features]
-from-finch = ["finch"]
-parallel = ["rayon"]
+from-finch = ["dep:finch"]
+parallel = ["dep:rayon"]
 maturin = []
-branchwater = ["rocksdb", "rkyv", "parallel"]
+branchwater = ["dep:rocksdb", "parallel"]
 default = []
 
 [dependencies]

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sourmash"
-version = "0.14.1"
+version = "0.15.0"
 authors = ["Luiz Irber <luiz@sourmash.bio>", "N. Tessa Pierce-Ward <tessa@sourmash.bio>"]
 description = "tools for comparing biological sequences with k-mer sketches"
 repository = "https://github.com/sourmash-bio/sourmash"

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -36,7 +36,6 @@ csv = "1.3.0"
 enum_dispatch = "0.3.13"
 finch = { version = "0.6.0", optional = true }
 fixedbitset = "0.4.0"
-getrandom = { version = "0.2", features = ["js"] }
 getset = "0.1.1"
 histogram = "0.11.0"
 itertools = "0.13.0"
@@ -99,7 +98,8 @@ skip_feature_sets = [
 [target.'cfg(all(target_arch = "wasm32", target_os="unknown"))'.dependencies]
 js-sys = "0.3.68"
 web-sys = { version = "0.3.69", features = ["console", "File", "FileReaderSync"] }
-wasm-bindgen = { version = "0.2.89", features = ["serde-serialize"] }
+wasm-bindgen = "0.2.89"
+getrandom = { version = "0.2", features = ["js"] }
 
 [target.'cfg(all(target_arch = "wasm32"))'.dependencies]
 chrono = { version = "0.4.32", features = ["wasmbind"] }

--- a/src/core/src/collection.rs
+++ b/src/core/src/collection.rs
@@ -65,6 +65,13 @@ impl CollectionSet {
         todo!("Extract selection from first sig")
     }
 
+    /// Replace the storage with a new one.
+    ///
+    /// # Safety
+    ///
+    /// This method doesn't check if the manifest matches what is in the
+    /// storage (which can be expensive). It is up to the caller to
+    /// guarantee the manifest and storage are in sync.
     pub unsafe fn set_storage_unchecked(&mut self, storage: InnerStorage) {
         self.storage = storage;
     }

--- a/src/core/src/collection.rs
+++ b/src/core/src/collection.rs
@@ -64,6 +64,10 @@ impl CollectionSet {
     pub fn selection(&self) -> Selection {
         todo!("Extract selection from first sig")
     }
+
+    pub unsafe fn set_storage_unchecked(&mut self, storage: InnerStorage) {
+        self.storage = storage;
+    }
 }
 
 impl Collection {

--- a/src/core/src/index/revindex/disk_revindex.rs
+++ b/src/core/src/index/revindex/disk_revindex.rs
@@ -174,7 +174,7 @@ impl RevIndex {
         }
         self.db.put_cf(&cf_metadata, MANIFEST, &wtr[..])?;
 
-        // write storage specdisk_re
+        // write storage spec
         let spec = self.collection.storage().spec();
 
         // TODO: check if spec if memstorage, would probably have to
@@ -459,7 +459,10 @@ impl RevIndexOps for RevIndex {
     }
 
     fn internalize_storage(&mut self) -> Result<()> {
-        // TODO: check if collection is already internal, if so return
+        // check if collection is already internal, if so return
+        if self.collection.storage().spec() == "rocksdb://" {
+            return Ok(());
+        }
 
         // build new rocksdb storage from db
         let new_storage = RocksDBStorage::from_db(self.db.clone());

--- a/src/core/src/index/revindex/disk_revindex.rs
+++ b/src/core/src/index/revindex/disk_revindex.rs
@@ -20,7 +20,7 @@ use crate::prelude::*;
 use crate::sketch::minhash::{KmerMinHash, KmerMinHashBTree};
 use crate::sketch::Sketch;
 use crate::storage::{
-    rocksdb::{cf_descriptors, db_options, DB, HASHES, METADATA, STORAGE},
+    rocksdb::{cf_descriptors, db_options, DB, HASHES, METADATA},
     InnerStorage, Storage,
 };
 use crate::Result;

--- a/src/core/src/index/revindex/disk_revindex.rs
+++ b/src/core/src/index/revindex/disk_revindex.rs
@@ -71,7 +71,6 @@ impl RevIndex {
         let mut opts = db_options();
         opts.create_if_missing(true);
         opts.create_missing_column_families(true);
-        opts.prepare_for_bulk_load();
 
         // prepare column family descriptors
         let cfs = cf_descriptors();
@@ -110,9 +109,6 @@ impl RevIndex {
         storage_spec: Option<&str>,
     ) -> Result<module::RevIndex> {
         let mut opts = db_options();
-        if !read_only {
-            opts.prepare_for_bulk_load();
-        }
 
         // prepare column family descriptors
         let cfs = cf_descriptors();

--- a/src/core/src/index/revindex/disk_revindex.rs
+++ b/src/core/src/index/revindex/disk_revindex.rs
@@ -161,7 +161,7 @@ impl RevIndex {
         };
 
         let storage = if spec == "rocksdb://" {
-            todo!("init storage from db")
+            InnerStorage::new(RocksDBStorage::from_db(db.clone()))
         } else {
             InnerStorage::from_spec(spec)?
         };
@@ -184,7 +184,7 @@ impl RevIndex {
         }
         self.db.put_cf(&cf_metadata, MANIFEST, &wtr[..])?;
 
-        // write storage spec
+        // write storage specdisk_re
         let spec = self.collection.storage().spec();
 
         // TODO: check if spec if memstorage, would probably have to
@@ -488,6 +488,11 @@ impl RevIndexOps for RevIndex {
             Arc::get_mut(&mut self.collection)
                 .map(|v| v.set_storage_unchecked(InnerStorage::new(new_storage)));
         }
+
+        // write storage spec
+        let cf_metadata = self.db.cf_handle(METADATA).unwrap();
+        let spec = "rocksdb://";
+        self.db.put_cf(&cf_metadata, STORAGE_SPEC, spec)?;
 
         Ok(())
     }

--- a/src/core/src/index/revindex/disk_revindex.rs
+++ b/src/core/src/index/revindex/disk_revindex.rs
@@ -19,7 +19,7 @@ use crate::manifest::Manifest;
 use crate::prelude::*;
 use crate::sketch::minhash::{KmerMinHash, KmerMinHashBTree};
 use crate::sketch::Sketch;
-use crate::storage::{InnerStorage, Storage, STORAGE};
+use crate::storage::{rocksdb::STORAGE, InnerStorage, Storage};
 use crate::Result;
 
 const DB_VERSION: u8 = 1;

--- a/src/core/src/index/revindex/mod.rs
+++ b/src/core/src/index/revindex/mod.rs
@@ -23,7 +23,7 @@ use crate::sketch::Sketch;
 use crate::HashIntoType;
 use crate::Result;
 
-type DB = rocksdb::DBWithThreadMode<rocksdb::MultiThreaded>;
+pub type DB = rocksdb::DBWithThreadMode<rocksdb::MultiThreaded>;
 
 type QueryColors = HashMap<Color, Datasets>;
 type HashToColorT = HashMap<HashIntoType, Color, BuildNoHashHasher<HashIntoType>>;
@@ -198,7 +198,7 @@ impl RevIndex {
         }
     }
 
-    fn db_options() -> rocksdb::Options {
+    pub(crate) fn db_options() -> rocksdb::Options {
         let mut opts = rocksdb::Options::default();
         opts.set_max_open_files(500);
 

--- a/src/core/src/storage/mod.rs
+++ b/src/core/src/storage/mod.rs
@@ -7,6 +7,7 @@ use std::sync::{Arc, RwLock};
 
 use camino::Utf8Path as Path;
 use camino::Utf8PathBuf as PathBuf;
+use cfg_if::cfg_if;
 use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -160,7 +161,14 @@ impl InnerStorage {
             x if x.starts_with("memory") => InnerStorage::new(MemStorage::new()),
             x if x.starts_with("rocksdb") => {
                 let path = x.split("://").last().expect("not a valid path");
-                InnerStorage::new(RocksDBStorage::from_path(path))
+
+                cfg_if! {
+                    if #[cfg(feature = "branchwater")] {
+                        InnerStorage::new(RocksDBStorage::from_path(path))
+                    } else {
+                        todo!("Must enable branchwater feature")
+                    }
+                }
             }
             x if x.starts_with("zip") => {
                 let path = x.split("://").last().expect("not a valid path");
@@ -656,4 +664,3 @@ impl Storage for MemStorage {
         "memory://".into()
     }
 }
-

--- a/src/core/src/storage/mod.rs
+++ b/src/core/src/storage/mod.rs
@@ -140,9 +140,11 @@ pub struct MemStorage {
     sigs: Arc<RwLock<HashMap<String, SigStore>>>,
 }
 
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
 #[cfg(feature = "branchwater")]
 pub mod rocksdb;
 
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
 #[cfg(feature = "branchwater")]
 pub use rocksdb::RocksDBStorage;
 

--- a/src/core/src/storage/mod.rs
+++ b/src/core/src/storage/mod.rs
@@ -141,12 +141,10 @@ pub struct MemStorage {
     sigs: Arc<RwLock<HashMap<String, SigStore>>>,
 }
 
-#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
-#[cfg(feature = "branchwater")]
+#[cfg(all(feature = "branchwater", not(target_arch = "wasm32")))]
 pub mod rocksdb;
 
-#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
-#[cfg(feature = "branchwater")]
+#[cfg(all(feature = "branchwater", not(target_arch = "wasm32")))]
 pub use self::rocksdb::RocksDBStorage;
 
 pub type Metadata<'a> = BTreeMap<&'a OsStr, &'a piz::read::FileMetadata<'a>>;
@@ -169,7 +167,7 @@ impl InnerStorage {
                 let path = x.split("://").last().expect("not a valid path");
 
                 cfg_if! {
-                    if #[cfg(feature = "branchwater")] {
+                    if #[cfg(all( feature = "branchwater", not(target_arch = "wasm32")))] {
                         InnerStorage::new(RocksDBStorage::from_path(path))
                     } else {
                         return Err(StorageError::MissingFeature("branchwater".into(), path.into()).into())

--- a/src/core/src/storage/mod.rs
+++ b/src/core/src/storage/mod.rs
@@ -98,12 +98,6 @@ impl PartialEq for SigStore {
     }
 }
 
-#[derive(Serialize, Deserialize)]
-pub(crate) struct StorageInfo {
-    pub backend: String,
-    pub args: StorageArgs,
-}
-
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum StorageArgs {

--- a/src/core/src/storage/mod.rs
+++ b/src/core/src/storage/mod.rs
@@ -137,15 +137,10 @@ pub struct MemStorage {
 }
 
 #[cfg(feature = "branchwater")]
-// Column family for using rocksdb as a Storage
-pub(crate) const STORAGE: &str = "storage";
+pub mod rocksdb;
 
 #[cfg(feature = "branchwater")]
-/// Store data in RocksDB
-#[derive(Debug, Clone)]
-pub struct RocksDBStorage {
-    db: Arc<crate::index::revindex::DB>,
-}
+pub use rocksdb::RocksDBStorage;
 
 pub type Metadata<'a> = BTreeMap<&'a OsStr, &'a piz::read::FileMetadata<'a>>;
 
@@ -662,48 +657,3 @@ impl Storage for MemStorage {
     }
 }
 
-#[cfg(feature = "branchwater")]
-impl RocksDBStorage {
-    pub fn from_path(path: &str) -> Self {
-        let mut opts = crate::index::revindex::RevIndex::db_options();
-        opts.create_if_missing(true);
-        opts.create_missing_column_families(true);
-        opts.prepare_for_bulk_load();
-
-        // prepare column family descriptors
-        let cfs = crate::index::revindex::disk_revindex::cf_descriptors();
-
-        let db =
-            Arc::new(crate::index::revindex::DB::open_cf_descriptors(&opts, path, cfs).unwrap());
-
-        Self { db }
-    }
-
-    pub fn from_db(db: Arc<crate::index::revindex::DB>) -> Self {
-        Self { db: db.clone() }
-    }
-}
-
-#[cfg(feature = "branchwater")]
-impl Storage for RocksDBStorage {
-    fn save(&self, path: &str, content: &[u8]) -> Result<String> {
-        let cf_storage = self.db.cf_handle(STORAGE).unwrap();
-        // TODO(lirber): deal with conflict for path?
-        self.db.put_cf(&cf_storage, path.as_bytes(), &content[..])?;
-        Ok(path.into())
-    }
-
-    fn load(&self, path: &str) -> Result<Vec<u8>> {
-        let cf_storage = self.db.cf_handle(STORAGE).unwrap();
-        let data = self.db.get_cf(&cf_storage, path.as_bytes())?;
-        data.ok_or_else(|| StorageError::DataReadError(path.into()).into())
-    }
-
-    fn args(&self) -> StorageArgs {
-        unimplemented!()
-    }
-
-    fn spec(&self) -> String {
-        "rocksdb://".into()
-    }
-}

--- a/src/core/src/storage/mod.rs
+++ b/src/core/src/storage/mod.rs
@@ -63,6 +63,9 @@ pub enum StorageError {
 
     #[error("Error reading data from {0}")]
     DataReadError(String),
+
+    #[error("Storage for path {1} requires the '{0}' feature to be enabled")]
+    MissingFeature(String, String),
 }
 
 #[derive(Clone)]
@@ -166,7 +169,7 @@ impl InnerStorage {
                     if #[cfg(feature = "branchwater")] {
                         InnerStorage::new(RocksDBStorage::from_path(path))
                     } else {
-                        todo!("Must enable branchwater feature")
+                        return Err(StorageError::MissingFeature("branchwater".into(), path.into()).into())
                     }
                 }
             }

--- a/src/core/src/storage/mod.rs
+++ b/src/core/src/storage/mod.rs
@@ -53,6 +53,7 @@ pub trait Storage {
     }
 }
 
+#[non_exhaustive]
 #[derive(Debug, Error)]
 pub enum StorageError {
     #[error("Path can't be empty")]
@@ -146,7 +147,7 @@ pub mod rocksdb;
 
 #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
 #[cfg(feature = "branchwater")]
-pub use rocksdb::RocksDBStorage;
+pub use self::rocksdb::RocksDBStorage;
 
 pub type Metadata<'a> = BTreeMap<&'a OsStr, &'a piz::read::FileMetadata<'a>>;
 

--- a/src/core/src/storage/mod.rs
+++ b/src/core/src/storage/mod.rs
@@ -639,8 +639,16 @@ impl Storage for MemStorage {
         unimplemented!()
     }
 
-    fn load(&self, _path: &str) -> Result<Vec<u8>> {
-        unimplemented!()
+    fn load(&self, path: &str) -> Result<Vec<u8>> {
+        let store = self.sigs.read().unwrap();
+        let sig = store.get(path).unwrap();
+
+        let mut buffer = vec![];
+        {
+            sig.to_writer(&mut buffer).unwrap();
+        }
+
+        Ok(buffer)
     }
 
     fn args(&self) -> StorageArgs {

--- a/src/core/src/storage/rocksdb.rs
+++ b/src/core/src/storage/rocksdb.rs
@@ -1,0 +1,57 @@
+use std::sync::Arc;
+
+use crate::storage::{Storage, StorageArgs, StorageError};
+use crate::{Error, Result};
+
+// Column family for using rocksdb as a Storage
+pub(crate) const STORAGE: &str = "storage";
+
+/// Store data in RocksDB
+#[derive(Debug, Clone)]
+pub struct RocksDBStorage {
+    db: Arc<crate::index::revindex::DB>,
+}
+
+impl RocksDBStorage {
+    pub fn from_path(path: &str) -> Self {
+        let mut opts = crate::index::revindex::RevIndex::db_options();
+        opts.create_if_missing(true);
+        opts.create_missing_column_families(true);
+        opts.prepare_for_bulk_load();
+
+        // prepare column family descriptors
+        let cfs = crate::index::revindex::disk_revindex::cf_descriptors();
+
+        let db =
+            Arc::new(crate::index::revindex::DB::open_cf_descriptors(&opts, path, cfs).unwrap());
+
+        Self { db }
+    }
+
+    pub fn from_db(db: Arc<crate::index::revindex::DB>) -> Self {
+        Self { db: db.clone() }
+    }
+}
+
+impl Storage for RocksDBStorage {
+    fn save(&self, path: &str, content: &[u8]) -> Result<String> {
+        let cf_storage = self.db.cf_handle(STORAGE).unwrap();
+        // TODO(lirber): deal with conflict for path?
+        self.db.put_cf(&cf_storage, path.as_bytes(), &content[..])?;
+        Ok(path.into())
+    }
+
+    fn load(&self, path: &str) -> Result<Vec<u8>> {
+        let cf_storage = self.db.cf_handle(STORAGE).unwrap();
+        let data = self.db.get_cf(&cf_storage, path.as_bytes())?;
+        data.ok_or_else(|| StorageError::DataReadError(path.into()).into())
+    }
+
+    fn args(&self) -> StorageArgs {
+        unimplemented!()
+    }
+
+    fn spec(&self) -> String {
+        "rocksdb://".into()
+    }
+}

--- a/src/core/src/storage/rocksdb.rs
+++ b/src/core/src/storage/rocksdb.rs
@@ -33,6 +33,8 @@ impl RocksDBStorage {
 
         let db = Arc::new(DB::open_cf_descriptors(&opts, path, cfs).unwrap());
 
+        // TODO: save storage_args
+
         Self { db }
     }
 

--- a/src/core/src/storage/rocksdb.rs
+++ b/src/core/src/storage/rocksdb.rs
@@ -33,8 +33,6 @@ impl RocksDBStorage {
 
         let db = Arc::new(DB::open_cf_descriptors(&opts, path, cfs).unwrap());
 
-        // TODO: save storage_args
-
         Self { db }
     }
 
@@ -62,7 +60,7 @@ impl Storage for RocksDBStorage {
     }
 
     fn spec(&self) -> String {
-        "rocksdb://".into()
+        format!("rocksdb://{}", self.db.path().display())
     }
 }
 

--- a/src/core/src/storage/rocksdb.rs
+++ b/src/core/src/storage/rocksdb.rs
@@ -1,34 +1,42 @@
 use std::sync::Arc;
 
+use rocksdb::{ColumnFamilyDescriptor, Options};
+
 use crate::storage::{Storage, StorageArgs, StorageError};
 use crate::{Error, Result};
+
+// Column families
+pub(crate) const HASHES: &str = "hashes";
+pub(crate) const COLORS: &str = "colors";
+pub(crate) const METADATA: &str = "metadata";
 
 // Column family for using rocksdb as a Storage
 pub(crate) const STORAGE: &str = "storage";
 
+pub type DB = rocksdb::DBWithThreadMode<rocksdb::MultiThreaded>;
+
 /// Store data in RocksDB
 #[derive(Debug, Clone)]
 pub struct RocksDBStorage {
-    db: Arc<crate::index::revindex::DB>,
+    db: Arc<DB>,
 }
 
 impl RocksDBStorage {
     pub fn from_path(path: &str) -> Self {
-        let mut opts = crate::index::revindex::RevIndex::db_options();
+        let mut opts = db_options();
         opts.create_if_missing(true);
         opts.create_missing_column_families(true);
         opts.prepare_for_bulk_load();
 
         // prepare column family descriptors
-        let cfs = crate::index::revindex::disk_revindex::cf_descriptors();
+        let cfs = cf_descriptors();
 
-        let db =
-            Arc::new(crate::index::revindex::DB::open_cf_descriptors(&opts, path, cfs).unwrap());
+        let db = Arc::new(DB::open_cf_descriptors(&opts, path, cfs).unwrap());
 
         Self { db }
     }
 
-    pub fn from_db(db: Arc<crate::index::revindex::DB>) -> Self {
+    pub fn from_db(db: Arc<DB>) -> Self {
         Self { db: db.clone() }
     }
 }
@@ -54,4 +62,64 @@ impl Storage for RocksDBStorage {
     fn spec(&self) -> String {
         "rocksdb://".into()
     }
+}
+
+pub(crate) fn cf_descriptors() -> Vec<ColumnFamilyDescriptor> {
+    let mut cfopts = Options::default();
+    cfopts.set_max_write_buffer_number(16);
+    cfopts.set_merge_operator_associative(
+        "datasets operator",
+        crate::index::revindex::disk_revindex::merge_datasets,
+    );
+    cfopts.set_min_write_buffer_number_to_merge(10);
+
+    // Updated default from
+    // https://github.com/facebook/rocksdb/wiki/Setup-Options-and-Basic-Tuning#other-general-options
+    cfopts.set_level_compaction_dynamic_level_bytes(true);
+
+    let cf_hashes = ColumnFamilyDescriptor::new(HASHES, cfopts);
+
+    let mut cfopts = Options::default();
+    cfopts.set_max_write_buffer_number(16);
+    // Updated default
+    cfopts.set_level_compaction_dynamic_level_bytes(true);
+
+    let cf_metadata = ColumnFamilyDescriptor::new(METADATA, cfopts);
+
+    let mut cfopts = Options::default();
+    cfopts.set_max_write_buffer_number(16);
+    // Updated default
+    cfopts.set_level_compaction_dynamic_level_bytes(true);
+
+    let cf_storage = ColumnFamilyDescriptor::new(STORAGE, cfopts);
+
+    let mut cfopts = Options::default();
+    cfopts.set_max_write_buffer_number(16);
+    // Updated default
+    cfopts.set_level_compaction_dynamic_level_bytes(true);
+
+    vec![cf_hashes, cf_metadata, cf_storage]
+}
+
+pub(crate) fn db_options() -> rocksdb::Options {
+    let mut opts = rocksdb::Options::default();
+    opts.set_max_open_files(500);
+
+    // Updated defaults from
+    // https://github.com/facebook/rocksdb/wiki/Setup-Options-and-Basic-Tuning#other-general-options
+    opts.set_bytes_per_sync(1048576);
+    let mut block_opts = rocksdb::BlockBasedOptions::default();
+    block_opts.set_block_size(16 * 1024);
+    block_opts.set_cache_index_and_filter_blocks(true);
+    block_opts.set_pin_l0_filter_and_index_blocks_in_cache(true);
+    block_opts.set_format_version(6);
+    opts.set_block_based_table_factory(&block_opts);
+    // End of updated defaults
+
+    opts.increase_parallelism(rayon::current_num_threads() as i32);
+    //opts.max_background_jobs = 6;
+    // opts.optimize_level_style_compaction();
+    // opts.optimize_universal_style_compaction();
+
+    opts
 }

--- a/src/core/src/storage/rocksdb.rs
+++ b/src/core/src/storage/rocksdb.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use rocksdb::{ColumnFamilyDescriptor, Options};
 
 use crate::storage::{Storage, StorageArgs, StorageError};
-use crate::{Error, Result};
+use crate::Result;
 
 // Column families
 pub(crate) const HASHES: &str = "hashes";


### PR DESCRIPTION
Implement a RocksDB storage for making a self-contained RevIndex (containing both the revindex and the sigs needed for gather) and support more flexible RocksDB sketch storage.

- Remove branchwater dependency on `rkyv`, make it optional
- Move most RocksDB initialization to the new `storage::rocksdb` module
- Disable `prepare_for_bulk_load`, it is a footgun for large index construction
- make `sourmash::storage::StorageError` non-exhaustive
- remove unused `StorageInfo` (#3261)