### PR TITLE
v4.8.11 release branch

### DIFF
--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -73,7 +73,6 @@ jobs:
           name: wheel-wasm
           path: './wheelhouse/sourmash*.whl'
 
-
   release:
     name: Publish wheels
     runs-on: ubuntu-20.04
@@ -88,9 +87,8 @@ jobs:
           path: 'wheels/'
 
       # if it matches a Python release tag, upload to github releases
-      # TODO: In the future, use the create-release and upload-release-assets actions
       - name: Release
-        uses: fnkr/github-action-ghr@v1
-        env:
-          GHR_PATH: ${{steps.fetch_artifacts.outputs.download-path}}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            ${{steps.fetch_artifacts.outputs.download-path}}/wheel-*/*

--- a/.github/workflows/build_wheel_all_archs.yml
+++ b/.github/workflows/build_wheel_all_archs.yml
@@ -80,9 +80,8 @@ jobs:
           path: 'wheels/'
 
       # if it matches a Python release tag, upload to github releases
-      # TODO: In the future, use the create-release and upload-release-assets actions
       - name: Release
-        uses: fnkr/github-action-ghr@v1
-        env:
-          GHR_PATH: ${{steps.fetch_artifacts.outputs.download-path}}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            ${{steps.fetch_artifacts.outputs.download-path}}/wheel-*/*

--- a/flake.nix
+++ b/flake.nix
@@ -62,7 +62,7 @@
 
           sourmash = python.buildPythonPackage ( commonArgs // rec {
             pname = "sourmash";
-            version = "4.8.10";
+            version = "4.8.11";
             format = "pyproject";
 
             cargoDeps = rustPlatform.importCargoLock {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = 'maturin'
 name = "sourmash"
 description = "tools for comparing biological sequences with k-mer sketches"
 readme = "README.md"
-version = "4.8.11-dev"
+version = "4.8.11"
 
 authors = [
   { name="Luiz Irber", orcid="0000-0003-4371-9659" },


### PR DESCRIPTION
Minor new features:

- RocksDB storage and self-contained RevIndex with internal storage (#3250)

Bug fixes:

- Break ahash dep cycle by bumping to 0.7.8, nix flake update (#3243)

Cleanup and documentation updates:

- Update dev env instructions (#2990)

Developer updates:

- Enable codspeed for Rust perf tracking (#3231)
- bump cibuildwheel for linux fixes, move wasm to use cibuildwheel too (#3241)

Dependabot updates:

- Bump actions/checkout from 3 to 4 (#3265)
- Bump moonrepo/setup-rust from 0 to 1 (#3266)
- Bump CodSpeedHQ/action from 2 to 3 (#3264)
- pre-commit autoupdate (#3270) (#3260) (#3255) (#3238)
- Bump DeterminateSystems/nix-installer-action from 12 to 13 (#3259)
- Update pytest requirement from <8.3.0,>=6.2.4 to >=6.2.4,<8.4.0 (#3258)
- Bump thiserror from 1.0.62 to 1.0.63 (#3257)
- Bump thiserror from 1.0.61 to 1.0.62 (#3254)
- Bump roaring from 0.10.5 to 0.10.6 (#3245)
- Bump serde from 1.0.203 to 1.0.204 (#3244)
- Bump counter from 0.5.7 to 0.6.0 (#3235)
- Bump log from 0.4.21 to 0.4.22 (#3236)
- Bump serde_json from 1.0.117 to 1.0.120 (#3234)