### PR TITLE
EXP: Added derives for mem-dbg

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -934,6 +934,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
+name = "mem_dbg"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfd7536481f50e36a48185e622c9643919a0fca99422069424c214e67d8ed264"
+dependencies = [
+ "bitflags 2.4.1",
+ "mem_dbg-derive",
+]
+
+[[package]]
+name = "mem_dbg-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31df6bf503386c041c631223d4eb77ee55912d7e75645c960a24512aded0d89"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.46",
+]
+
+[[package]]
 name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1669,6 +1690,7 @@ dependencies = [
  "js-sys",
  "log",
  "md5",
+ "mem_dbg",
  "memmap2",
  "murmurhash3",
  "needletail",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ authors = [
   { name="Colton Baumler", orcid="0000-0002-5926-7792" },
   { name="Olga Botvinnik", orcid="0000-0003-4412-7970" },
   { name="Phillip Brooks", orcid="0000-0003-3987-244X" },
+  { name="Luca Cappelletti", orcid="0000-0002-1269-2038" },
   { name="Peter Cock", orcid="0000-0001-9513-9993" },
   { name="Daniel Dsouza", orcid="0000-0001-7843-8596" },
   { name="Jade Gardner", orcid="0009-0005-0787-5752" },

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -41,6 +41,7 @@ histogram = "0.11.0"
 itertools = "0.13.0"
 log = "0.4.22"
 md5 = "0.7.0"
+mem_dbg = {version="0.2.4", optional = true}
 memmap2 = "0.9.4"
 murmurhash3 = "0.0.5"
 needletail = { version = "0.5.1", default-features = false }

--- a/src/core/src/encodings.rs
+++ b/src/core/src/encodings.rs
@@ -26,6 +26,7 @@ type ColorToIdx = HashMap<Color, IdxTracker, BuildNoHashHasher<Color>>;
     derive(rkyv::Serialize, rkyv::Deserialize, rkyv::Archive)
 )]
 #[non_exhaustive]
+#[cfg_attr(feature = "mem_dbg", derive(mem_dbg::MemDbg, mem_dbg::MemSize))]
 pub enum HashFunctions {
     Murmur64Dna,
     Murmur64Protein,

--- a/src/core/src/sketch/hyperloglog/mod.rs
+++ b/src/core/src/sketch/hyperloglog/mod.rs
@@ -30,6 +30,7 @@ use estimators::CounterType;
     feature = "rkyv",
     derive(rkyv::Serialize, rkyv::Deserialize, rkyv::Archive)
 )]
+#[cfg_attr(feature = "mem_dbg", derive(mem_dbg::MemDbg, mem_dbg::MemSize))]
 pub struct HyperLogLog {
     registers: Vec<CounterType>,
     p: usize,

--- a/src/core/src/sketch/minhash.rs
+++ b/src/core/src/sketch/minhash.rs
@@ -38,6 +38,7 @@ pub fn scaled_for_max_hash(max_hash: u64) -> u64 {
     feature = "rkyv",
     derive(rkyv::Serialize, rkyv::Deserialize, rkyv::Archive)
 )]
+#[cfg_attr(feature = "mem_dbg", derive(mem_dbg::MemDbg, mem_dbg::MemSize))]
 pub struct KmerMinHash {
     num: u32,
     ksize: u32,


### PR DESCRIPTION
* Added support as an optional feature to [mem_dbg](https://crates.io/crates/mem_dbg), an easy way to compute memory requirements for a struct. It is useful for comparing this library with other implementations.

No change to API nor any other aspects are introduced in this pull request.