### PR TITLE
MRG: misc Rust updates to core

### DIFF
--- a/src/core/src/collection.rs
+++ b/src/core/src/collection.rs
@@ -197,7 +197,6 @@ impl Collection {
 
     pub fn sig_from_record(&self, record: &Record) -> Result<SigStore> {
         let match_path = record.internal_location().as_str();
-        eprintln!("XXX match path: {}", match_path);
         let selection = Selection::from_record(record)?;
         let sig = self.storage.load_sig(match_path)?.select(&selection)?;
         assert_eq!(sig.signatures.len(), 1);

--- a/src/core/src/collection.rs
+++ b/src/core/src/collection.rs
@@ -137,8 +137,8 @@ impl Collection {
 
     #[cfg(all(feature = "branchwater", not(target_arch = "wasm32")))]
     pub fn from_rocksdb<P: AsRef<Path>>(dirname: P) -> Result<Self> {
-        use crate::index::revindex::{ RevIndex, RevIndexOps };
-    
+        use crate::index::revindex::{RevIndex, RevIndexOps};
+
         let path = dirname.as_ref().as_str().to_string();
         let index = RevIndex::open(path, true, None)?;
         let collection: Collection = index.collection().clone().into_inner();

--- a/src/core/src/collection.rs
+++ b/src/core/src/collection.rs
@@ -134,19 +134,17 @@ impl Collection {
             storage: InnerStorage::new(storage),
         })
     }
-    #[cfg(all(feature = "branchwater", not(target_arch = "wasm32")))]
+/*    #[cfg(all(feature = "branchwater", not(target_arch = "wasm32")))]
     pub fn from_rocksdb<P: AsRef<Path>>(dirname: P) -> Result<Self> {
-        // @CTB: is this right?
-        let path = dirname.as_ref().as_os_str().to_str().unwrap();
-        let storage = RocksDBStorage::from_path(path);
-        // Load manifest from standard location in zipstorage
-        let manifest = Manifest::from_reader(storage.load("SOURMASH-MANIFEST.csv")?.as_slice())?;
+        let index = RevIndex::open(dirname, true, None)?;
+        let collection = db.collection();
+
         Ok(Self {
             manifest,
             storage: InnerStorage::new(storage),
         })
     }
-
+*/
     pub fn from_sigs(sigs: Vec<Signature>) -> Result<Self> {
         let storage = MemStorage::new();
 

--- a/src/core/src/collection.rs
+++ b/src/core/src/collection.rs
@@ -139,6 +139,8 @@ impl Collection {
 
     #[cfg(all(feature = "branchwater", not(target_arch = "wasm32")))]
     pub fn from_rocksdb<P: AsRef<Path>>(dirname: P) -> Result<Self> {
+        use crate::index::revindex::{ RevIndex, RevIndexOps };
+    
         let path = dirname.as_ref().as_str().to_string();
         let index = RevIndex::open(path, true, None)?;
         let collection: Collection = index.collection().clone().into_inner();

--- a/src/core/src/collection.rs
+++ b/src/core/src/collection.rs
@@ -12,10 +12,14 @@ use crate::{Error, Result};
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 
+/// a Manifest and Storage, combined. Can contain any collection of signatures.
+
 pub struct Collection {
     manifest: Manifest,
     storage: InnerStorage,
 }
+
+/// A consistent collection of signatures. Can be created using `select`.
 
 pub struct CollectionSet {
     collection: Collection,

--- a/src/core/src/collection.rs
+++ b/src/core/src/collection.rs
@@ -197,6 +197,7 @@ impl Collection {
 
     pub fn sig_from_record(&self, record: &Record) -> Result<SigStore> {
         let match_path = record.internal_location().as_str();
+        eprintln!("XXX match path: {}", match_path);
         let selection = Selection::from_record(record)?;
         let sig = self.storage.load_sig(match_path)?.select(&selection)?;
         assert_eq!(sig.signatures.len(), 1);

--- a/src/core/src/collection.rs
+++ b/src/core/src/collection.rs
@@ -7,8 +7,6 @@ use crate::encodings::Idx;
 use crate::manifest::{Manifest, Record};
 use crate::prelude::*;
 use crate::storage::{FSStorage, InnerStorage, MemStorage, SigStore, ZipStorage};
-#[cfg(all(feature = "branchwater", not(target_arch = "wasm32")))]
-use crate::index::revindex::{ RevIndex, RevIndexOps };
 use crate::{Error, Result};
 
 #[cfg(feature = "parallel")]

--- a/src/core/src/from.rs
+++ b/src/core/src/from.rs
@@ -16,7 +16,7 @@ impl From<MashSketcher> for KmerMinHash {
 
         let mut new_mh = KmerMinHash::new(
             0,
-            values.get(0).unwrap().kmer.len() as u32,
+            values.first().unwrap().kmer.len() as u32,
             HashFunctions::Murmur64Dna,
             42,
             true,

--- a/src/core/src/index/linear.rs
+++ b/src/core/src/index/linear.rs
@@ -17,6 +17,8 @@ use crate::sketch::Sketch;
 use crate::storage::SigStore;
 use crate::Result;
 
+/// Supports parallel search without a particular index.
+
 pub struct LinearIndex {
     collection: CollectionSet,
     template: Sketch,

--- a/src/core/src/index/revindex/disk_revindex.rs
+++ b/src/core/src/index/revindex/disk_revindex.rs
@@ -364,7 +364,7 @@ impl RevIndexOps for RevIndex {
         orig_query: &KmerMinHash,
         selection: Option<Selection>,
     ) -> Result<Vec<GatherResult>> {
-        let mut match_size = usize::max_value();
+        let mut match_size = usize::MAX;
         let mut matches = vec![];
         let mut query = KmerMinHashBTree::from(orig_query.clone());
         let mut sum_weighted_found = 0;
@@ -554,8 +554,7 @@ impl RevIndexOps for RevIndex {
         // Using unchecked version because we just used the manifest
         // above to make sure the storage is still consistent
         unsafe {
-            Arc::get_mut(&mut self.collection)
-                .map(|v| v.set_storage_unchecked(InnerStorage::new(new_storage)));
+            if let Some(v) = Arc::get_mut(&mut self.collection) { v.set_storage_unchecked(InnerStorage::new(new_storage)) }
         }
 
         // write storage spec

--- a/src/core/src/index/revindex/disk_revindex.rs
+++ b/src/core/src/index/revindex/disk_revindex.rs
@@ -554,7 +554,9 @@ impl RevIndexOps for RevIndex {
         // Using unchecked version because we just used the manifest
         // above to make sure the storage is still consistent
         unsafe {
-            if let Some(v) = Arc::get_mut(&mut self.collection) { v.set_storage_unchecked(InnerStorage::new(new_storage)) }
+            if let Some(v) = Arc::get_mut(&mut self.collection) {
+                v.set_storage_unchecked(InnerStorage::new(new_storage))
+            }
         }
 
         // write storage spec

--- a/src/core/src/index/revindex/mem_revindex.rs
+++ b/src/core/src/index/revindex/mem_revindex.rs
@@ -204,7 +204,7 @@ impl RevIndex {
         threshold: usize,
         query: &KmerMinHash,
     ) -> Result<Vec<GatherResult>> {
-        let mut match_size = usize::max_value();
+        let mut match_size = usize::MAX;
         let mut matches = vec![];
 
         while match_size > threshold && !counter.is_empty() {

--- a/src/core/src/manifest.rs
+++ b/src/core/src/manifest.rs
@@ -231,7 +231,7 @@ impl Select for Manifest {
                 valid
             };
             valid = if let Some(scaled) = selection.scaled() {
-                eprintln!("foo: {0}, {scaled}", row.scaled);
+                eprintln!("foo: {0}, {scaled}", row.scaled); // @CTB
                 // num sigs have row.scaled = 0, don't include them
                 valid && row.scaled != 0 && row.scaled <= scaled as u64
             } else {

--- a/src/core/src/manifest.rs
+++ b/src/core/src/manifest.rs
@@ -231,7 +231,6 @@ impl Select for Manifest {
                 valid
             };
             valid = if let Some(scaled) = selection.scaled() {
-                eprintln!("foo: {0}, {scaled}", row.scaled); // @CTB
                 // num sigs have row.scaled = 0, don't include them
                 valid && row.scaled != 0 && row.scaled <= scaled as u64
             } else {

--- a/src/core/src/manifest.rs
+++ b/src/core/src/manifest.rs
@@ -231,7 +231,7 @@ impl Select for Manifest {
                 valid
             };
             valid = if let Some(scaled) = selection.scaled() {
-                dbg!("foo: {row.scaled}, {scaled}");
+                eprintln!("foo: {0}, {scaled}", row.scaled);
                 // num sigs have row.scaled = 0, don't include them
                 valid && row.scaled != 0 && row.scaled <= scaled as u64
             } else {

--- a/src/core/src/manifest.rs
+++ b/src/core/src/manifest.rs
@@ -30,8 +30,13 @@ pub struct Record {
 
     moltype: String,
 
+    #[getset(get = "pub")]
     num: u32,
+
+    #[getset(get = "pub")]
     scaled: u64,
+
+    #[getset(get = "pub")]
     n_hashes: usize,
 
     #[getset(get_copy = "pub", set = "pub")]

--- a/src/core/src/manifest.rs
+++ b/src/core/src/manifest.rs
@@ -15,6 +15,8 @@ use crate::signature::SigsTrait;
 use crate::sketch::Sketch;
 use crate::Result;
 
+/// Individual manifest record, containing information about sketches.
+
 #[derive(Debug, Serialize, Deserialize, Clone, CopyGetters, Getters, Setters, PartialEq, Eq)]
 pub struct Record {
     #[getset(get = "pub", set = "pub")]

--- a/src/core/src/manifest.rs
+++ b/src/core/src/manifest.rs
@@ -80,12 +80,15 @@ where
     }
 }
 
+/// A description of a collection of sketches.
+
 #[derive(Debug, Default, Serialize, Deserialize, Clone)]
 pub struct Manifest {
     records: Vec<Record>,
 }
 
 impl Record {
+    /// Build a Record from a Signature
     pub fn from_sig(sig: &Signature, path: &str) -> Vec<Self> {
         sig.iter()
             .map(|sketch| {
@@ -228,6 +231,7 @@ impl Select for Manifest {
                 valid
             };
             valid = if let Some(scaled) = selection.scaled() {
+                dbg!("foo: {row.scaled}, {scaled}");
                 // num sigs have row.scaled = 0, don't include them
                 valid && row.scaled != 0 && row.scaled <= scaled as u64
             } else {

--- a/src/core/src/storage/mod.rs
+++ b/src/core/src/storage/mod.rs
@@ -306,7 +306,15 @@ impl Storage for FSStorage {
                     .into();
                 sig
             }
-            _ => todo!("cannot load from path {path}"),
+            x if x.ends_with(".zip") => {
+                let store = ZipStorage::from_file(path)?;
+                let fnames = store.filenames().unwrap();
+                eprintln!("ZYZ {}", fnames.len());
+                todo!("fail here, now")
+                // @CTB
+                    
+            }
+            _ => todo!("cannot load from path '{path}'"),
         };
 
         Ok(sig)

--- a/src/core/src/storage/mod.rs
+++ b/src/core/src/storage/mod.rs
@@ -297,6 +297,7 @@ impl Storage for FSStorage {
     }
 
     fn load_sig(&self, path: &str) -> Result<SigStore> {
+        eprintln!("FSStorage: load_sig {path}");
         let raw = self.load(path)?;
         let sig = Signature::from_reader(&mut &raw[..])?
             // TODO: select the right sig?

--- a/src/core/src/storage/mod.rs
+++ b/src/core/src/storage/mod.rs
@@ -298,12 +298,18 @@ impl Storage for FSStorage {
 
     fn load_sig(&self, path: &str) -> Result<SigStore> {
         eprintln!("FSStorage: load_sig {path}");
-        let raw = self.load(path)?;
-        let sig = Signature::from_reader(&mut &raw[..])?
-            // TODO: select the right sig?
-            .swap_remove(0);
+        let sig = match path {
+            x if x.ends_with(".sig") || x.ends_with(".sig.gz") => {
+                let raw = self.load(path)?;
+                let sig = Signature::from_reader(&mut &raw[..])?
+                    .swap_remove(0)
+                    .into();
+                sig
+            }
+            _ => todo!("cannot load from path {path}"),
+        };
 
-        Ok(sig.into())
+        Ok(sig)
     }
 
     fn spec(&self) -> String {

--- a/src/core/src/storage/mod.rs
+++ b/src/core/src/storage/mod.rs
@@ -112,6 +112,7 @@ pub struct FSStorage {
     subdir: String,
 }
 
+/// Store files in a zip file.
 #[ouroboros::self_referencing]
 pub struct ZipStorage {
     mapping: Option<memmap2::Mmap>,

--- a/src/core/src/storage/mod.rs
+++ b/src/core/src/storage/mod.rs
@@ -297,19 +297,12 @@ impl Storage for FSStorage {
     }
 
     fn load_sig(&self, path: &str) -> Result<SigStore> {
-        let sig = match self.load(path) {
-            Ok(raw) => {
-                let sig = Signature::from_reader(&mut &raw[..])?
-                    .swap_remove(0)
-                    .into();
-                sig
-            },
-            Err(_) => {
-                todo!("cannot load from path '{path}'")
-            }
-        };
+        let raw = self.load(path)?;
+        let sig = Signature::from_reader(&mut &raw[..])?
+            // TODO: select the right sig?
+            .swap_remove(0);
 
-        Ok(sig)
+        Ok(sig.into())
     }
 
     fn spec(&self) -> String {

--- a/src/core/src/storage/mod.rs
+++ b/src/core/src/storage/mod.rs
@@ -297,24 +297,16 @@ impl Storage for FSStorage {
     }
 
     fn load_sig(&self, path: &str) -> Result<SigStore> {
-        eprintln!("FSStorage: load_sig {path}");
-        let sig = match path {
-            x if x.ends_with(".sig") || x.ends_with(".sig.gz") => {
-                let raw = self.load(path)?;
+        let sig = match self.load(path) {
+            Ok(raw) => {
                 let sig = Signature::from_reader(&mut &raw[..])?
                     .swap_remove(0)
                     .into();
                 sig
+            },
+            Err(_) => {
+                todo!("cannot load from path '{path}'")
             }
-            x if x.ends_with(".zip") => {
-                let store = ZipStorage::from_file(path)?;
-                let fnames = store.filenames().unwrap();
-                eprintln!("ZYZ {}", fnames.len());
-                todo!("fail here, now")
-                // @CTB
-                    
-            }
-            _ => todo!("cannot load from path '{path}'"),
         };
 
         Ok(sig)

--- a/src/core/src/storage/rocksdb.rs
+++ b/src/core/src/storage/rocksdb.rs
@@ -47,7 +47,7 @@ impl Storage for RocksDBStorage {
     fn save(&self, path: &str, content: &[u8]) -> Result<String> {
         let cf_storage = self.db.cf_handle(STORAGE).unwrap();
         // TODO(lirber): deal with conflict for path?
-        self.db.put_cf(&cf_storage, path.as_bytes(), &content[..])?;
+        self.db.put_cf(&cf_storage, path.as_bytes(), content)?;
         Ok(path.into())
     }
 


### PR DESCRIPTION
A few useful things from the branchwater plugin perspective:
- add getters to `num`, `scaled`, and `n_hashes` in `Record`
- add misc documentation, based in part on descriptions in #2230
- add `#[derive Clone]` to `Collection` and `CollectionSet`
- add `Collection::from_rocksdb(...)`
