### PR TITLE
MRG: propagate error from `RocksDB::open` on bad directory

### DIFF
--- a/src/core/src/index/revindex/disk_revindex.rs
+++ b/src/core/src/index/revindex/disk_revindex.rs
@@ -114,7 +114,7 @@ impl RevIndex {
 
         info!("Compact SSTs");
         index.compact();
-        info!("Processed {} reference sigs", processed_sigs.into_inner());
+        info!("Done! Processed {} reference sigs", processed_sigs.into_inner());
 
         Ok(module::RevIndex::Plain(index))
     }

--- a/src/core/src/index/revindex/mod.rs
+++ b/src/core/src/index/revindex/mod.rs
@@ -186,7 +186,7 @@ impl RevIndex {
 
     pub fn open<P: AsRef<Path>>(index: P, read_only: bool, spec: Option<&str>) -> Result<Self> {
         let opts = db_options();
-        let cfs = DB::list_cf(&opts, index.as_ref()).unwrap();
+        let cfs = DB::list_cf(&opts, index.as_ref())?;
 
         if cfs.into_iter().any(|c| c == COLORS) {
             // TODO: ColorRevIndex can't be read-only for now,
@@ -1019,5 +1019,15 @@ mod test {
         });
 
         Ok(())
+    }
+
+    #[test]
+    fn rocksdb_storage_fail_bad_directory() -> Result<()> {
+        let testdir = TempDir::new()?;
+
+        match RevIndex::open(testdir, true, None) {
+            Err(_) => Ok(()),
+            Ok(_) => panic!("test should not reach here"),
+        }
     }
 }


### PR DESCRIPTION
Extracted from https://github.com/sourmash-bio/sourmash/pull/3305

This PR adjusts `RevIndex::open` to propagate a `RocksDBError` when opening a non-RocksDB directory.

It also modifies the creation printout in `RevIndex::create` to distinguish index completion from interim output, for slightly easier debugging.
