### PR TITLE
MRG: have ruff ignore ipynb so as to avoid triggering an error during CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,6 +160,9 @@ macos-deployment-target = "10.14"
 [tool.maturin.target.aarch64-apple-darwin]
 macos-deployment-target = "11.0"
 
+[tool.ruff]
+exclude = [".ipynb"]
+
 [tool.ruff.lint]
 extend-select = [
   "UP",  # pyupgrade

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,7 +161,7 @@ macos-deployment-target = "10.14"
 macos-deployment-target = "11.0"
 
 [tool.ruff]
-extend-exclude = [".ipynb"]
+extend-exclude = ["*.ipynb"]
 
 [tool.ruff.lint]
 extend-select = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,7 +161,7 @@ macos-deployment-target = "10.14"
 macos-deployment-target = "11.0"
 
 [tool.ruff]
-exclude = [".ipynb"]
+extend-exclude = [".ipynb"]
 
 [tool.ruff.lint]
 extend-select = [


### PR DESCRIPTION
ruff is reporting:
```
error: Failed to parse doc/sourmash-examples.ipynb:3:1:5: Expected an expression
157 files left unchanged

ruff.....................................................................Failed
- hook id: ruff
- exit code: 1

doc/sourmash-examples.ipynb:cell 5:1:5: SyntaxError: Expected an expression
  |
1 | ls *.sig
  |     ^
  |
```
and we don't really care ;)