### PR TITLE
MRG: update sourmash core to r0.15.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1646,7 +1646,7 @@ checksum = "9f1341053f34bb13b5e9590afb7d94b48b48d4b87467ec28e3c238693bb553de"
 
 [[package]]
 name = "sourmash"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "az",
  "byteorder",

--- a/src/core/CHANGELOG.md
+++ b/src/core/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.15.2] - 2024-09-25
+
+MSRV: 1.65
+
+Changes/additions:
+* add `Manifest::intersect_manifest` to Rust core (#3305)
+* propagate error from `RocksDB::open` on bad directory (#3306, #3307)
+
+Updates:
+
+* Bump getset from 0.1.2 to 0.1.3 (#3328)
+* Bump memmap2 from 0.9.4 to 0.9.5 (#3326)
+* Bump codspeed-criterion-compat from 2.6.0 to 2.7.2 (#3324)
+* Bump serde_json from 1.0.127 to 1.0.128 (#3316)
+* Bump serde from 1.0.209 to 1.0.210 (#3318)
+* Bump serde from 1.0.208 to 1.0.209 (#3310)
+* Bump serde_json from 1.0.125 to 1.0.127 (#3309)
+
 ## [0.15.1] - 2024-08-20
 
 MSRV: 1.65

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sourmash"
-version = "0.15.1"
+version = "0.15.2"
 authors = ["Luiz Irber <luiz@sourmash.bio>", "N. Tessa Pierce-Ward <tessa@sourmash.bio>"]
 description = "tools for comparing biological sequences with k-mer sketches"
 repository = "https://github.com/sourmash-bio/sourmash"


### PR DESCRIPTION
from https://github.com/sourmash-bio/sourmash/issues/2987#issuecomment-1959820207:

- [x] verify minimum supported rust version (MSRV) for writing release notes (see https://github.com/sourmash-bio/sourmash/pull/2988 for an example); MSRV is checked by CI in `.github/workflows/rust.yml`, `minimum_rust_version`
- [x] write release notes using `git log --oneline r0.12.0..latest src/core | cut -d\  -f2- > /tmp/out.txt`
- [x] verify that the ChangeLog is up to date: https://github.com/sourmash-bio/sourmash/blob/latest/src/core/CHANGELOG.md
- [x] bump version in `src/core/Cargo.toml`

# Release notes:

## [0.15.2] - 2024-09-25

MSRV: 1.65

Changes/additions:
* add `Manifest::intersect_manifest` to Rust core (#3305)
* propagate error from `RocksDB::open` on bad directory (#3306, #3307)

Updates:

* Bump getset from 0.1.2 to 0.1.3 (#3328)
* Bump memmap2 from 0.9.4 to 0.9.5 (#3326)
* Bump codspeed-criterion-compat from 2.6.0 to 2.7.2 (#3324)
* Bump serde_json from 1.0.127 to 1.0.128 (#3316)                               
* Bump serde from 1.0.209 to 1.0.210 (#3318)                                    
* Bump serde from 1.0.208 to 1.0.209 (#3310)                                    
* Bump serde_json from 1.0.125 to 1.0.127 (#3309)