### PR TITLE
MRG: derive Hash for `HashFunctions`

### DIFF
--- a/src/core/src/encodings.rs
+++ b/src/core/src/encodings.rs
@@ -20,7 +20,7 @@ pub type Idx = u32;
 type IdxTracker = (vec_collections::VecSet<[Idx; 8]>, u64);
 type ColorToIdx = HashMap<Color, IdxTracker, BuildNoHashHasher<Color>>;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(
     feature = "rkyv",
     derive(rkyv::Serialize, rkyv::Deserialize, rkyv::Archive)


### PR DESCRIPTION
- derive Hash for HashFunctions, so I can use it over in https://github.com/sourmash-bio/sourmash_plugin_directsketch/pull/112
