### PR TITLE
feat: Implement TryInto to convert Signature and SigStore into KmerMinHash

### DIFF
--- a/src/core/src/collection.rs
+++ b/src/core/src/collection.rs
@@ -241,7 +241,6 @@ mod test {
     use crate::prelude::Select;
     use crate::selection::Selection;
     use crate::signature::Signature;
-    use crate::Result;
 
     #[test]
     fn sigstore_selection_with_downsample() {

--- a/src/core/src/errors.rs
+++ b/src/core/src/errors.rs
@@ -31,6 +31,15 @@ pub enum SourmashError {
     #[error("sketch needs abundance for this operation")]
     NeedsAbundanceTracking,
 
+    #[error("Expected a MinHash sketch in this signature")]
+    NoMinHashFound,
+
+    #[error("Empty signature")]
+    EmptySignature,
+
+    #[error("Multiple sketches found, expected one")]
+    MultipleSketchesFound,
+
     #[error("Invalid hash function: {function:?}")]
     InvalidHashFunction { function: String },
 
@@ -108,6 +117,9 @@ pub enum SourmashErrorCode {
     MismatchNum = 1_07,
     NeedsAbundanceTracking = 1_08,
     CannotUpsampleScaled = 1_09,
+    NoMinHashFound = 1_10,
+    EmptySignature = 1_11,
+    MultipleSketchesFound = 1_12,
     // Input sequence errors
     InvalidDNA = 11_01,
     InvalidProt = 11_02,
@@ -147,6 +159,9 @@ impl SourmashErrorCode {
             SourmashError::MismatchSeed => SourmashErrorCode::MismatchSeed,
             SourmashError::MismatchSignatureType => SourmashErrorCode::MismatchSignatureType,
             SourmashError::NonEmptyMinHash { .. } => SourmashErrorCode::NonEmptyMinHash,
+            SourmashError::NoMinHashFound => SourmashErrorCode::NoMinHashFound,
+            SourmashError::EmptySignature => SourmashErrorCode::EmptySignature,
+            SourmashError::MultipleSketchesFound => SourmashErrorCode::MultipleSketchesFound,
             SourmashError::InvalidDNA { .. } => SourmashErrorCode::InvalidDNA,
             SourmashError::InvalidProt { .. } => SourmashErrorCode::InvalidProt,
             SourmashError::InvalidCodonLength { .. } => SourmashErrorCode::InvalidCodonLength,

--- a/src/core/src/signature.rs
+++ b/src/core/src/signature.rs
@@ -888,9 +888,9 @@ impl PartialEq for Signature {
 }
 
 impl TryInto<KmerMinHash> for Signature {
-    type Error = crate::Error;
+    type Error = Error;
 
-    fn try_into(self) -> Result<KmerMinHash, Self::Error> {
+    fn try_into(self) -> Result<KmerMinHash, Error> {
         match self.signatures.len() {
             1 => self
                 .signatures
@@ -902,9 +902,9 @@ impl TryInto<KmerMinHash> for Signature {
                         None
                     }
                 })
-                .ok_or_else(|| todo!("error, no minhash found")),
-            0 => todo!("error, empty signature"),
-            2.. => todo!("Multiple sketches found! Please run select first."),
+                .ok_or_else(|| Error::NoMinHashFound),
+            0 => Err(Error::EmptySignature),
+            2.. => Err(Error::MultipleSketchesFound),
         }
     }
 }

--- a/src/core/src/signature.rs
+++ b/src/core/src/signature.rs
@@ -887,6 +887,28 @@ impl PartialEq for Signature {
     }
 }
 
+impl TryInto<KmerMinHash> for Signature {
+    type Error = crate::Error;
+
+    fn try_into(self) -> Result<KmerMinHash, Self::Error> {
+        match self.signatures.len() {
+            1 => self
+                .signatures
+                .into_iter()
+                .find_map(|sk| {
+                    if let Sketch::MinHash(mh) = sk {
+                        Some(mh)
+                    } else {
+                        None
+                    }
+                })
+                .ok_or_else(|| todo!("error, no minhash found")),
+            0 => todo!("error, empty signature"),
+            2.. => todo!("Multiple sketches found! Please run select first."),
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use std::fs::File;

--- a/src/core/src/storage/mod.rs
+++ b/src/core/src/storage/mod.rs
@@ -16,6 +16,7 @@ use typed_builder::TypedBuilder;
 use crate::errors::ReadDataError;
 use crate::prelude::*;
 use crate::signature::SigsTrait;
+use crate::sketch::minhash::KmerMinHash;
 use crate::sketch::Sketch;
 use crate::{Error, Result};
 
@@ -547,6 +548,15 @@ impl From<Signature> for SigStore {
             .metadata("")
             .storage(None)
             .build()
+    }
+}
+
+impl TryInto<KmerMinHash> for SigStore {
+    type Error = crate::Error;
+
+    fn try_into(self) -> std::result::Result<KmerMinHash, Self::Error> {
+        let sig: Signature = self.into();
+        sig.try_into()
     }
 }
 


### PR DESCRIPTION
Ref: https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/467/files#r1797783380

Implement `TryInto<KmerMinHash>` for Signature and SigStore to avoid having to clone a (potentially big) minhash sketch.