### PR TITLE
CI: use supported ubuntu for codspeed

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   benchmarks-rust:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Fix build issues with codspeed, it doesn't support `ubuntu-24.04` (alias to `ubuntu-latest`) yet