### PR TITLE
remove match_

### DIFF
--- a/src/core/src/ffi/index/revindex.rs
+++ b/src/core/src/ffi/index/revindex.rs
@@ -207,16 +207,13 @@ unsafe fn revindex_gather(
     let threshold: usize = (threshold * (mh.size() as f64)) as _;
 
     let counter = revindex.counter_for_query(mh);
-    dbg!(&counter);
 
     let results: Vec<(f64, Signature, String)> = revindex
         .gather(counter, threshold, mh)
         .unwrap() // TODO: proper error handling
         .into_iter()
         .map(|r| {
-            let filename = r.filename().to_owned();
-            let sig = r.get_match();
-            (r.f_match(), sig, filename)
+            todo!()
         })
         .collect();
 

--- a/src/core/src/index/linear.rs
+++ b/src/core/src/index/linear.rs
@@ -183,7 +183,6 @@ impl LinearIndex {
         let intersect_bp: u64 = match_mh.scaled() as u64 * intersect_orig;
 
         let f_unique_to_query = intersect_orig as f64 / query.size() as f64;
-        let match_ = match_sig;
 
         // TODO: all of these
         let f_unique_weighted = 0.;
@@ -217,7 +216,6 @@ impl LinearIndex {
             filename,
             name,
             md5,
-            match_,
             f_match_orig,
             unique_intersect_bp,
             gather_result_rank,

--- a/src/core/src/index/mod.rs
+++ b/src/core/src/index/mod.rs
@@ -65,9 +65,6 @@ pub struct GatherResult {
     #[getset(get = "pub")]
     md5: String,
 
-    #[serde(skip)]
-    match_: SigStore,
-
     #[getset(get_copy = "pub")]
     f_match_orig: f64,
 
@@ -116,12 +113,6 @@ pub struct GatherResult {
 
     #[getset(get_copy = "pub")]
     max_containment_ani: f64,
-}
-
-impl GatherResult {
-    pub fn get_match(&self) -> Signature {
-        self.match_.clone().into()
-    }
 }
 
 type SigCounter = counter::Counter<Idx>;
@@ -219,8 +210,11 @@ pub fn calculate_gather_stats(
     calc_ani_ci: bool,
     confidence: Option<f64>,
 ) -> Result<(GatherResult, (Vec<u64>, u64))> {
+    let match_filename = match_sig.filename();
+    let match_name = match_sig.name();
+    let match_md5 = match_sig.md5sum();
     // get match_mh
-    let match_mh = match_sig.minhash().expect("cannot retrieve sketch");
+    let match_mh: KmerMinHash = match_sig.try_into()?;
 
     // it's ok to downsample match, but query is often big and repeated,
     // so we do not allow downsampling of query in this function.
@@ -330,10 +324,9 @@ pub fn calculate_gather_stats(
         .average_abund(average_abund)
         .median_abund(median_abund)
         .std_abund(std_abund)
-        .filename(match_sig.filename())
-        .name(match_sig.name())
-        .md5(match_sig.md5sum())
-        .match_(match_sig)
+        .filename(match_filename)
+        .name(match_name)
+        .md5(match_md5)
         .f_match_orig(f_match_orig)
         .unique_intersect_bp(unique_intersect_bp)
         .gather_result_rank(gather_result_rank)

--- a/src/core/src/index/revindex/mem_revindex.rs
+++ b/src/core/src/index/revindex/mem_revindex.rs
@@ -208,26 +208,29 @@ impl RevIndex {
         let mut matches = vec![];
 
         while match_size > threshold && !counter.is_empty() {
-            let (dataset_id, size) = counter.most_common()[0];
+            let (dataset_id, size) = counter.k_most_common_ordered(1)[0];
             match_size = if size >= threshold { size } else { break };
             let result = self
                 .linear
                 .gather_round(dataset_id, match_size, query, matches.len())?;
-            if let Some(Sketch::MinHash(match_mh)) =
-                result.match_.select_sketch(self.linear.template())
-            {
-                // Prepare counter for finding the next match by decrementing
-                // all hashes found in the current match in other datasets
-                for hash in match_mh.iter_mins() {
-                    if let Some(color) = self.hash_to_color.get(hash) {
-                        counter.subtract(self.colors.indices(color).cloned());
-                    }
-                }
-                counter.remove(&dataset_id);
-                matches.push(result);
-            } else {
-                unimplemented!()
+
+            // handle special case where threshold was set to 0
+            if match_size == 0 {
+                break;
             }
+
+            let match_sig = self.linear.collection().sig_for_dataset(dataset_id)?;
+            let match_mh = match_sig.minhash().unwrap().clone();
+
+            // Prepare counter for finding the next match by decrementing
+            // all hashes found in the current match in other datasets
+            for hash in match_mh.iter_mins() {
+                if let Some(color) = self.hash_to_color.get(hash) {
+                    counter.subtract(self.colors.indices(color).cloned());
+                }
+            }
+            counter.remove(&dataset_id);
+            matches.push(result);
         }
         Ok(matches)
     }


### PR DESCRIPTION
I think `match_` is a leftover from the first impl of `Index` on the rust side, and not needed?