### PR TITLE
fix: Avoid re-calculating md5sum on clone and conversion to KmerMinHashBTree

### DIFF
--- a/src/core/src/sketch/minhash.rs
+++ b/src/core/src/sketch/minhash.rs
@@ -1006,7 +1006,7 @@ impl Clone for KmerMinHashBTree {
             mins: self.mins.clone(),
             abunds: self.abunds.clone(),
             current_max: self.current_max,
-            md5sum: Mutex::new(Some(self.md5sum())),
+            md5sum: Mutex::new(self.md5sum.lock().unwrap().clone()),
         }
     }
 }
@@ -1667,6 +1667,8 @@ impl From<KmerMinHashBTree> for KmerMinHash {
         new_mh.mins = mins;
         new_mh.abunds = abunds;
 
+        new_mh.md5sum = other.md5sum;
+
         new_mh
     }
 }
@@ -1691,6 +1693,8 @@ impl From<&KmerMinHashBTree> for KmerMinHash {
         new_mh.mins = mins;
         new_mh.abunds = abunds;
 
+        new_mh.md5sum = Mutex::new(other.md5sum.lock().unwrap().clone());
+
         new_mh
     }
 }
@@ -1713,6 +1717,8 @@ impl From<KmerMinHash> for KmerMinHashBTree {
 
         new_mh.mins = mins;
         new_mh.abunds = abunds;
+
+        new_mh.md5sum = other.md5sum;
 
         new_mh
     }


### PR DESCRIPTION
While debugging https://github.com/sourmash-bio/sourmash_plugin_branchwater/issues/503 the flamegraph showed ~26% of the time was spent on calculating MD5.

WHY????

Turns out cloning and converting to `KmerMinHash` to `KmerMinHashBTree` triggered recalculation of the MD5 sum, even if it was already present (or... not needed). Oops!