### PR TITLE
MRG: bump sourmash core to r0.17.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1640,7 +1640,7 @@ checksum = "9f1341053f34bb13b5e9590afb7d94b48b48d4b87467ec28e3c238693bb553de"
 
 [[package]]
 name = "sourmash"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "az",
  "byteorder",

--- a/src/core/CHANGELOG.md
+++ b/src/core/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.17.2] - 2024-11-15
+
+MSRV: 1.66
+
+Changes/additions:
+
+* enforce a single scaled on a `CollectionSet` (#3397)
+* change `sig_from_record` to use scaled from `Record` to downsample (#3387)
+
+Updates:
+
+* Upgrade rocksdb to 0.22.0, bump MSRV to 1.66  (#3383)
+* Bump thiserror from 1.0.68 to 2.0.3 (#3389)
+* Bump csv from 1.3.0 to 1.3.1 (#3390)
+* Bump tempfile from 3.13.0 to 3.14.0 (#3391)
+
 ## [0.17.1] - 2024-11-11
 
 Changes/additions:

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sourmash"
-version = "0.17.1"
+version = "0.17.2"
 authors = ["Luiz Irber <luiz@sourmash.bio>", "N. Tessa Pierce-Ward <tessa@sourmash.bio>", "C. Titus Brown <titus@idyll.org>"]
 description = "tools for comparing biological sequences with k-mer sketches"
 repository = "https://github.com/sourmash-bio/sourmash"


### PR DESCRIPTION
## [0.17.2] - 2024-11-15

MSRV: 1.66

Changes/additions:

* enforce a single scaled on a `CollectionSet` (#3397)
* change `sig_from_record` to use scaled from `Record` to downsample (#3387)

Updates:

* Upgrade rocksdb to 0.22.0, bump MSRV to 1.66  (#3383)
* Bump thiserror from 1.0.68 to 2.0.3 (#3389)
* Bump csv from 1.3.0 to 1.3.1 (#3390)
* Bump tempfile from 3.13.0 to 3.14.0 (#3391)