### PR TITLE
WIP: switch docs to using python=3.12 for release testing

### DIFF
--- a/doc/release.md
+++ b/doc/release.md
@@ -46,7 +46,7 @@ conda version with `conda --version` and update with `conda update conda`.
 Create the basic build environment:
 
 ```
-mamba create -y -n sourmash-rc python=3.10 pip \
+mamba create -y -n sourmash-rc python=3.12 pip \
     cxx-compiler make twine tox tox-conda rust
 ```
 


### PR DESCRIPTION
we should update release docs generally - 

- [ ] update number of release wheels
- [ ] switch to using uv?
- [ ] be specific about recommending where things be pasted - issues, PRs, etc.