### PR TITLE
MRG: add comment about semver and column headings

### DIFF
--- a/doc/support.md
+++ b/doc/support.md
@@ -81,6 +81,13 @@ you upgrade within a major sourmash release (barring bug fixes!). Moreover,
 if you rely on a feature introduced in v3.3.0, that feature will not break
 in v3.4.0, but will also not be backported to version 3.2.0.
 
+### Output file formats
+
+In particular, the CSV output file formats are guaranteed to be stable
+within major versions, with one caveat: we may add or rearrange
+columns between releases.  You should use column headers/column names
+to parse CSV files, and not depend on column order.
+
 ### Python API
 
 We intend to guarantee the Python API at the top level, i.e.


### PR DESCRIPTION
This PR updates the docs to make it clear that we may rearrange or add columns within major versions, and suggests that people parse based on CSV headings.

Fixes https://github.com/sourmash-bio/sourmash/issues/3432
