### PR TITLE
MRG: adjust `Signature::name()` to return `Option<String>` instead of `filename()` and `md5sum()`

### DIFF
--- a/src/core/src/index/revindex/disk_revindex.rs
+++ b/src/core/src/index/revindex/disk_revindex.rs
@@ -351,7 +351,15 @@ impl RevIndexOps for RevIndex {
                         .collection
                         .record_for_dataset(dataset_id)
                         .expect("dataset not found");
-                    Some((row.name().into(), size))
+
+                    let mut name = row.name();
+                    if name == "" {
+                        name = row.filename();
+                    }
+                    if name == "" {
+                        name = row.md5();
+                    }
+                    Some((name.into(), size))
                 } else {
                     None
                 }

--- a/src/core/src/index/revindex/disk_revindex.rs
+++ b/src/core/src/index/revindex/disk_revindex.rs
@@ -352,13 +352,12 @@ impl RevIndexOps for RevIndex {
                         .record_for_dataset(dataset_id)
                         .expect("dataset not found");
 
-                    let mut name = row.name();
-                    if name == "" {
-                        name = row.filename();
-                    }
-                    if name == "" {
-                        name = row.md5();
-                    }
+                    let name = [row.name(), row.filename(), row.md5()]
+                        .into_iter()
+                        .skip_while(|v| v.is_empty())
+                        .next()
+                        .unwrap();  // guaranteed to succeed because `md5` always exists
+
                     Some((name.into(), size))
                 } else {
                     None

--- a/src/core/src/index/revindex/disk_revindex.rs
+++ b/src/core/src/index/revindex/disk_revindex.rs
@@ -356,7 +356,7 @@ impl RevIndexOps for RevIndex {
                         .into_iter()
                         .skip_while(|v| v.is_empty())
                         .next()
-                        .unwrap();  // guaranteed to succeed because `md5` always exists
+                        .unwrap(); // guaranteed to succeed because `md5` always exists
 
                     Some((name.into(), size))
                 } else {

--- a/src/core/src/index/revindex/mod.rs
+++ b/src/core/src/index/revindex/mod.rs
@@ -558,7 +558,7 @@ mod test {
         )?;
 
         assert_eq!(matches.len(), 1);
-        assert_eq!(matches[0].name(), "../genome-s10.fa.gz");
+        assert_eq!(matches[0].name(), ""); // signature name is empty
         assert_eq!(matches[0].f_match(), 1.0);
 
         Ok(())

--- a/src/core/src/manifest.rs
+++ b/src/core/src/manifest.rs
@@ -181,7 +181,7 @@ impl Record {
 impl PartialEq for Record {
     // match everything but internal_location
     fn eq(&self, other: &Self) -> bool {
-        let b = self.md5 == other.md5
+        self.md5 == other.md5
             && self.ksize == other.ksize
             && self.moltype == other.moltype
             && self.scaled == other.scaled
@@ -189,11 +189,7 @@ impl PartialEq for Record {
             && self.n_hashes == other.n_hashes
             && self.with_abundance == other.with_abundance
             && self.name == other.name
-            && self.filename == other.filename;
-        if !b {
-            eprintln!("xxx {:?}, {:?}", self.name, other.name);
-        };
-        b
+            && self.filename == other.filename
     }
 }
 
@@ -251,16 +247,12 @@ impl Manifest {
         // extract tuples from other mf:
         let pairs: HashSet<_> = other.iter().collect();
 
-        eprintln!("yyy {}, {}", self.records.len(), pairs.len());
-        eprintln!("yyy3 {:?}, {:?}", self.records, pairs);
-        let records: Vec<_> = self
+        let records = self
             .records
             .iter()
             .filter(|row| pairs.contains(row))
             .cloned()
             .collect();
-
-        eprintln!("yyy2 {}", records.len());
 
         Self { records }
     }

--- a/src/core/src/manifest.rs
+++ b/src/core/src/manifest.rs
@@ -192,7 +192,8 @@ impl PartialEq for Record {
             && self.filename == other.filename;
         if !b {
             eprintln!("xxx {:?}, {:?}", self.name, other.name);
-        }
+        };
+        b
     }
 }
 

--- a/src/core/src/manifest.rs
+++ b/src/core/src/manifest.rs
@@ -181,7 +181,7 @@ impl Record {
 impl PartialEq for Record {
     // match everything but internal_location
     fn eq(&self, other: &Self) -> bool {
-        self.md5 == other.md5
+        let b = self.md5 == other.md5
             && self.ksize == other.ksize
             && self.moltype == other.moltype
             && self.scaled == other.scaled
@@ -189,7 +189,10 @@ impl PartialEq for Record {
             && self.n_hashes == other.n_hashes
             && self.with_abundance == other.with_abundance
             && self.name == other.name
-            && self.filename == other.filename
+            && self.filename == other.filename;
+        if !b {
+            eprintln!("xxx {:?}, {:?}", self.name, other.name);
+        }
     }
 }
 

--- a/src/core/src/manifest.rs
+++ b/src/core/src/manifest.rs
@@ -129,7 +129,7 @@ impl Record {
                 Self {
                     internal_location: path.into(),
                     moltype: moltype.to_string(),
-                    name: sig.name(),
+                    name: sig.name().unwrap_or("".into()),
                     ksize,
                     md5,
                     md5short,

--- a/src/core/src/manifest.rs
+++ b/src/core/src/manifest.rs
@@ -129,7 +129,7 @@ impl Record {
                 Self {
                     internal_location: path.into(),
                     moltype: moltype.to_string(),
-                    name: sig.name().unwrap_or("".into()),
+                    name: sig.name_str(),
                     ksize,
                     md5,
                     md5short,

--- a/src/core/src/manifest.rs
+++ b/src/core/src/manifest.rs
@@ -252,6 +252,7 @@ impl Manifest {
         let pairs: HashSet<_> = other.iter().collect();
 
         eprintln!("yyy {}, {}", self.records.len(), pairs.len());
+        eprintln!("yyy3 {:?}, {:?}", self.records, pairs);
         let records: Vec<_> = self
             .records
             .iter()

--- a/src/core/src/manifest.rs
+++ b/src/core/src/manifest.rs
@@ -251,12 +251,15 @@ impl Manifest {
         // extract tuples from other mf:
         let pairs: HashSet<_> = other.iter().collect();
 
-        let records = self
+        eprintln!("yyy {}, {}", self.records.len(), pairs.len());
+        let records: Vec<_> = self
             .records
             .iter()
             .filter(|row| pairs.contains(row))
             .cloned()
             .collect();
+
+        eprintln!("yyy2 {}", records.len());
 
         Self { records }
     }

--- a/src/core/src/signature.rs
+++ b/src/core/src/signature.rs
@@ -451,7 +451,7 @@ impl Signature {
 //        } else if let Some(filename) = &self.filename {
 //            filename.clone()
         } else {
-            self.md5sum()
+            "".to_string()
         }
     }
 

--- a/src/core/src/signature.rs
+++ b/src/core/src/signature.rs
@@ -453,6 +453,11 @@ impl Signature {
         }
     }
 
+    // return name, if not None; or "" if None.
+    pub fn name_str(&self) -> String {
+        self.name().unwrap_or("".into())
+    }
+
     pub fn set_name(&mut self, name: &str) {
         self.name = Some(name.into())
     }
@@ -981,7 +986,7 @@ mod test {
         assert_eq!(sig.signatures[1].size(), 2);
         assert_eq!(sig.signatures[2].size(), 1);
 
-        assert_eq!(sig.name().unwrap_or("".into()), "");
+        assert_eq!(sig.name_str(), "");
     }
 
     #[test]

--- a/src/core/src/signature.rs
+++ b/src/core/src/signature.rs
@@ -449,7 +449,7 @@ impl Signature {
         self.name.clone()
     }
 
-    // return name, if not None; or "" if None.
+    /// return name, if not None; or "" if None.
     pub fn name_str(&self) -> String {
         self.name().unwrap_or("".into())
     }

--- a/src/core/src/signature.rs
+++ b/src/core/src/signature.rs
@@ -980,6 +980,8 @@ mod test {
         assert_eq!(sig.signatures[0].size(), 3);
         assert_eq!(sig.signatures[1].size(), 2);
         assert_eq!(sig.signatures[2].size(), 1);
+
+        assert_eq!(sig.name(), "");
     }
 
     #[test]

--- a/src/core/src/signature.rs
+++ b/src/core/src/signature.rs
@@ -448,10 +448,8 @@ impl Signature {
     pub fn name(&self) -> String {
         if let Some(name) = &self.name {
             name.clone()
-//        } else if let Some(filename) = &self.filename {
-//            filename.clone()
         } else {
-            "".to_string()
+            "".into()
         }
     }
 

--- a/src/core/src/signature.rs
+++ b/src/core/src/signature.rs
@@ -445,11 +445,11 @@ fn default_version() -> f64 {
 }
 
 impl Signature {
-    pub fn name(&self) -> String {
+    pub fn name(&self) -> Option<String> {
         if let Some(name) = &self.name {
-            name.clone()
+            Some(name.clone())
         } else {
-            "".into()
+            None
         }
     }
 
@@ -981,7 +981,7 @@ mod test {
         assert_eq!(sig.signatures[1].size(), 2);
         assert_eq!(sig.signatures[2].size(), 1);
 
-        assert_eq!(sig.name(), "");
+        assert_eq!(sig.name().unwrap_or("".into()), "");
     }
 
     #[test]

--- a/src/core/src/signature.rs
+++ b/src/core/src/signature.rs
@@ -446,11 +446,7 @@ fn default_version() -> f64 {
 
 impl Signature {
     pub fn name(&self) -> Option<String> {
-        if let Some(name) = &self.name {
-            Some(name.clone())
-        } else {
-            None
-        }
+        self.name.as_ref().map(|name| name.clone())
     }
 
     // return name, if not None; or "" if None.

--- a/src/core/src/signature.rs
+++ b/src/core/src/signature.rs
@@ -448,8 +448,8 @@ impl Signature {
     pub fn name(&self) -> String {
         if let Some(name) = &self.name {
             name.clone()
-        } else if let Some(filename) = &self.filename {
-            filename.clone()
+//        } else if let Some(filename) = &self.filename {
+//            filename.clone()
         } else {
             self.md5sum()
         }

--- a/src/core/src/signature.rs
+++ b/src/core/src/signature.rs
@@ -446,7 +446,7 @@ fn default_version() -> f64 {
 
 impl Signature {
     pub fn name(&self) -> Option<String> {
-        self.name.as_ref().map(|name| name.clone())
+        self.name.clone()
     }
 
     // return name, if not None; or "" if None.

--- a/src/core/src/storage/mod.rs
+++ b/src/core/src/storage/mod.rs
@@ -466,7 +466,7 @@ impl ZipStorage {
 
 impl SigStore {
     pub fn new_with_storage(sig: Signature, storage: InnerStorage) -> Self {
-        let name = sig.name().unwrap_or("".into());
+        let name = sig.name_str();
         let filename = sig.filename();
 
         SigStore::builder()
@@ -555,7 +555,7 @@ impl Deref for SigStore {
 
 impl From<Signature> for SigStore {
     fn from(other: Signature) -> SigStore {
-        let name = other.name().unwrap_or("".into());
+        let name = other.name_str();
         let filename = other.filename();
 
         SigStore::builder()

--- a/src/core/src/storage/mod.rs
+++ b/src/core/src/storage/mod.rs
@@ -466,7 +466,7 @@ impl ZipStorage {
 
 impl SigStore {
     pub fn new_with_storage(sig: Signature, storage: InnerStorage) -> Self {
-        let name = sig.name();
+        let name = sig.name().unwrap_or("".into());
         let filename = sig.filename();
 
         SigStore::builder()
@@ -555,7 +555,7 @@ impl Deref for SigStore {
 
 impl From<Signature> for SigStore {
     fn from(other: Signature) -> SigStore {
-        let name = other.name();
+        let name = other.name().unwrap_or("".into());
         let filename = other.filename();
 
         SigStore::builder()

--- a/src/core/tests/storage.rs
+++ b/src/core/tests/storage.rs
@@ -98,7 +98,7 @@ fn innerstorage_save_sig() -> Result<(), Box<dyn std::error::Error>> {
 
     let loaded_sig = instorage.load_sig("test")?;
 
-    assert_eq!(sig.name(), loaded_sig.name());
+    assert_eq!(sig.name().unwrap_or("".into()), loaded_sig.name());
     assert_eq!(sig.md5sum(), loaded_sig.md5sum());
 
     Ok(())

--- a/src/core/tests/storage.rs
+++ b/src/core/tests/storage.rs
@@ -98,7 +98,7 @@ fn innerstorage_save_sig() -> Result<(), Box<dyn std::error::Error>> {
 
     let loaded_sig = instorage.load_sig("test")?;
 
-    assert_eq!(sig.name().unwrap_or("".into()), loaded_sig.name());
+    assert_eq!(sig.name_str(), loaded_sig.name());
     assert_eq!(sig.md5sum(), loaded_sig.md5sum());
 
     Ok(())


### PR DESCRIPTION
This PR adjusts `Signature::name()` to return `None` when no name is set, instead of returning first `filename()` or (if empty) `md5sum()`. It also adds `name_str()` which returns an empty string, to avoid too many `unwrap_or` scattered throughout the codebase.

Fixes https://github.com/sourmash-bio/sourmash/issues/3441
