### PR TITLE
Deps: update to rocksdb 0.23

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -222,7 +222,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: check if README matches MSRV defined here
-        run: grep '1.66.0' src/core/README.md
+        run: grep '1.71.1' src/core/README.md
 
       - name: Check if it builds properly
         run: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -217,7 +217,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: "1.66.0"
+          toolchain: "1.71.1"
 
       - uses: Swatinem/rust-cache@v2
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,7 +8,7 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.10"
-    rust: "1.70"
+    rust: "1.75"
   apt_packages:
     - llvm-dev
     - libclang-dev

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -844,17 +844,15 @@ checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
 
 [[package]]
 name = "librocksdb-sys"
-version = "0.16.0+8.10.0"
+version = "0.17.1+9.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce3d60bc059831dc1c83903fb45c103f75db65c5a7bf22272764d9cc683e348c"
+checksum = "2b7869a512ae9982f4d46ba482c2a304f1efd80c6412a3d4bf57bb79a619679f"
 dependencies = [
  "bindgen",
  "bzip2-sys",
  "cc",
- "glob",
  "libc",
  "libz-sys",
- "lz4-sys",
  "zstd-sys",
 ]
 
@@ -895,16 +893,6 @@ name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
-
-[[package]]
-name = "lz4-sys"
-version = "1.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d27b317e207b10f69f5e75494119e391a96f48861ae870d1da6edac98ca900"
-dependencies = [
- "cc",
- "libc",
-]
 
 [[package]]
 name = "lzma-sys"
@@ -1457,9 +1445,9 @@ dependencies = [
 
 [[package]]
 name = "rocksdb"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bd13e55d6d7b8cd0ea569161127567cd587676c99f4472f779a0279aa60a7a7"
+checksum = "26ec73b20525cb235bad420f911473b69f9fe27cc856c5461bccd7e4af037f43"
 dependencies = [
  "libc",
  "librocksdb-sys",

--- a/flake.nix
+++ b/flake.nix
@@ -127,7 +127,7 @@
             #cargo-llvm-cov
             cargo-component
             cargo-codspeed
-            cargo-semver-checks
+            #cargo-semver-checks
             nixpkgs-fmt
           ];
 

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -108,7 +108,11 @@ chrono = { version = "0.4.32", features = ["wasmbind"] }
 wasm-bindgen-test = "0.3.42"
 
 ### These crates don't compile on wasm
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-rocksdb = { version = "0.22.0", optional = true }
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies.rocksdb]
+version = "0.23.0"
+optional = true
+default-features = false
+features = [ "bindgen-runtime", "snappy", "zstd" ]
+
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 criterion = "0.5.1"

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 readme = "README.md"
 autoexamples = false
 autobins = false
-rust-version = "1.66.0"
+rust-version = "1.71.1"
 
 [lib]
 name = "sourmash"

--- a/src/core/README.md
+++ b/src/core/README.md
@@ -38,4 +38,4 @@ Development happens on github at
 
 ## Minimum supported Rust version
 
-Currently the minimum supported Rust version is 1.66.0.
+Currently the minimum supported Rust version is 1.71.1.

--- a/src/core/src/encodings.rs
+++ b/src/core/src/encodings.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::hash::{BuildHasher, BuildHasherDefault, Hash, Hasher};
+use std::hash::{BuildHasher, BuildHasherDefault, Hash};
 use std::str;
 
 use nohash_hasher::BuildNoHashHasher;
@@ -469,9 +469,7 @@ impl Colors {
 
     fn compute_color(idxs: &IdxTracker) -> Color {
         let s = BuildHasherDefault::<twox_hash::Xxh3Hash128>::default();
-        let mut hasher = s.build_hasher();
-        idxs.0.hash(&mut hasher);
-        hasher.finish()
+        s.hash_one(&idxs.0)
     }
 
     pub fn len(&self) -> usize {

--- a/src/core/src/index/revindex/disk_revindex.rs
+++ b/src/core/src/index/revindex/disk_revindex.rs
@@ -1,5 +1,5 @@
 use std::cmp::max;
-use std::hash::{BuildHasher, BuildHasherDefault, Hash, Hasher};
+use std::hash::{BuildHasher, BuildHasherDefault};
 use std::path::Path;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, RwLock};
@@ -30,9 +30,7 @@ const DB_VERSION: u8 = 1;
 
 fn compute_color(idxs: &Datasets) -> Color {
     let s = BuildHasherDefault::<twox_hash::Xxh3Hash128>::default();
-    let mut hasher = s.build_hasher();
-    idxs.hash(&mut hasher);
-    hasher.finish()
+    s.hash_one(idxs)
 }
 
 #[derive(Clone)]
@@ -354,8 +352,7 @@ impl RevIndexOps for RevIndex {
 
                     let name = [row.name(), row.filename(), row.md5()]
                         .into_iter()
-                        .skip_while(|v| v.is_empty())
-                        .next()
+                        .find(|v| !v.is_empty())
                         .unwrap(); // guaranteed to succeed because `md5` always exists
 
                     Some((name.into(), size))


### PR DESCRIPTION
New rocksdb release: https://docs.rs/crate/rocksdb/0.23.0

Bump MSRV to 1.71, which currently accounts for >97% of crates downloads:
https://lib.rs/stats#rustc-usage