### PR TITLE
MRG: 4.8.13 release branch

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -63,7 +63,7 @@
 
           sourmash = python.buildPythonPackage ( commonArgs // rec {
             pname = "sourmash";
-            version = "4.8.12";
+            version = "4.8.13";
             format = "pyproject";
 
             cargoDeps = rustPlatform.importCargoLock {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = 'maturin'
 name = "sourmash"
 description = "tools for comparing biological sequences with k-mer sketches"
 readme = "README.md"
-version = "4.8.13-dev"
+version = "4.8.13"
 
 authors = [
   { name="Luiz Irber" },


### PR DESCRIPTION
Release issue: https://github.com/sourmash-bio/sourmash/issues/3481

----

NOTE: This release adds basic support for skipmers, but they are not
yet fully supported.

Minor new features:

* add genbank plant db to docs (#3429)
* add skipmer capacity to sourmash python layer via ffi (#3446)
* add skipmers; switch to reading frame approach for translation, skipmers (#3395)
* additional moltype specification needed for `sig downsample` with skipmers (#3457)
* update with misc animal genomes (#3422)

Cleanup and documentation updates:

* add comment about semver and column headings (#3433)

Developer updates:

* Deps: update to rocksdb 0.23 (#3456)
* Refactor: Use to_writer/from_reader across the codebase (#3443)
* adjust `Signature::name()` to return `Option<String>` instead of `filename()` and `md5sum()` (#3434)
* bump version to 4.8.13-dev (#3474)
* fix comment in _set_num_scaled (#3451)
* propagate zipfile errors (#3431)
* update rust CHANGELOG in preparation for r0.18.0 (#3450)
* CI: github actions updates (#3476)

Dependabot updates:

* Bump itertools from 0.13.0 to 0.14.0 (#3471)
* Bump needletail from 0.6.0 to 0.6.1 (#3427)
* Bump proptest from 1.5.0 to 1.6.0 (#3437)
* Bump roaring from 0.10.7 to 0.10.8 (#3423)
* Bump roaring from 0.10.8 to 0.10.9 (#3438)
* Bump serde from 1.0.215 to 1.0.216 (#3436)
* Bump serde from 1.0.216 to 1.0.217 (#3464)
* Bump serde_json from 1.0.133 to 1.0.134 (#3453)
* Bump statrs from 0.17.1 to 0.18.0 (#3426)
* Bump tempfile from 3.14.0 to 3.15.0 (#3472)
* Bump thiserror from 2.0.3 to 2.0.6 (#3425)
* Bump thiserror from 2.0.6 to 2.0.7 (#3435)
* Bump thiserror from 2.0.7 to 2.0.8 (#3448)
* Bump thiserror from 2.0.8 to 2.0.9 (#3452)
* Update maturin requirement from <1.8.0,>=1 to >=1,<1.9.0 (#3465)
* [pre-commit.ci] pre-commit autoupdate (#3428)
* [pre-commit.ci] pre-commit autoupdate (#3439)
* [pre-commit.ci] pre-commit autoupdate (#3454)
* [pre-commit.ci] pre-commit autoupdate (#3473)
