### PR TITLE
MRG: 4.8.14 release branch

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -63,7 +63,7 @@
 
           sourmash = python.buildPythonPackage ( commonArgs // rec {
             pname = "sourmash";
-            version = "4.8.13";
+            version = "4.8.14";
             format = "pyproject";
 
             cargoDeps = rustPlatform.importCargoLock {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = 'maturin'
 name = "sourmash"
 description = "tools for comparing biological sequences with k-mer sketches"
 readme = "README.md"
-version = "4.8.13"
+version = "4.8.14"
 
 authors = [
   { name="Luiz Irber" },


### PR DESCRIPTION
Developer updates:

* 4.8.14 release branch (#3493)

Dependabot updates:

- Bump serde_json from 1.0.134 to 1.0.135 (#3490)
- Bump roaring from 0.10.9 to 0.10.10 (#3489)
- Bump thiserror from 2.0.9 to 2.0.11 (#3488)
- Bump ouroboros from 0.18.4 to 0.18.5 (#3491)
- [pre-commit.ci] pre-commit autoupdate (#3492)