### PR TITLE
MRG: fix beta clippy errors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: check-toml
       - id: debug-statements
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.6
+    rev: v0.9.7
     hooks:
       - id: ruff-format
       - id: ruff

--- a/src/core/src/errors.rs
+++ b/src/core/src/errors.rs
@@ -166,9 +166,7 @@ impl SourmashErrorCode {
             SourmashError::Panic { .. } => SourmashErrorCode::Panic,
             SourmashError::CannotUpsampleScaled => SourmashErrorCode::CannotUpsampleScaled,
             SourmashError::MismatchNum { .. } => SourmashErrorCode::MismatchNum,
-            SourmashError::NeedsAbundanceTracking => {
-                SourmashErrorCode::NeedsAbundanceTracking
-            }
+            SourmashError::NeedsAbundanceTracking => SourmashErrorCode::NeedsAbundanceTracking,
             SourmashError::MismatchKSizes => SourmashErrorCode::MismatchKSizes,
             SourmashError::MismatchDNAProt => SourmashErrorCode::MismatchDNAProt,
             SourmashError::MismatchScaled => SourmashErrorCode::MismatchScaled,

--- a/src/core/src/errors.rs
+++ b/src/core/src/errors.rs
@@ -164,9 +164,9 @@ impl SourmashErrorCode {
         match error {
             SourmashError::Internal { .. } => SourmashErrorCode::Internal,
             SourmashError::Panic { .. } => SourmashErrorCode::Panic,
-            SourmashError::CannotUpsampleScaled { .. } => SourmashErrorCode::CannotUpsampleScaled,
+            SourmashError::CannotUpsampleScaled => SourmashErrorCode::CannotUpsampleScaled,
             SourmashError::MismatchNum { .. } => SourmashErrorCode::MismatchNum,
-            SourmashError::NeedsAbundanceTracking { .. } => {
+            SourmashError::NeedsAbundanceTracking => {
                 SourmashErrorCode::NeedsAbundanceTracking
             }
             SourmashError::MismatchKSizes => SourmashErrorCode::MismatchKSizes,
@@ -187,7 +187,7 @@ impl SourmashErrorCode {
             SourmashError::InvalidTranslateFrame { .. } => SourmashErrorCode::InvalidTranslateFrame,
             SourmashError::ReadDataError { .. } => SourmashErrorCode::ReadData,
             SourmashError::StorageError { .. } => SourmashErrorCode::Storage,
-            SourmashError::HLLPrecisionBounds { .. } => SourmashErrorCode::HLLPrecisionBounds,
+            SourmashError::HLLPrecisionBounds => SourmashErrorCode::HLLPrecisionBounds,
             SourmashError::ANIEstimationError { .. } => SourmashErrorCode::ANIEstimationError,
             SourmashError::SerdeError { .. } => SourmashErrorCode::SerdeError,
             SourmashError::IOError { .. } => SourmashErrorCode::Io,


### PR DESCRIPTION
Fixes errors encountered in #3547. Note: includes #3547!
```
error: struct pattern is not needed for a unit variant
   --> src/core/src/errors.rs:167:48
    |
167 |             SourmashError::CannotUpsampleScaled { .. } => SourmashErrorCode::CannotUpsampleScaled,
    |                                                ^^^^^^^ help: remove the struct pattern
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unneeded_struct_pattern
    = note: `-D clippy::unneeded-struct-pattern` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::unneeded_struct_pattern)]`

error: struct pattern is not needed for a unit variant
   --> src/core/src/errors.rs:169:50
    |
169 |             SourmashError::NeedsAbundanceTracking { .. } => {
    |                                                  ^^^^^^^ help: remove the struct pattern
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unneeded_struct_pattern

error: struct pattern is not needed for a unit variant
   --> src/core/src/errors.rs:190:46
    |
190 |             SourmashError::HLLPrecisionBounds { .. } => SourmashErrorCode::HLLPrecisionBounds,
    |                                              ^^^^^^^ help: remove the struct pattern
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unneeded_struct_pattern
```