### PR TITLE
WIP: simplify `RevIndex` in Python & expand functionality

### DIFF
--- a/include/sourmash.h
+++ b/include/sourmash.h
@@ -388,20 +388,9 @@ const SourmashSearchResult *const *revindex_gather(const SourmashRevIndex *ptr,
 
 uint64_t revindex_len(const SourmashRevIndex *ptr);
 
-SourmashRevIndex *revindex_new_with_paths(const SourmashStr *const *search_sigs_ptr,
-                                          uintptr_t insigs,
-                                          const SourmashKmerMinHash *template_ptr,
-                                          uintptr_t threshold,
-                                          const SourmashKmerMinHash *const *queries_ptr,
-                                          uintptr_t inqueries,
-                                          bool keep_sigs);
-
 SourmashRevIndex *revindex_new_with_sigs(const SourmashSignature *const *search_sigs_ptr,
                                          uintptr_t insigs,
-                                         const SourmashKmerMinHash *template_ptr,
-                                         uintptr_t threshold,
-                                         const SourmashKmerMinHash *const *queries_ptr,
-                                         uintptr_t inqueries);
+                                         const SourmashKmerMinHash *template_ptr);
 
 ScaledType revindex_scaled(const SourmashRevIndex *ptr);
 

--- a/src/core/src/ffi/index/revindex.rs
+++ b/src/core/src/ffi/index/revindex.rs
@@ -52,6 +52,7 @@ fn from_template(template: &Sketch) -> Selection {
         .build()
 }
 
+/*
 ffi_fn! {
 unsafe fn revindex_new_with_paths(
     search_sigs_ptr: *const *const SourmashStr,
@@ -105,15 +106,13 @@ unsafe fn revindex_new_with_paths(
     Ok(SourmashRevIndex::from_rust(revindex))
 }
 }
+*/
 
 ffi_fn! {
 unsafe fn revindex_new_with_sigs(
     search_sigs_ptr: *const *const SourmashSignature,
     insigs: usize,
     template_ptr: *const SourmashKmerMinHash,
-    threshold: usize,
-    queries_ptr: *const *const SourmashKmerMinHash,
-    inqueries: usize,
 ) -> Result<*mut SourmashRevIndex> {
     let search_sigs: Vec<Signature> = {
         assert!(!search_sigs_ptr.is_null());
@@ -130,6 +129,8 @@ unsafe fn revindex_new_with_sigs(
         Sketch::MinHash(SourmashKmerMinHash::as_rust(template_ptr).clone())
     };
 
+    let queries = None;
+/*
     let queries_vec: Vec<KmerMinHash>;
     let queries: Option<&[KmerMinHash]> = if queries_ptr.is_null() {
         None
@@ -142,8 +143,9 @@ unsafe fn revindex_new_with_sigs(
             .collect();
         Some(queries_vec.as_ref())
     };
-
+*/
     let selection = from_template(&template);
+    let threshold = 0;
     let revindex = mem_revindex::RevIndex::new_with_sigs(search_sigs, &selection, threshold, queries)?;
     Ok(SourmashRevIndex::from_rust(revindex))
 }

--- a/src/core/src/ffi/index/revindex.rs
+++ b/src/core/src/ffi/index/revindex.rs
@@ -1,17 +1,14 @@
 use std::slice;
 
-use camino::Utf8PathBuf as PathBuf;
-
 use crate::encodings::*;
 use crate::ffi::index::SourmashSearchResult;
 use crate::ffi::minhash::SourmashKmerMinHash;
 use crate::ffi::signature::SourmashSignature;
-use crate::ffi::utils::{ForeignObject, SourmashStr};
+use crate::ffi::utils::ForeignObject;
 use crate::index::revindex::mem_revindex;
 use crate::index::Index;
 use crate::prelude::*;
 use crate::signature::{Signature, SigsTrait};
-use crate::sketch::minhash::KmerMinHash;
 use crate::sketch::Sketch;
 use crate::ScaledType;
 
@@ -129,24 +126,8 @@ unsafe fn revindex_new_with_sigs(
         Sketch::MinHash(SourmashKmerMinHash::as_rust(template_ptr).clone())
     };
 
-    let queries = None;
-/*
-    let queries_vec: Vec<KmerMinHash>;
-    let queries: Option<&[KmerMinHash]> = if queries_ptr.is_null() {
-        None
-    } else {
-        queries_vec = slice::from_raw_parts(queries_ptr, inqueries)
-            .iter()
-            .map(|mh_ptr|
-            // TODO: avoid this clone
-          SourmashKmerMinHash::as_rust(*mh_ptr).clone())
-            .collect();
-        Some(queries_vec.as_ref())
-    };
-*/
     let selection = from_template(&template);
-    let threshold = 0;
-    let revindex = mem_revindex::RevIndex::new_with_sigs(search_sigs, &selection, threshold, queries)?;
+    let revindex = mem_revindex::RevIndex::new_with_sigs(search_sigs, &selection, 0, None)?;
     Ok(SourmashRevIndex::from_rust(revindex))
 }
 }

--- a/src/core/src/ffi/index/revindex.rs
+++ b/src/core/src/ffi/index/revindex.rs
@@ -35,7 +35,7 @@ fn from_template(template: &Sketch) -> Selection {
     let adj_ksize: u32 = match moltype {
         HashFunctions::Murmur64Dna => ksize,
         HashFunctions::Murmur64Protein => ksize / 3,
-        HashFunctions::Murmur64Dayhoff => ksize /  3,
+        HashFunctions::Murmur64Dayhoff => ksize / 3,
         HashFunctions::Murmur64Hp => ksize / 3,
         HashFunctions::Murmur64Skipm1n3 => ksize,
         HashFunctions::Murmur64Skipm2n3 => ksize,

--- a/src/core/src/index/revindex/mem_revindex.rs
+++ b/src/core/src/index/revindex/mem_revindex.rs
@@ -13,6 +13,7 @@ use crate::index::linear::LinearIndex;
 use crate::index::revindex::HashToColor;
 use crate::index::{GatherResult, Index, SigCounter};
 use crate::prelude::*;
+use crate::ScaledType;
 use crate::signature::{Signature, SigsTrait};
 use crate::sketch::minhash::KmerMinHash;
 use crate::sketch::Sketch;
@@ -236,6 +237,14 @@ impl RevIndex {
         self.linear.template().clone()
     }
 
+    pub fn scaled(&self) -> ScaledType {
+        if let Sketch::MinHash(mh) = self.linear.template() {
+            mh.clone().scaled() // @CTB avoid clone
+        } else {
+            unimplemented!()
+        }
+    }
+
     // TODO: mh should be a sketch, or even a sig...
     pub(crate) fn find_signatures(
         &self,
@@ -244,10 +253,13 @@ impl RevIndex {
         containment: bool,
         _ignore_scaled: bool,
     ) -> Result<Vec<(f64, Signature, String)>> {
+        let scaled = self.scaled();
+        // @CTB avoid clone?
+        let query_mh = mh.clone().downsample_scaled(scaled).expect("cannot downsample query");
         // TODO: proper threshold calculation
-        let threshold: usize = (threshold * (mh.size() as f64)) as _;
+        let threshold: usize = (threshold * (query_mh.size() as f64)) as _;
 
-        let counter = self.counter_for_query(mh);
+        let counter = self.counter_for_query(&query_mh);
 
         debug!(
             "number of matching signatures for hashes: {}",
@@ -266,6 +278,7 @@ impl RevIndex {
                 .internal_location();
 
             let mut match_mh = None;
+            //@CTB use something other than mh here?
             if let Some(Sketch::MinHash(mh)) = match_sig.select_sketch(self.linear.template()) {
                 match_mh = Some(mh);
             }
@@ -273,9 +286,9 @@ impl RevIndex {
 
             if size >= threshold {
                 let score = if containment {
-                    size as f64 / mh.size() as f64
+                    size as f64 / query_mh.size() as f64
                 } else {
-                    mh.jaccard(match_mh).expect("cannot calculate Jaccard")
+                    query_mh.jaccard(match_mh).expect("cannot calculate Jaccard")
                 };
                 let filename = match_path.to_string();
                 let mut sig: Signature = match_sig.clone().into();

--- a/src/core/src/index/revindex/mem_revindex.rs
+++ b/src/core/src/index/revindex/mem_revindex.rs
@@ -13,11 +13,11 @@ use crate::index::linear::LinearIndex;
 use crate::index::revindex::HashToColor;
 use crate::index::{GatherResult, Index, SigCounter};
 use crate::prelude::*;
-use crate::ScaledType;
 use crate::signature::{Signature, SigsTrait};
 use crate::sketch::minhash::KmerMinHash;
 use crate::sketch::Sketch;
 use crate::Result;
+use crate::ScaledType;
 
 pub struct RevIndex {
     linear: LinearIndex,
@@ -259,8 +259,7 @@ impl RevIndex {
         // @CTB avoid clones?
         let query_mh = {
             if query_scaled < index_scaled {
-                mh
-                    .clone()
+                mh.clone()
                     .downsample_scaled(index_scaled)
                     .expect("cannot downsample query")
             } else {
@@ -280,7 +279,9 @@ impl RevIndex {
 
         let mut results = vec![];
         for (dataset_id, size) in counter.most_common() {
-            if size < threshold { break };
+            if size < threshold {
+                break;
+            };
 
             let match_sig = self.linear.sig_for_dataset(dataset_id)?;
             let match_path = self
@@ -300,7 +301,9 @@ impl RevIndex {
                 let score = if containment {
                     size as f64 / query_mh.size() as f64
                 } else {
-                    query_mh.jaccard(match_mh).expect("cannot calculate Jaccard")
+                    query_mh
+                        .jaccard(match_mh)
+                        .expect("cannot calculate Jaccard")
                 };
                 let filename = match_path.to_string();
                 let mut sig: Signature = match_sig.clone().into();

--- a/src/core/src/index/revindex/mem_revindex.rs
+++ b/src/core/src/index/revindex/mem_revindex.rs
@@ -256,7 +256,7 @@ impl RevIndex {
 
         let mut results = vec![];
         for (dataset_id, size) in counter.most_common() {
-            let match_size = if size >= threshold { size } else { break };
+            if size < threshold { break };
 
             let match_sig = self.linear.sig_for_dataset(dataset_id)?;
             let match_path = self

--- a/src/core/src/index/revindex/mem_revindex.rs
+++ b/src/core/src/index/revindex/mem_revindex.rs
@@ -253,9 +253,21 @@ impl RevIndex {
         containment: bool,
         _ignore_scaled: bool,
     ) -> Result<Vec<(f64, Signature, String)>> {
-        let scaled = self.scaled();
-        // @CTB avoid clone?
-        let query_mh = mh.clone().downsample_scaled(scaled).expect("cannot downsample query");
+        let index_scaled = self.scaled();
+        let query_scaled = mh.scaled();
+
+        // @CTB avoid clones?
+        let query_mh = {
+            if query_scaled < index_scaled {
+                mh
+                    .clone()
+                    .downsample_scaled(index_scaled)
+                    .expect("cannot downsample query")
+            } else {
+                mh.clone()
+            }
+        };
+
         // TODO: proper threshold calculation
         let threshold: usize = (threshold * (query_mh.size() as f64)) as _;
 

--- a/src/sourmash/commands.py
+++ b/src/sourmash/commands.py
@@ -942,7 +942,7 @@ def gather(args):
 
     if args.linear:  # force linear traversal?
         databases = [LazyLinearIndex(db) for db in databases]
-    else:
+    elif 0:
         # @CTB foo revindex
         from sourmash.index.revindex import RevIndex
         from sourmash.index import ZipFileLinearIndex

--- a/src/sourmash/commands.py
+++ b/src/sourmash/commands.py
@@ -944,6 +944,7 @@ def gather(args):
         databases = [LazyLinearIndex(db) for db in databases]
     elif 1:
         # @CTB foo revindex
+        print('XXX NOTE: using RevIndex for ZipFileLinearIndex')
         from sourmash.index.revindex import RevIndex
         from sourmash.index import ZipFileLinearIndex
 

--- a/src/sourmash/commands.py
+++ b/src/sourmash/commands.py
@@ -944,7 +944,7 @@ def gather(args):
         databases = [LazyLinearIndex(db) for db in databases]
     elif 1:
         # @CTB foo revindex
-        print('XXX NOTE: using RevIndex for ZipFileLinearIndex')
+        print("XXX NOTE: using RevIndex for ZipFileLinearIndex")
         from sourmash.index.revindex import RevIndex
         from sourmash.index import ZipFileLinearIndex
 

--- a/src/sourmash/commands.py
+++ b/src/sourmash/commands.py
@@ -942,7 +942,7 @@ def gather(args):
 
     if args.linear:  # force linear traversal?
         databases = [LazyLinearIndex(db) for db in databases]
-    elif 0:
+    elif 1:
         # @CTB foo revindex
         from sourmash.index.revindex import RevIndex
         from sourmash.index import ZipFileLinearIndex

--- a/src/sourmash/commands.py
+++ b/src/sourmash/commands.py
@@ -942,7 +942,7 @@ def gather(args):
 
     if args.linear:  # force linear traversal?
         databases = [LazyLinearIndex(db) for db in databases]
-    elif 1:
+    elif 0:
         # @CTB foo revindex
         print("XXX NOTE: using RevIndex for ZipFileLinearIndex")
         from sourmash.index.revindex import RevIndex

--- a/src/sourmash/commands.py
+++ b/src/sourmash/commands.py
@@ -946,6 +946,7 @@ def gather(args):
         # @CTB foo revindex
         from sourmash.index.revindex import RevIndex
         from sourmash.index import ZipFileLinearIndex
+
         xx = []
         for db in databases:
             if isinstance(db, ZipFileLinearIndex):

--- a/src/sourmash/index/__init__.py
+++ b/src/sourmash/index/__init__.py
@@ -311,7 +311,7 @@ class Index(ABC):
         with query.update() as prefetch_query:
             prefetch_query.minhash = prefetch_query.minhash.flatten()
 
-        if 1:  # @CTB
+        if 0:  # @CTB
             # find all matches and construct a CounterGather object.
             counter = CounterGather(prefetch_query)
             for result in self.prefetch(prefetch_query, threshold_bp, **kwargs):
@@ -320,6 +320,7 @@ class Index(ABC):
             # tada!
             return counter
         else:
+            print('XXX NOTE: Using RevIndex CounterGather')
             from .revindex import RevIndex
 
             revindex = RevIndex(template=prefetch_query.minhash)

--- a/src/sourmash/index/__init__.py
+++ b/src/sourmash/index/__init__.py
@@ -323,7 +323,7 @@ class Index(ABC):
             from .revindex import RevIndex
 
             revindex = RevIndex(template=prefetch_query.minhash)
-            #return revindex.CounterGather(prefetch_query, threshold_bp, **kwargs)
+            # return revindex.CounterGather(prefetch_query, threshold_bp, **kwargs)
 
             for result in self.prefetch(prefetch_query, threshold_bp, **kwargs):
                 revindex.insert(result.signature)

--- a/src/sourmash/index/__init__.py
+++ b/src/sourmash/index/__init__.py
@@ -321,16 +321,21 @@ class Index(ABC):
             return counter
         else:
             print('XXX NOTE: Using RevIndex CounterGather')
-            from .revindex import RevIndex
+            from .revindex import RevIndex_CounterGather, RevIndex
 
             revindex = RevIndex(template=prefetch_query.minhash)
-            # return revindex.CounterGather(prefetch_query, threshold_bp, **kwargs)
+            cg = RevIndex_CounterGather(prefetch_query, revindex, threshold_bp,
+                                        allow_insert=True)
 
+            n_added = 0
             for result in self.prefetch(prefetch_query, threshold_bp, **kwargs):
-                revindex.insert(result.signature)
+                cg.add(result.signature, location=result.location)
+                n_added += 1
 
-            # this is like double jeopardy... @CTB
-            return revindex.counter_gather(prefetch_query, threshold_bp)
+            if n_added == 0:
+                raise ValueError("no signatures to count")
+
+            return cg
 
     @abstractmethod
     def select(

--- a/src/sourmash/index/__init__.py
+++ b/src/sourmash/index/__init__.py
@@ -311,7 +311,7 @@ class Index(ABC):
         with query.update() as prefetch_query:
             prefetch_query.minhash = prefetch_query.minhash.flatten()
 
-        if 1: # @CTB
+        if 1:  # @CTB
             # find all matches and construct a CounterGather object.
             counter = CounterGather(prefetch_query)
             for result in self.prefetch(prefetch_query, threshold_bp, **kwargs):
@@ -321,6 +321,7 @@ class Index(ABC):
             return counter
         else:
             from .revindex import RevIndex
+
             revindex = RevIndex(template=prefetch_query.minhash)
 
             for result in self.prefetch(prefetch_query, threshold_bp, **kwargs):

--- a/src/sourmash/index/__init__.py
+++ b/src/sourmash/index/__init__.py
@@ -311,7 +311,7 @@ class Index(ABC):
         with query.update() as prefetch_query:
             prefetch_query.minhash = prefetch_query.minhash.flatten()
 
-        if 0: # @CTB
+        if 1: # @CTB
             # find all matches and construct a CounterGather object.
             counter = CounterGather(prefetch_query)
             for result in self.prefetch(prefetch_query, threshold_bp, **kwargs):

--- a/src/sourmash/index/__init__.py
+++ b/src/sourmash/index/__init__.py
@@ -311,7 +311,7 @@ class Index(ABC):
         with query.update() as prefetch_query:
             prefetch_query.minhash = prefetch_query.minhash.flatten()
 
-        if 1:  # @CTB
+        if 0:  # @CTB
             # find all matches and construct a CounterGather object.
             counter = CounterGather(prefetch_query)
             for result in self.prefetch(prefetch_query, threshold_bp, **kwargs):
@@ -323,10 +323,12 @@ class Index(ABC):
             from .revindex import RevIndex
 
             revindex = RevIndex(template=prefetch_query.minhash)
+            #return revindex.CounterGather(prefetch_query, threshold_bp, **kwargs)
 
             for result in self.prefetch(prefetch_query, threshold_bp, **kwargs):
                 revindex.insert(result.signature)
 
+            # this is like double jeopardy... @CTB
             return revindex.counter_gather(prefetch_query, threshold_bp)
 
     @abstractmethod

--- a/src/sourmash/index/__init__.py
+++ b/src/sourmash/index/__init__.py
@@ -320,12 +320,13 @@ class Index(ABC):
             # tada!
             return counter
         else:
-            print('XXX NOTE: Using RevIndex CounterGather')
+            print("XXX NOTE: Using RevIndex CounterGather")
             from .revindex import RevIndex_CounterGather, RevIndex
 
             revindex = RevIndex(template=prefetch_query.minhash)
-            cg = RevIndex_CounterGather(prefetch_query, revindex, threshold_bp,
-                                        allow_insert=True)
+            cg = RevIndex_CounterGather(
+                prefetch_query, revindex, threshold_bp, allow_insert=True
+            )
 
             n_added = 0
             for result in self.prefetch(prefetch_query, threshold_bp, **kwargs):

--- a/src/sourmash/index/__init__.py
+++ b/src/sourmash/index/__init__.py
@@ -311,7 +311,7 @@ class Index(ABC):
         with query.update() as prefetch_query:
             prefetch_query.minhash = prefetch_query.minhash.flatten()
 
-        if 0:  # @CTB
+        if 1:  # @CTB
             # find all matches and construct a CounterGather object.
             counter = CounterGather(prefetch_query)
             for result in self.prefetch(prefetch_query, threshold_bp, **kwargs):

--- a/src/sourmash/index/revindex.py
+++ b/src/sourmash/index/revindex.py
@@ -29,6 +29,7 @@ class RevIndex(RustObject):  # , Index):
         self.template = template.copy_and_clear().to_mutable()
         self._scaled = template.scaled
         self._signatures = []
+        self._orig_signatures = {}
         self._objptr = ffi.NULL
 
     def _check_not_init(self, *, do_raise=True):
@@ -65,6 +66,11 @@ class RevIndex(RustObject):  # , Index):
             sigs_size,
             template_ptr,
         )
+
+        for n, (orig_ss, stored_ss) in enumerate(zip(self._signatures,
+                                                     self.signatures())):
+            self._orig_signatures[stored_ss.md5sum()] = orig_ss
+
 
     def signatures(self):
         self._init_inner()
@@ -188,8 +194,10 @@ class RevIndex(RustObject):  # , Index):
         for i in range(size):
             match = SearchResult._from_objptr(results_ptr[i])
             if match.score >= threshold:
+                match_md5 = match.signature.md5sum()
+                orig_ss = self._orig_signatures[match_md5]
                 results.append(
-                    IndexSearchResult(match.score, match.signature, match.location)
+                    IndexSearchResult(match.score, orig_ss, match.location)
                 )
 
         return results

--- a/src/sourmash/index/revindex.py
+++ b/src/sourmash/index/revindex.py
@@ -21,28 +21,12 @@ class RevIndex(RustObject): #, Index):
     is_database = True
     location = None
 
-    def __init__(
-        self,
-        *,
-        signatures=None,
-        signature_paths=None,
-        template=None,
-        threshold=0,
-        queries=None,
-        keep_sigs=False,
-    ):
-        self.template = template.to_mutable()
-        self.threshold = threshold
-        self.queries = queries
-        self.keep_sigs = keep_sigs
-        self.signature_paths = signature_paths
-        self._signatures = signatures
-
-        if signature_paths is None or signatures is None:
-            # delay initialization
-            self._objptr = ffi.NULL
-        else:
-            self._init_inner()
+    def __init__(self, *, template=None):
+        assert template is not None
+        assert isinstance(template, MinHash)
+        self.template = template
+        self._signatures = []
+        self._objptr = ffi.NULL
 
     def _check_init(self):
         if self._objptr != ffi.NULL:
@@ -53,71 +37,25 @@ class RevIndex(RustObject): #, Index):
             # Already initialized
             return
 
-        if (
-            self.signature_paths is None
-            and not self._signatures
-            and self._objptr == ffi.NULL
-        ):
+        if not self._signatures and self._objptr == ffi.NULL:
             raise ValueError("No signatures provided")
-        elif (self.signature_paths or self._signatures) and self._objptr != ffi.NULL:
-            raise NotImplementedError("Need to update RevIndex")
 
-        attached_refs = weakref.WeakKeyDictionary()
-
-        queries_ptr = ffi.NULL
-        queries_size = 0
-        if self.queries:
-            # get list of rust objects
-            collected = []
-            for obj in queries:
-                rv = obj._get_objptr()
-                attached_refs[rv] = obj
-                collected.append(rv)
-            queries_ptr = ffi.new("SourmashSignature*[]", collected)
-            queries_size = len(queries)
-
-        template_ptr = ffi.NULL
-        if self.template:
-            if isinstance(self.template, MinHash):
-                template_ptr = self.template._get_objptr()
-            else:
-                raise ValueError("Template must be a MinHash")
+        template_ptr = self.template._get_objptr()
 
         search_sigs_ptr = ffi.NULL
         sigs_size = 0
         collected = []
-        if self.signature_paths:
-            for path in self.signature_paths:
-                collected.append(encode_str(path))
-            search_sigs_ptr = ffi.new("SourmashStr*[]", collected)
-            sigs_size = len(signature_paths)
-
-            self._objptr = rustcall(
-                lib.revindex_new_with_paths,
-                search_sigs_ptr,
-                sigs_size,
-                template_ptr,
-                self.threshold,
-                queries_ptr,
-                queries_size,
-                self.keep_sigs,
-            )
-        elif self._signatures:
-            # force keep_sigs=True, and pass SourmashSignature directly to RevIndex.
-            for sig in self._signatures:
-                collected.append(sig._get_objptr())
+        for sig in self._signatures:
+            collected.append(sig._get_objptr())
             search_sigs_ptr = ffi.new("SourmashSignature*[]", collected)
             sigs_size = len(self._signatures)
 
-            self._objptr = rustcall(
-                lib.revindex_new_with_sigs,
-                search_sigs_ptr,
-                sigs_size,
-                template_ptr,
-                self.threshold,
-                queries_ptr,
-                queries_size,
-            )
+        self._objptr = rustcall(
+            lib.revindex_new_with_sigs,
+            search_sigs_ptr,
+            sigs_size,
+            template_ptr,
+        )
 
     def signatures(self):
         self._init_inner()
@@ -134,25 +72,16 @@ class RevIndex(RustObject): #, Index):
         for sig in sigs:
             yield sig
 
-        # if self._signatures:
-        #    yield from self._signatures
-        # else:
-        #    raise NotImplementedError("Call into Rust and retrieve sigs")
-
     def signatures_with_location(self):
         for ss in self.signatures():
-            yield ss, self.location
+            yield ss, self.location # @CTB
 
     def __len__(self):
-        if self._objptr:
-            return self._methodcall(lib.revindex_len)
-        else:
-            return len(self._signatures)
+        self._init_inner()
+        return self._methodcall(lib.revindex_len)
 
     def insert(self, node):
         self._check_init()
-        if self._signatures is None:
-            self._signatures = []
         self._signatures.append(node)
 
     def save(self, path):
@@ -250,38 +179,9 @@ class RevIndex(RustObject): #, Index):
 
         return results
 
-    #    def gather(self, query, *args, **kwargs):
-    #        "Return the match with the best Jaccard containment in the database."
-    #        if not query.minhash:
-    #            return []
-    #
-    #        self._init_inner()
-    #
-    #        threshold_bp = kwargs.get("threshold_bp", 0.0)
-    #        threshold = threshold_bp / (len(query.minhash) * self.scaled)
-    #
-    #        results = []
-    #        size = ffi.new("uintptr_t *")
-    #        results_ptr = self._methodcall(
-    #            lib.revindex_gather, query._get_objptr(), threshold, True, True, size
-    #        )
-    #        size = size[0]
-    #        if size == 0:
-    #            return []
-    #
-    #        results = []
-    #        for i in range(size):
-    #            match = SearchResult._from_objptr(results_ptr[i])
-    #            if match.score >= threshold:
-    #                results.append(IndexSearchResult(match.score, match.signature, match.filename))
-    #
-    #        results.sort(reverse=True,
-    #                     key=lambda x: (x.score, x.signature.md5sum()))
-    #
-    #        return results[:1]
-
     @property
     def scaled(self):
+        self._init_inner()
         return self._methodcall(lib.revindex_scaled)
 
     def prefetch(self, query_ss, threshold_bp=0, **kwargs):

--- a/src/sourmash/index/revindex.py
+++ b/src/sourmash/index/revindex.py
@@ -15,7 +15,7 @@ from sourmash.minhash import flatten_and_intersect_scaled
 from sourmash.manifest import CollectionManifest
 
 
-class RevIndex(RustObject): #, Index):
+class RevIndex(RustObject):  # , Index):
     __dealloc_func__ = lib.revindex_free
     manifest = None
     is_database = True
@@ -75,7 +75,7 @@ class RevIndex(RustObject): #, Index):
 
     def signatures_with_location(self):
         for ss in self.signatures():
-            yield ss, self.location # @CTB
+            yield ss, self.location  # @CTB
 
     def __len__(self):
         self._init_inner()
@@ -83,7 +83,9 @@ class RevIndex(RustObject): #, Index):
 
     def insert(self, sig):
         if sig.minhash.scaled > self._scaled:
-            raise Exception(f"insert scaled {sig.minhash.scaled} is higher than template scaled {self._scaled}")
+            raise Exception(
+                f"insert scaled {sig.minhash.scaled} is higher than template scaled {self._scaled}"
+            )
         self._check_init()
         self._signatures.append(sig)
 
@@ -103,7 +105,8 @@ class RevIndex(RustObject): #, Index):
         abund=None,
         containment=None,
         picklist=None,
-        **kwargs):
+        **kwargs,
+    ):
         _check_select_parameters(
             ksize=ksize,
             moltype=moltype,
@@ -178,7 +181,9 @@ class RevIndex(RustObject): #, Index):
         for i in range(size):
             match = SearchResult._from_objptr(results_ptr[i])
             if match.score >= threshold:
-                results.append(IndexSearchResult(match.score, match.signature, match.location))
+                results.append(
+                    IndexSearchResult(match.score, match.signature, match.location)
+                )
 
         return results
 
@@ -200,8 +205,7 @@ class RevIndex(RustObject): #, Index):
         if not query_mh:
             raise ValueError("empty query")
         threshold = threshold_bp / query_mh.scaled / len(query_mh)
-        results = self.search(query_ss, threshold=threshold,
-                              do_containment=True)
+        results = self.search(query_ss, threshold=threshold, do_containment=True)
 
         if results:
             results.sort(key=lambda x: -x.score)
@@ -362,7 +366,7 @@ class DiskRevIndex(RustObject, Index):
                 raise ValueError(f"revindex ksize is {my_ksize}, not {ksize}")
         if scaled is not None and scaled < my_scaled:
             raise ValueError(f"revindex scaled is {my_scaled}, not {scaled}")
-        if 0 and moltype is not None and moltype != my_moltype: #  @CTB
+        if 0 and moltype is not None and moltype != my_moltype:  #  @CTB
             raise ValueError(f"revindex moltype is {my_moltype}, not {moltype}")
 
         if picklist is not None:

--- a/src/sourmash/index/revindex.py
+++ b/src/sourmash/index/revindex.py
@@ -585,7 +585,6 @@ class RevIndex_CounterGather:
 
     def add(self, match_ss, *, location=None, require_overlap=True):  # @CTB location
         if self.allow_insert:
-            self.db._check_not_init(do_raise=False)
             if self.db._check_not_init(do_raise=False):
                 self.db.insert(match_ss)
             else:

--- a/src/sourmash/index/revindex.py
+++ b/src/sourmash/index/revindex.py
@@ -574,9 +574,9 @@ class RevIndex_CounterGather:
         self.allow_insert = allow_insert
         self.locations = dict()
 
-    def add(self, match_ss, *, location=None, require_overlap=True): # @CTB location
+    def add(self, match_ss, *, location=None, require_overlap=True):  # @CTB location
         if self.allow_insert:
-            x = self.db._check_not_init(do_raise=False)
+            self.db._check_not_init(do_raise=False)
             if self.db._check_not_init(do_raise=False):
                 self.db.insert(match_ss)
             else:
@@ -592,13 +592,13 @@ class RevIndex_CounterGather:
 
         self.found_mh += intersect_mh
 
-    def peek(self, query_mh, *, threshold_bp=0): # threshold_bp default?? @CTB
+    def peek(self, query_mh, *, threshold_bp=0):  # threshold_bp default?? @CTB
         if not query_mh:
             return []
 
         if query_mh.contained_by(self.orig_query_mh) != 1.0:
             raise ValueError
-        #assert threshold_bp is not None
+        # assert threshold_bp is not None
 
         res = self.db.peek(query_mh, threshold_bp=threshold_bp)
         if not res:
@@ -607,8 +607,7 @@ class RevIndex_CounterGather:
         sr, intersect_mh = res
         sr_ss = sr.signature
         sr_score = sr.score
-        new_sr = IndexSearchResult(sr_score, sr_ss,
-                                   self.locations[sr_ss.md5sum()])
+        new_sr = IndexSearchResult(sr_score, sr_ss, self.locations[sr_ss.md5sum()])
         return new_sr, intersect_mh
 
     def consume(self, intersect_mh):

--- a/src/sourmash/index/revindex.py
+++ b/src/sourmash/index/revindex.py
@@ -242,8 +242,8 @@ class RevIndex(RustObject):  # , Index):
         self._init_inner()
 
         counter = RevIndex_CounterGather(query, self, threshold_bp)
-        #for result in self.prefetch(query, threshold_bp=threshold_bp):
-        #    counter.add(result.signature)
+        for result in self.prefetch(query, threshold_bp=threshold_bp):
+            counter.add(result.signature)
 
         return counter
 

--- a/src/sourmash/index/revindex.py
+++ b/src/sourmash/index/revindex.py
@@ -623,6 +623,12 @@ class RevIndex_CounterGather:
 
     def consume(self, intersect_mh):
         self.db._init_inner()
+
+        if self.found_mh.scaled < intersect_mh.scaled:
+            self.found_mh = self.found_mh.downsample(scaled=intersect_mh.scaled)
+        elif self.found_mh.scaled > intersect_mh.scaled:
+            intersect_mh = intersect_mh.downsample(scaled=self.found_mh.scaled)
+
         self.found_mh += intersect_mh
 
     @property

--- a/src/sourmash/index/revindex.py
+++ b/src/sourmash/index/revindex.py
@@ -618,7 +618,7 @@ class RevIndex_CounterGather:
         sr, intersect_mh = res
         sr_ss = sr.signature
         sr_score = sr.score
-        new_sr = IndexSearchResult(sr_score, sr_ss, self.locations[sr_ss.md5sum()])
+        new_sr = IndexSearchResult(sr_score, sr_ss, self.locations.get(sr_ss.md5sum()))
         return new_sr, intersect_mh
 
     def consume(self, intersect_mh):

--- a/src/sourmash/index/revindex.py
+++ b/src/sourmash/index/revindex.py
@@ -24,14 +24,19 @@ class RevIndex(RustObject):  # , Index):
     def __init__(self, *, template=None):
         assert template is not None
         assert isinstance(template, MinHash)
+        if template.num != 0:
+            raise ValueError("must use scaled sketches")
         self.template = template.copy_and_clear().to_mutable()
         self._scaled = template.scaled
         self._signatures = []
         self._objptr = ffi.NULL
 
-    def _check_not_init(self):
+    def _check_not_init(self, *, do_raise=True):
         if self._objptr != ffi.NULL:
-            raise Exception("already initialized")
+            if do_raise:
+                raise Exception("already initialized")
+            return False
+        return True
 
     def _init_inner(self):
         if self._objptr != ffi.NULL:
@@ -572,12 +577,22 @@ class RevIndex_CounterGather:
         self.threshold_bp = threshold_bp
         self.allow_insert = allow_insert
 
-    def add(self, match_ss, location=None): # @CTB location
+    def add(self, match_ss, *, location=None, require_overlap=True): # @CTB location
         if self.allow_insert:
-            self.db.insert(match_ss)
+            x = self.db._check_not_init(do_raise=False)
+            print('checking', x)
+            if self.db._check_not_init(do_raise=False):
+                print('not init')
+                self.db.insert(match_ss)
+            else:
+                raise ValueError
+
         query_mh = self.orig_query_mh
         match_mh = match_ss.minhash.downsample(scaled=query_mh.scaled)
         intersect_mh = query_mh.intersection(match_mh.flatten())
+        if require_overlap and not intersect_mh:
+            raise ValueError("require overlap")
+
         self.found_mh += intersect_mh
 
     def peek(self, query_mh, *, threshold_bp=0): # threshold_bp default?? @CTB
@@ -591,6 +606,7 @@ class RevIndex_CounterGather:
         return self.db.peek(query_mh, threshold_bp=threshold_bp)
 
     def consume(self, intersect_mh):
+        self.db._init_inner()
         self.found_mh += intersect_mh
 
     @property

--- a/src/sourmash/index/revindex.py
+++ b/src/sourmash/index/revindex.py
@@ -234,7 +234,7 @@ class RevIndex(RustObject):  # , Index):
             match_mh = found[0].signature.minhash.flatten()
             intersect_mh = match_mh.intersection(query_mh.flatten())
             return found[0], intersect_mh
-        return None
+        return []
 
     def consume(self, intersect_mh):
         pass
@@ -559,7 +559,7 @@ class RevIndex_CounterGather:
     while passing most calls back to the parent RevIndex.
     """
 
-    def __init__(self, query, db, threshold_bp):
+    def __init__(self, query, db, threshold_bp, *, allow_insert=False):
         """
         Initialize a CounterGather obj.
 
@@ -570,15 +570,23 @@ class RevIndex_CounterGather:
         self.found_mh = query.minhash.copy_and_clear().to_mutable()
         self.db = db
         self.threshold_bp = threshold_bp
+        self.allow_insert = allow_insert
 
-    def add(self, match):
+    def add(self, match_ss, location=None): # @CTB location
+        if self.allow_insert:
+            self.db.insert(match_ss)
         query_mh = self.orig_query_mh
-        match_mh = match.minhash.downsample(scaled=query_mh.scaled)
+        match_mh = match_ss.minhash.downsample(scaled=query_mh.scaled)
         intersect_mh = query_mh.intersection(match_mh.flatten())
         self.found_mh += intersect_mh
 
-    def peek(self, query_mh, *, threshold_bp=None):
-        assert threshold_bp is not None
+    def peek(self, query_mh, *, threshold_bp=0): # threshold_bp default?? @CTB
+        if not query_mh:
+            return []
+
+        if query_mh.contained_by(self.orig_query_mh) != 1.0:
+            raise ValueError
+        #assert threshold_bp is not None
         print('BBB peek')
         return self.db.peek(query_mh, threshold_bp=threshold_bp)
 

--- a/src/sourmash/index/revindex.py
+++ b/src/sourmash/index/revindex.py
@@ -6,7 +6,7 @@ import os
 import weakref
 
 from sourmash.index import Index, IndexSearchResult, _check_select_parameters
-from sourmash.minhash import MinHash
+from sourmash.minhash import MinHash, flatten_and_intersect_scaled
 from sourmash.signature import SourmashSignature
 from sourmash._lowlevel import ffi, lib
 from sourmash.utils import RustObject, rustcall, decode_str, encode_str
@@ -230,7 +230,7 @@ class RevIndex(RustObject):  # , Index):
 
         if found:
             match_mh = found[0].signature.minhash.flatten()
-            intersect_mh = match_mh.intersection(query_mh.flatten())
+            intersect_mh = flatten_and_intersect_scaled(query_mh, match_mh)
             return found[0], intersect_mh
         return []
 
@@ -345,6 +345,11 @@ class DiskRevIndex(RustObject, Index):
 
     def __len__(self):
         return self._methodcall(lib.disk_revindex_len)
+
+    @property
+    def scaled(self):
+        scaled = self._methodcall(lib.disk_revindex_scaled)
+        return scaled
 
     def select(
         self,
@@ -574,6 +579,10 @@ class RevIndex_CounterGather:
         self.allow_insert = allow_insert
         self.locations = dict()
 
+    @property
+    def scaled(self):
+        return self.db.scaled
+
     def add(self, match_ss, *, location=None, require_overlap=True):  # @CTB location
         if self.allow_insert:
             self.db._check_not_init(do_raise=False)
@@ -585,10 +594,13 @@ class RevIndex_CounterGather:
         self.locations[match_ss.md5sum()] = location
 
         query_mh = self.orig_query_mh
-        match_mh = match_ss.minhash.downsample(scaled=query_mh.scaled)
-        intersect_mh = query_mh.intersection(match_mh.flatten())
+        match_mh = match_ss.minhash
+        intersect_mh = flatten_and_intersect_scaled(query_mh, match_mh)
         if require_overlap and not intersect_mh:
             raise ValueError("require overlap")
+
+        if self.found_mh.scaled < intersect_mh.scaled:
+            self.found_mh = self.found_mh.downsample(scaled=intersect_mh.scaled)
 
         self.found_mh += intersect_mh
 

--- a/src/sourmash/index/revindex.py
+++ b/src/sourmash/index/revindex.py
@@ -607,7 +607,7 @@ class RevIndex_CounterGather:
         if not query_mh:
             return []
 
-        if query_mh.contained_by(self.orig_query_mh) != 1.0:
+        if query_mh.contained_by(self.orig_query_mh, True) != 1.0:
             raise ValueError
         # assert threshold_bp is not None
 

--- a/src/sourmash/index/revindex.py
+++ b/src/sourmash/index/revindex.py
@@ -24,12 +24,12 @@ class RevIndex(RustObject):  # , Index):
     def __init__(self, *, template=None):
         assert template is not None
         assert isinstance(template, MinHash)
-        self.template = template
+        self.template = template.copy_and_clear().to_mutable()
         self._scaled = template.scaled
         self._signatures = []
         self._objptr = ffi.NULL
 
-    def _check_init(self):
+    def _check_not_init(self):
         if self._objptr != ffi.NULL:
             raise Exception("already initialized")
 
@@ -40,6 +40,10 @@ class RevIndex(RustObject):  # , Index):
 
         if not self._signatures and self._objptr == ffi.NULL:
             raise ValueError("No signatures provided")
+
+        if self.template.scaled != self._scaled:
+            print(f'XXX downsampling: {self.template.scaled}, {self._scaled}')
+            self.template = self.template.downsample(scaled=self._scaled)
 
         template_ptr = self.template._get_objptr()
 
@@ -83,10 +87,9 @@ class RevIndex(RustObject):  # , Index):
 
     def insert(self, sig):
         if sig.minhash.scaled > self._scaled:
-            raise Exception(
-                f"insert scaled {sig.minhash.scaled} is higher than template scaled {self._scaled}"
-            )
-        self._check_init()
+            self._scaled = sig.minhash.scaled
+
+        self._check_not_init()
         self._signatures.append(sig)
 
     def save(self, path):
@@ -154,6 +157,8 @@ class RevIndex(RustObject):  # , Index):
         if not query.minhash:
             return []
 
+        print('XYY', query.minhash.scaled, self._scaled)
+
         # check arguments
         if "threshold" not in kwargs:
             raise TypeError("'search' requires 'threshold'")
@@ -196,8 +201,12 @@ class RevIndex(RustObject):  # , Index):
         query_mh = query_ss.minhash
         if not query_mh:
             raise ValueError
+        query_mh = query_mh.downsample(scaled=self._scaled)
+        ss = SourmashSignature(query_mh)
         threshold = threshold_bp / query_mh.scaled / len(query_mh)
-        sr = self.search(query_ss, threshold=threshold, do_containment=True)
+        print('XZZY prefetch', query_mh.scaled, self._scaled, threshold)
+        sr = self.search(ss, threshold=threshold, do_containment=True)
+        print(f'found: {len(sr)}')
         return sr
 
     def best_containment(self, query_ss, *, threshold_bp=0, **kwargs):
@@ -205,6 +214,7 @@ class RevIndex(RustObject):  # , Index):
         if not query_mh:
             raise ValueError("empty query")
         threshold = threshold_bp / query_mh.scaled / len(query_mh)
+        print('XZX', query_mh.scaled, self._scaled, threshold)
         results = self.search(query_ss, threshold=threshold, do_containment=True)
 
         if results:
@@ -216,6 +226,7 @@ class RevIndex(RustObject):  # , Index):
         if not len(query_mh):
             raise ValueError
         threshold = threshold_bp / query_mh.scaled / len(query_mh)
+        print('XZZ peek', query_mh.scaled, self._scaled, threshold)
         query_ss = sourmash.SourmashSignature(query_mh)
         found = self.search(query_ss, threshold=threshold, do_containment=True)
 
@@ -229,9 +240,12 @@ class RevIndex(RustObject):  # , Index):
         pass
 
     def counter_gather(self, query, threshold_bp, **kwargs):
+        # will raise ValueError if empty:
+        self._init_inner()
+
         counter = RevIndex_CounterGather(query, self, threshold_bp)
-        for result in self.prefetch(query, threshold_bp=threshold_bp):
-            counter.add(result.signature)
+        #for result in self.prefetch(query, threshold_bp=threshold_bp):
+        #    counter.add(result.signature)
 
         return counter
 
@@ -565,6 +579,7 @@ class RevIndex_CounterGather:
 
     def peek(self, query_mh, *, threshold_bp=None):
         assert threshold_bp is not None
+        print('BBB peek')
         return self.db.peek(query_mh, threshold_bp=threshold_bp)
 
     def consume(self, intersect_mh):
@@ -575,6 +590,7 @@ class RevIndex_CounterGather:
         return self.found_mh
 
     def signatures(self):
-        # don't track actual signatures - go back to DiskRevIndex
+        # don't track actual signatures - go back to RevIndex
         for sr in self.db.prefetch(self.query):
+            print('FOO')
             yield sr.signature

--- a/src/sourmash/index/revindex.py
+++ b/src/sourmash/index/revindex.py
@@ -25,6 +25,7 @@ class RevIndex(RustObject): #, Index):
         assert template is not None
         assert isinstance(template, MinHash)
         self.template = template
+        self._scaled = template.scaled
         self._signatures = []
         self._objptr = ffi.NULL
 
@@ -80,9 +81,11 @@ class RevIndex(RustObject): #, Index):
         self._init_inner()
         return self._methodcall(lib.revindex_len)
 
-    def insert(self, node):
+    def insert(self, sig):
+        if sig.minhash.scaled > self._scaled:
+            raise Exception(f"insert scaled {sig.minhash.scaled} is higher than template scaled {self._scaled}")
         self._check_init()
-        self._signatures.append(node)
+        self._signatures.append(sig)
 
     def save(self, path):
         pass
@@ -213,10 +216,10 @@ class RevIndex(RustObject): #, Index):
         found = self.search(query_ss, threshold=threshold, do_containment=True)
 
         if found:
-            match_mh = found[0].signature.minhash
-            intersect_mh = match_mh.intersection(query_mh)
+            match_mh = found[0].signature.minhash.flatten()
+            intersect_mh = match_mh.intersection(query_mh.flatten())
             return found[0], intersect_mh
-        return None, None
+        return None
 
     def consume(self, intersect_mh):
         pass

--- a/src/sourmash/index/revindex.py
+++ b/src/sourmash/index/revindex.py
@@ -47,7 +47,6 @@ class RevIndex(RustObject):  # , Index):
             raise ValueError("No signatures provided")
 
         if self.template.scaled != self._scaled:
-            print(f'XXX downsampling: {self.template.scaled}, {self._scaled}')
             self.template = self.template.downsample(scaled=self._scaled)
 
         template_ptr = self.template._get_objptr()
@@ -162,8 +161,6 @@ class RevIndex(RustObject):  # , Index):
         if not query.minhash:
             return []
 
-        print('XYY', query.minhash.scaled, self._scaled)
-
         # check arguments
         if "threshold" not in kwargs:
             raise TypeError("'search' requires 'threshold'")
@@ -209,9 +206,7 @@ class RevIndex(RustObject):  # , Index):
         query_mh = query_mh.downsample(scaled=self._scaled)
         ss = SourmashSignature(query_mh)
         threshold = threshold_bp / query_mh.scaled / len(query_mh)
-        print('XZZY prefetch', query_mh.scaled, self._scaled, threshold)
         sr = self.search(ss, threshold=threshold, do_containment=True)
-        print(f'found: {len(sr)}')
         return sr
 
     def best_containment(self, query_ss, *, threshold_bp=0, **kwargs):
@@ -219,7 +214,6 @@ class RevIndex(RustObject):  # , Index):
         if not query_mh:
             raise ValueError("empty query")
         threshold = threshold_bp / query_mh.scaled / len(query_mh)
-        print('XZX', query_mh.scaled, self._scaled, threshold)
         results = self.search(query_ss, threshold=threshold, do_containment=True)
 
         if results:
@@ -231,7 +225,6 @@ class RevIndex(RustObject):  # , Index):
         if not len(query_mh):
             raise ValueError
         threshold = threshold_bp / query_mh.scaled / len(query_mh)
-        print('XZZ peek', query_mh.scaled, self._scaled, threshold)
         query_ss = sourmash.SourmashSignature(query_mh)
         found = self.search(query_ss, threshold=threshold, do_containment=True)
 
@@ -317,6 +310,9 @@ class DiskRevIndex(RustObject, Index):
         # store location
         self._path = path
         self._idx_picklist = None
+
+    def _init_inner(self):
+        pass
 
     @property
     def location(self):
@@ -581,14 +577,12 @@ class RevIndex_CounterGather:
     def add(self, match_ss, *, location=None, require_overlap=True): # @CTB location
         if self.allow_insert:
             x = self.db._check_not_init(do_raise=False)
-            print('checking', x)
             if self.db._check_not_init(do_raise=False):
-                print('not init')
                 self.db.insert(match_ss)
             else:
                 raise ValueError
 
-            self.locations[match_ss.md5sum()] = location
+        self.locations[match_ss.md5sum()] = location
 
         query_mh = self.orig_query_mh
         match_mh = match_ss.minhash.downsample(scaled=query_mh.scaled)
@@ -605,7 +599,6 @@ class RevIndex_CounterGather:
         if query_mh.contained_by(self.orig_query_mh) != 1.0:
             raise ValueError
         #assert threshold_bp is not None
-        print('BBB peek')
 
         res = self.db.peek(query_mh, threshold_bp=threshold_bp)
         if not res:
@@ -629,5 +622,4 @@ class RevIndex_CounterGather:
     def signatures(self):
         # don't track actual signatures - go back to RevIndex
         for sr in self.db.prefetch(self.query):
-            print('FOO')
             yield sr.signature

--- a/src/sourmash/index/revindex.py
+++ b/src/sourmash/index/revindex.py
@@ -583,7 +583,7 @@ class RevIndex_CounterGather:
         self.db = db
         self.threshold_bp = threshold_bp
         self.allow_insert = allow_insert
-        self.locations = dict()
+        self.locations = {}
 
     @property
     def scaled(self):

--- a/src/sourmash/index/revindex.py
+++ b/src/sourmash/index/revindex.py
@@ -67,10 +67,10 @@ class RevIndex(RustObject):  # , Index):
             template_ptr,
         )
 
-        for n, (orig_ss, stored_ss) in enumerate(zip(self._signatures,
-                                                     self.signatures())):
+        for n, (orig_ss, stored_ss) in enumerate(
+            zip(self._signatures, self.signatures())
+        ):
             self._orig_signatures[stored_ss.md5sum()] = orig_ss
-
 
     def signatures(self):
         self._init_inner()
@@ -196,9 +196,7 @@ class RevIndex(RustObject):  # , Index):
             if match.score >= threshold:
                 match_md5 = match.signature.md5sum()
                 orig_ss = self._orig_signatures[match_md5]
-                results.append(
-                    IndexSearchResult(match.score, orig_ss, match.location)
-                )
+                results.append(IndexSearchResult(match.score, orig_ss, match.location))
 
         return results
 

--- a/src/sourmash/index/revindex.py
+++ b/src/sourmash/index/revindex.py
@@ -576,6 +576,7 @@ class RevIndex_CounterGather:
         self.db = db
         self.threshold_bp = threshold_bp
         self.allow_insert = allow_insert
+        self.locations = dict()
 
     def add(self, match_ss, *, location=None, require_overlap=True): # @CTB location
         if self.allow_insert:
@@ -586,6 +587,8 @@ class RevIndex_CounterGather:
                 self.db.insert(match_ss)
             else:
                 raise ValueError
+
+            self.locations[match_ss.md5sum()] = location
 
         query_mh = self.orig_query_mh
         match_mh = match_ss.minhash.downsample(scaled=query_mh.scaled)
@@ -603,7 +606,17 @@ class RevIndex_CounterGather:
             raise ValueError
         #assert threshold_bp is not None
         print('BBB peek')
-        return self.db.peek(query_mh, threshold_bp=threshold_bp)
+
+        res = self.db.peek(query_mh, threshold_bp=threshold_bp)
+        if not res:
+            return []
+
+        sr, intersect_mh = res
+        sr_ss = sr.signature
+        sr_score = sr.score
+        new_sr = IndexSearchResult(sr_score, sr_ss,
+                                   self.locations[sr_ss.md5sum()])
+        return new_sr, intersect_mh
 
     def consume(self, intersect_mh):
         self.db._init_inner()

--- a/src/sourmash/search.py
+++ b/src/sourmash/search.py
@@ -761,9 +761,7 @@ def _find_best(counters, query, threshold_bp):
 
     # find the best score across multiple counters, without consuming
     for counter in counters:
-        print('TTT _find_best')
         result = counter.peek(query.minhash, threshold_bp=threshold_bp)
-        print('TTT result:', result)
         if result:
             (sr, intersect_mh) = result
 
@@ -879,10 +877,7 @@ class GatherDatabases:
     def __next__(self):
         query = self.query
         if not self.query.minhash:
-            print('SSS empty', self.query.minhash.scaled)
             raise StopIteration
-        else:
-            print('SSS ok')
 
         # may be changed:
         counters = self.counters

--- a/src/sourmash/search.py
+++ b/src/sourmash/search.py
@@ -761,7 +761,9 @@ def _find_best(counters, query, threshold_bp):
 
     # find the best score across multiple counters, without consuming
     for counter in counters:
+        print('TTT _find_best')
         result = counter.peek(query.minhash, threshold_bp=threshold_bp)
+        print('TTT result:', result)
         if result:
             (sr, intersect_mh) = result
 
@@ -877,7 +879,10 @@ class GatherDatabases:
     def __next__(self):
         query = self.query
         if not self.query.minhash:
+            print('SSS empty', self.query.minhash.scaled)
             raise StopIteration
+        else:
+            print('SSS ok')
 
         # may be changed:
         counters = self.counters

--- a/tests/test_index_protocol.py
+++ b/tests/test_index_protocol.py
@@ -757,6 +757,7 @@ def test_counter_get_signatures(counter_gather_constructor):
     assert match_ss_3 in siglist
 
 
+# utility function to exhaust a CounterGather set of matches
 def _consume_all(query_mh, counter, threshold_bp=0):
     results = []
     query_mh = query_mh.to_mutable()

--- a/tests/test_index_protocol.py
+++ b/tests/test_index_protocol.py
@@ -703,8 +703,10 @@ class CounterGather_LCA:
 
 ## XXX @CTB
 
+
 def build_RevIndex_CounterGather(query):
     from sourmash.index.revindex import RevIndex_CounterGather
+
     ri = RevIndex(template=query.minhash)
     cg = RevIndex_CounterGather(query, ri, 0, allow_insert=True)
     return cg
@@ -715,7 +717,7 @@ def build_RevIndex_CounterGather(query):
         CounterGather,
         CounterGather_LinearIndex,
         CounterGather_LCA,
-        build_RevIndex_CounterGather
+        build_RevIndex_CounterGather,
     ]
 )
 def counter_gather_constructor(request):
@@ -1184,9 +1186,9 @@ def test_counter_gather_add_after_consume(counter_gather_constructor):
     query_ss = SourmashSignature(query_mh, name="query")
 
     # load up the counter
-    print('create')
+    print("create")
     counter = counter_gather_constructor(query_ss)
-    print('insert')
+    print("insert")
     counter.add(query_ss, location="somewhere over the rainbow")
 
     counter.consume(query_ss.minhash)

--- a/tests/test_index_protocol.py
+++ b/tests/test_index_protocol.py
@@ -695,7 +695,7 @@ class CounterGather_LCA:
         location = self.locations[md5]
 
         new_sr = IndexSearchResult(cont, match, location)
-        return [new_sr, intersect_mh]
+        return new_sr, intersect_mh
 
     def consume(self, intersect_mh):
         self.query_started = 1

--- a/tests/test_index_protocol.py
+++ b/tests/test_index_protocol.py
@@ -1184,7 +1184,9 @@ def test_counter_gather_add_after_consume(counter_gather_constructor):
     query_ss = SourmashSignature(query_mh, name="query")
 
     # load up the counter
+    print('create')
     counter = counter_gather_constructor(query_ss)
+    print('insert')
     counter.add(query_ss, location="somewhere over the rainbow")
 
     counter.consume(query_ss.minhash)

--- a/tests/test_index_protocol.py
+++ b/tests/test_index_protocol.py
@@ -701,11 +701,21 @@ class CounterGather_LCA:
         self.query_started = 1
 
 
+## XXX @CTB
+
+def build_RevIndex_CounterGather(query):
+    from sourmash.index.revindex import RevIndex_CounterGather
+    ri = RevIndex(template=query.minhash)
+    cg = RevIndex_CounterGather(query, ri, 0, allow_insert=True)
+    return cg
+
+
 @pytest.fixture(
     params=[
         CounterGather,
         CounterGather_LinearIndex,
         CounterGather_LCA,
+        build_RevIndex_CounterGather
     ]
 )
 def counter_gather_constructor(request):

--- a/tests/test_revindex.py
+++ b/tests/test_revindex.py
@@ -10,6 +10,7 @@ from sourmash.index import revindex
 from sourmash.index.revindex import RevIndex, DiskRevIndex
 from sourmash.signature import load_one_signature_from_json
 from sourmash.search import JaccardSearch, SearchType
+from sourmash import SourmashSignature
 
 ##
 ## test a slightly outre version of JaccardSearch - this is a test of the
@@ -58,6 +59,53 @@ def test_revindex_index_search():
     ss63 = load_one_signature_from_json(sig63)
 
     lidx = RevIndex(template=ss2.minhash)
+    lidx.insert(ss2)
+    lidx.insert(ss47)
+    lidx.insert(ss63)
+
+    # now, search for sig2
+    sr = lidx.search(ss2, threshold=1.0)
+    print([s[1].name for s in sr])
+    assert len(sr) == 1
+    assert sr[0][1] == ss2
+
+    # search for sig47 with lower threshold; search order not guaranteed.
+    sr = lidx.search(ss47, threshold=0.1)
+    print([s[1].name for s in sr])
+    assert len(sr) == 2
+    sr.sort(key=lambda x: -x[0])
+    assert sr[0][1] == ss47
+    assert sr[1][1] == ss63
+
+    # search for sig63 with lower threshold; search order not guaranteed.
+    sr = lidx.search(ss63, threshold=0.1)
+    print([s[1].name for s in sr])
+    assert len(sr) == 2
+    sr.sort(key=lambda x: -x[0])
+    assert sr[0][1] == ss63
+    assert sr[1][1] == ss47
+
+    # search for sig63 with high threshold => 1 match
+    sr = lidx.search(ss63, threshold=0.8)
+    print([s[1].name for s in sr])
+    assert len(sr) == 1
+    sr.sort(key=lambda x: -x[0])
+    assert sr[0][1] == ss63
+
+
+def test_revindex_index_search_retrieve_orig():
+    # confirm that RevIndex returns the original, not the downsampled sketches
+    sig2 = utils.get_test_data("2.fa.sig")
+    sig47 = utils.get_test_data("47.fa.sig")
+    sig63 = utils.get_test_data("63.fa.sig")
+
+    ss2 = load_one_signature_from_json(sig2, ksize=31)
+    ss47 = load_one_signature_from_json(sig47)
+    ss63 = load_one_signature_from_json(sig63)
+
+    # store downsampled:
+    ds_mh = ss2.minhash.downsample(scaled=10_000)
+    lidx = RevIndex(template=ds_mh)
     lidx.insert(ss2)
     lidx.insert(ss47)
     lidx.insert(ss63)

--- a/tests/test_revindex.py
+++ b/tests/test_revindex.py
@@ -38,6 +38,14 @@ class JaccardSearchBestOnly_ButIgnore(JaccardSearch): # @CTB remove?
         return True
 
 
+def test_revindex_empty():
+    sig2 = utils.get_test_data("2.fa.sig")
+    ss2 = load_one_signature_from_json(sig2, ksize=31)
+    lidx = RevIndex(template=ss2.minhash)
+
+    x = list(lidx.signatures())
+
+
 def test_revindex_index_search():
     # confirm that RevIndex works
     sig2 = utils.get_test_data("2.fa.sig")

--- a/tests/test_revindex.py
+++ b/tests/test_revindex.py
@@ -17,7 +17,7 @@ from sourmash.search import JaccardSearch, SearchType
 ##
 
 
-class JaccardSearchBestOnly_ButIgnore(JaccardSearch): # @CTB remove?
+class JaccardSearchBestOnly_ButIgnore(JaccardSearch):  # @CTB remove?
     "A class that ignores certain results, but still does all the pruning."
 
     def __init__(self, ignore_list):
@@ -44,7 +44,7 @@ def test_revindex_empty():
     lidx = RevIndex(template=ss2.minhash)
 
     with pytest.raises(ValueError):
-        x = list(lidx.signatures())
+        list(lidx.signatures())
 
 
 def test_revindex_index_search():
@@ -119,7 +119,7 @@ def test_revindex_best_containment():
 
 
 def test_revindex_gather_ignore():
-    raise pytest.skip('not implemented')
+    raise pytest.skip("not implemented")
     # check that RevIndex gather ignores things properly.
     sig2 = utils.get_test_data("2.fa.sig")
     sig47 = utils.get_test_data("47.fa.sig")
@@ -157,7 +157,7 @@ def test_revindex_insert_after_init():
 
     ss2 = load_one_signature_from_json(sig2, ksize=31)
     ss47 = load_one_signature_from_json(sig47)
-    ss63 = load_one_signature_from_json(sig63)
+    load_one_signature_from_json(sig63)
 
     lidx = RevIndex(template=ss2.minhash)
     lidx.insert(ss2)

--- a/tests/test_revindex.py
+++ b/tests/test_revindex.py
@@ -43,7 +43,8 @@ def test_revindex_empty():
     ss2 = load_one_signature_from_json(sig2, ksize=31)
     lidx = RevIndex(template=ss2.minhash)
 
-    x = list(lidx.signatures())
+    with pytest.raises(ValueError):
+        x = list(lidx.signatures())
 
 
 def test_revindex_index_search():

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -4281,6 +4281,7 @@ def test_gather_f_match_orig(runtmp, linear_gather, prefetch_gather):
             # double check -- should match 'search --containment'.
             # (this is kind of useless for a 1.0 contained_by, I guess)
             filename = row["filename"]
+            print('trying load from:', row["filename"])
             match = load_one_signature(filename, ksize=21)
             assert match.contained_by(combined_sig) == 1.0
 

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -5565,6 +5565,7 @@ def test_gather_check_scaled_bounds_more_than_maximum(
 
 
 def test_gather_query_downsample(runtmp, linear_gather, prefetch_gather):
+    # check that query sig gets properly downsampled
     testdata_glob = utils.get_test_data("gather/GCF*.sig")
     testdata_sigs = glob.glob(testdata_glob)
     print(testdata_sigs)

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -4281,7 +4281,7 @@ def test_gather_f_match_orig(runtmp, linear_gather, prefetch_gather):
             # double check -- should match 'search --containment'.
             # (this is kind of useless for a 1.0 contained_by, I guess)
             filename = row["filename"]
-            print('trying load from:', row["filename"])
+            print("trying load from:", row["filename"])
             match = load_one_signature(filename, ksize=21)
             assert match.contained_by(combined_sig) == 1.0
 


### PR DESCRIPTION
Note: PR into https://github.com/sourmash-bio/sourmash/pull/3545

This PR tackles https://github.com/sourmash-bio/sourmash/issues/1939, fixing & customizing & simplifying the `index.RevIndex` Python container wrapping `MemRevIndex` on the Rust side.

A few notes -

* fixes ksize calculation for templating/selection for protein, hp, and dayhoff sketches;
* fixes Jaccard calculation inside `MemRevIndex` search;
* adds hooks in `sourmash gather` (CLI) and `Index.prefetch(...)` (Python layer) to test out `RevIndex` as a replacement index class & `CounterGather` implementation;
* simplifies the Python layer and removes unused Rust code for `MemRevIndex`;

Overall things seem to work well enough, with a few hiccups around `scaled` and sketch `location`.