### PR TITLE
MRG: fully support skip-mers at the Python level; provide documentation

### DIFF
--- a/doc/command-line.md
+++ b/doc/command-line.md
@@ -460,7 +460,7 @@ indexes that we support for legacy reasons.
 
 All signatures in an index must be of compatible types (i.e. the same
 k-mer size, scaled, and molecule type). You can specify the usual
-command line selectors (`-k`, `--scaled`, `--dna`, `--protein`, etc.)
+command line selectors (`-k`, `--scaled`, `--dna/--protein/--hp/--dayhoff/--skipm1n3/--skipm2n3`, etc.)
 to pick out the types of signatures to include when running `index`.
 
 Usage:
@@ -513,7 +513,7 @@ or together:
 * `--save-unmatched-hashes` saves a single signature containing the complement of `--save-matching-hashes`.
 
 Other options include:
-* the usual `-k/--ksize` and `--dna`/`--protein`/`--dayhoff`/`--hp` signature selectors;
+* the usual `-k/--ksize` and `--dna/--protein/--dayhoff/--hp/--skipm1n3/--skipm2n3` signature selectors;
 * `--threshold-bp` to require a minimum estimated bp overlap for output;
 * `--scaled` for downsampling;
 * `--force` to continue past survivable errors;
@@ -1462,7 +1462,7 @@ the same scaled value.
 
 If there are multiple signatures in a file with different ksizes and/or
 from nucleotide and protein sequences, you can choose amongst them with
-`-k/--ksize` and `--dna` or `--protein`, as with other sourmash commands
+`-k/--ksize` and `--dna/--protein/--hp/--dayhoff/--skipm1n3/--skipm2n3`, as with other sourmash commands
 such as `search`, `gather`, and `compare`.
 
 Note, you can use `sourmash sig` as shorthand for all of these commands.
@@ -1615,7 +1615,7 @@ with fields:
 * `md5sum` - a unique hash value based on the contents of the signature.
 * `k=<ksize>` - k-mer size.
 * `scaled=<scaled>` or `num=<num>` - scaled or num value for MinHash.
-* `<moltype>` - the molecule type (DNA, protein, dayhoff, or hp)
+* `<moltype>` - the molecule type (DNA, protein, dayhoff, hp, skipm1n3, or skipm2n3)
 * `dup=<n>` - a non-negative integer that prevents duplicate signatures from colliding.
 * `basename` - basename of first input file used to create signature; if none provided, or stdin, this is `none`.
 
@@ -1643,7 +1643,7 @@ behavior and allow merging of mixtures by removing all abundances.
 `sig merge` can only merge compatible sketches - if there are multiple
 k-mer sizes or molecule types present in any of the signature files,
 you will need to choose one k-mer size with `-k/--ksize`, and/or one
-moltype with `--dna/--protein/--hp/--dayhoff`.
+moltype with `--dna/--protein/--hp/--dayhoff/--skipm1n3/--skipm2n3`.
 
 Use `--set-name <name>` to set the name of the output sketch.
 
@@ -1681,7 +1681,7 @@ To use `subtract` on signatures calculated with
 `sig subtract` can only work with compatible sketches - if there are multiple
 k-mer sizes or molecule types present in any of the signature files,
 you will need to choose one k-mer size with `-k/--ksize`, and/or one
-moltype with `--dna/--protein/--hp/--dayhoff`.
+moltype with `--dna/--protein/--hp/--dayhoff/--skipm1n3/--skipm2n3`.
 
 Use `--set-name <name>` to set the name of the output sketch.
 
@@ -1708,7 +1708,7 @@ to the intersection).
 `sig intersect` can only work with compatible sketches - if there are multiple
 k-mer sizes or molecule types present in any of the signature files,
 you will need to choose one k-mer size with `-k/--ksize`, and/or one
-moltype with `--dna/--protein/--hp/--dayhoff`.
+moltype with `--dna/--protein/--hp/--dayhoff/--skipm1n3/--skipm2n3`.
 
 Use `--set-name <name>` to set the name of the output sketch(es).
 
@@ -1729,7 +1729,7 @@ Any hashes that are not present in `file1.sig` will be removed from
 `sig inflate` can only work with compatible sketches - if there are multiple
 k-mer sizes or molecule types present in any of the signature files,
 you will need to choose one k-mer size with `-k/--ksize`, and/or one
-moltype with `--dna/--protein/--hp/--dayhoff`.
+moltype with `--dna/--protein/--hp/--dayhoff/--skipm1n3/--skipm2n3`.
 
 ### `sourmash signature downsample` - decrease the size of a signature
 
@@ -1892,7 +1892,7 @@ total (union):               7886
 `sig overlap` can only work with compatible sketches - if there are multiple
 k-mer sizes or molecule types present in any of the signature files,
 you will need to choose one k-mer size with `-k/--ksize`, and/or one
-moltype with `--dna/--protein/--hp/--dayhoff`.
+moltype with `--dna/--protein/--hp/--dayhoff/--skipm1n3/--skipm2n3`.
 
 ### `sourmash signature kmers` - extract k-mers and/or sequences that match to signatures
 
@@ -2060,7 +2060,7 @@ Briefly,
   multiple signatures or databases. In this case, there has to be a
   single identifiable query for sourmash to use, and if you're using a
   database or list of signatures as the source of a query, you'll
-  need to provide a selector (ksize with `-k`, moltype with `--dna` etc,
+  need to provide a selector (ksize with `-k`, moltype with `--dna/--protein/--hp/--dayhoff/--skipm1n3/--skipm2n3` etc,
   or md5sum with `--query-md5`) that picks out a single signature.
 
 * `compare` takes multiple signatures and can load them from any

--- a/doc/sourmash-sketch.md
+++ b/doc/sourmash-sketch.md
@@ -15,9 +15,9 @@ sourmash sketch translate
 sourmash sketch fromfile
 ```
 
-The `sketch dna` command reads in **DNA sequences** and outputs **DNA sketches**.
+The `sketch dna` command reads in **DNA sequences** and outputs **DNA sketches** (including skip-mer sketches).
 
-The `sketch protein` command reads in **protein sequences** and outputs **protein sketches**.
+The `sketch protein` command reads in **protein sequences** and outputs **protein sketches** (including hp and dayhoff sketches - see ).
 
 The `sketch translate` command reads in **DNA sequences**, translates them in all six frames, and outputs **protein sketches**.
 
@@ -139,7 +139,7 @@ the signatures requested by the parameter strings.  Other columns in
 this file will be ignored.
 
 If no protein, hp, or dayhoff sketches are requested, `protein_filename`
-can be empty for a given row; likewise, if no DNA sketches are requested,
+can be empty for a given row; likewise, if no DNA, skipm1n3, or skipm2n3 sketches are requested,
 `genome_filename` can be empty for a given row.
 
 Some of the key command-line options supported by `fromfile` are:
@@ -182,6 +182,22 @@ If you specify `--merge <name>`, sourmash sketch will produce signatures for all
 
 The output signature(s) will be saved in locations that depend on your input parameters. By default, `sourmash sketch` will put the signatures in the current directory, in a file named for the input file with a `.sig` suffix. If you specify `-o`, all of the signatures will be placed in that file.
 
+### DNA encodings
+
+`sourmash sketch dna` outputs DNA sketches (by default) or,
+optionally, skip-mer sketches of types `skipm1n3` and
+`skipm2n3`. Skip-mers allow more mismatches and hence are more
+sensitive across evolutionary distances.
+
+`skipm1n3` keeps 1 base, and skips 2 bases; `skipm2n3` keeps 2 bases,
+and skips 1 base. The ksize specified is the sum of the bases kept,
+that is, the final size of the k-mer that is sketched. So, for ksize
+3, the sequence ACTAG would produce two skip-mers for m2n3: ACA, CTG.
+
+Skip-mer References:
+- [Skip-mers: increasing entropy and sensitivity to detect conserved genic regions with simple cyclic q-grams](https://www.biorxiv.org/content/10.1101/179960.abstract)
+- [Extracting and Evaluating Features from RNA Virus Sequences to Predict Host Species Susceptibility Using Deep Learning](https://dl.acm.org/doi/abs/10.1145/3473258.3473271)
+
 ### Protein encodings
 
 `sourmash sketch protein` and `sourmash sketch translate` output protein sketches by default, but can also use the `dayhoff` and `hp` encodings.  The [Dayhoff encoding](https://bmcbioinformatics.biomedcentral.com/articles/10.1186/1471-2105-9-367/tables/1) collapses multiple amino acids into a smaller alphabet so that amino acids that share biochemical properties map to the same character. The hp encoding divides amino acids into hydrophobic and polar (hydrophilic) amino acids, collapsing amino acids with hydrophobic side chains together and doing the same for polar amino acids.
@@ -203,7 +219,7 @@ A parameter string is a space-delimited collection that can contain one or more 
 * `scaled=<int>` - create a scaled MinHash with k-mers sampled deterministically at 1 per `<scaled>` value. This controls sketch compression rates and resolution; for example, a 5 Mbp genome sketched with a scaled of 1000 would yield approximately 5,000 k-mers. `scaled` is incompatible with `num`. See [our guide to signature resolution](using-sourmash-a-guide.md#what-resolution-should-my-signatures-be-and-how-should-i-create-them) for more information.
 * `num=<int>` - create a standard MinHash with no more than `<num>` k-mers kept. This will produce sketches identical to [mash sketches](https://mash.readthedocs.io/en/latest/). `num` is incompatible with `scaled`. See [our guide to signature resolution](using-sourmash-a-guide.md#what-resolution-should-my-signatures-be-and-how-should-i-create-them) for more information.
 * `abund` / `noabund` - create abundance-weighted (or not) sketches. See [Classify signatures: Abundance Weighting](classifying-signatures.md#abundance-weighting) for details of how this works.
-* `dna`, `protein`, `dayhoff`, `hp` - create this kind of sketch. Note that `sourmash sketch dna -p protein` and `sourmash sketch protein -p dna` are invalid; please use `sourmash sketch translate` for the former.
+* `dna`, `protein`, `dayhoff`, `hp`, `skipm1n3`, `skipm2n3` - create this kind of sketch. Note that `sourmash sketch dna -p protein` and `sourmash sketch protein -p dna` are invalid; please use `sourmash sketch translate` for the former.
 * `seed=<int>` - set the random number seed used for k-mer hashing. This is for advanced users who want to choose a completely different set of k-mers for sketches! The default is 42.
 
 For all field names but `k`, if multiple fields in a parameter string are provided, the last one encountered overrides the previous values. For `k`, if multiple ksizes are specified in a single parameter string, sketches for all ksizes specified are created.
@@ -218,12 +234,14 @@ The default parameters for sketches are as follows:
 * protein: `k=10,scaled=200,noabund`
 * dayhoff: `k=16,scaled=200,noabund`
 * hp: `k=42,scaled=200,noabund`
+* skipm1n3: `k=21,scaled=1000,noabund`
+* skipm2n3: `k=21,scaled=1000,noabund`
 
 These were chosen by a committee of PhDs as being good defaults for an initial analysis, so, beware :).
 
 More seriously, the DNA parameters were chosen based on the analyses done by Koslicki and Falush in [MetaPalette: a k-mer Painting Approach for Metagenomic Taxonomic Profiling and Quantification of Novel Strain Variation](https://msystems.asm.org/content/1/3/e00020-16).
 
-The protein, dayhoff, and hp parameters were selected based on unpublished research results and/or magic formulas. We are working on publishing the results! Please ask on the [issue tracker](https://github.com/sourmash-bio/sourmash/issues) if you are curious.
+The protein, dayhoff, hp, skipm1n3, and skipm2n3 parameters were selected based on unpublished research results and/or magic formulas. We are working on publishing the results! Please ask on the [issue tracker](https://github.com/sourmash-bio/sourmash/issues) if you are curious.
 
 ### More complex parameter string examples
 

--- a/doc/sourmash-sketch.md
+++ b/doc/sourmash-sketch.md
@@ -194,7 +194,7 @@ and skips 1 base. The ksize specified is the sum of the bases kept,
 that is, the final size of the k-mer that is sketched. So, for ksize
 3, the sequence ACTAG would produce two skip-mers for m2n3: ACA, CTG.
 
-Skip-mer References:
+Skip-mer references:
 - [Skip-mers: increasing entropy and sensitivity to detect conserved genic regions with simple cyclic q-grams](https://www.biorxiv.org/content/10.1101/179960.abstract)
 - [Extracting and Evaluating Features from RNA Virus Sequences to Predict Host Species Susceptibility Using Deep Learning](https://dl.acm.org/doi/abs/10.1145/3473258.3473271)
 

--- a/doc/sourmash-sketch.md
+++ b/doc/sourmash-sketch.md
@@ -15,9 +15,9 @@ sourmash sketch translate
 sourmash sketch fromfile
 ```
 
-The `sketch dna` command reads in **DNA sequences** and outputs **DNA sketches** (including skip-mer sketches).
+The `sketch dna` command reads in **DNA sequences** and outputs **DNA sketches** (including skip-mer sketches - see [DNA encodings](#dna-encodings)).
 
-The `sketch protein` command reads in **protein sequences** and outputs **protein sketches** (including hp and dayhoff sketches - see ).
+The `sketch protein` command reads in **protein sequences** and outputs **protein sketches** (including hp and dayhoff sketches - see [protein encodings](#protein-encodings)).
 
 The `sketch translate` command reads in **DNA sequences**, translates them in all six frames, and outputs **protein sketches**.
 

--- a/include/sourmash.h
+++ b/include/sourmash.h
@@ -138,7 +138,15 @@ void computeparams_set_scaled(SourmashComputeParameters *ptr, uint32_t scaled);
 
 void computeparams_set_seed(SourmashComputeParameters *ptr, uint64_t new_seed);
 
+void computeparams_set_skipm1n3(SourmashComputeParameters *ptr, bool v);
+
+void computeparams_set_skipm2n3(SourmashComputeParameters *ptr, bool v);
+
 void computeparams_set_track_abundance(SourmashComputeParameters *ptr, bool v);
+
+bool computeparams_skipm1n3(const SourmashComputeParameters *ptr);
+
+bool computeparams_skipm2n3(const SourmashComputeParameters *ptr);
 
 bool computeparams_track_abundance(const SourmashComputeParameters *ptr);
 

--- a/src/core/src/ffi/cmd/compute.rs
+++ b/src/core/src/ffi/cmd/compute.rs
@@ -124,6 +124,30 @@ pub unsafe extern "C" fn computeparams_set_dna(ptr: *mut SourmashComputeParamete
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn computeparams_skipm1n3(ptr: *const SourmashComputeParameters) -> bool {
+    let cp = SourmashComputeParameters::as_rust(ptr);
+    cp.skipm1n3()
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn computeparams_set_skipm1n3(ptr: *mut SourmashComputeParameters, v: bool) {
+    let cp = SourmashComputeParameters::as_rust_mut(ptr);
+    cp.set_skipm1n3(v);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn computeparams_skipm2n3(ptr: *const SourmashComputeParameters) -> bool {
+    let cp = SourmashComputeParameters::as_rust(ptr);
+    cp.skipm2n3()
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn computeparams_set_skipm2n3(ptr: *mut SourmashComputeParameters, v: bool) {
+    let cp = SourmashComputeParameters::as_rust_mut(ptr);
+    cp.set_skipm2n3(v);
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn computeparams_track_abundance(
     ptr: *const SourmashComputeParameters,
 ) -> bool {

--- a/src/sourmash/command_sketch.py
+++ b/src/sourmash/command_sketch.py
@@ -908,6 +908,8 @@ class ComputeParameters(RustObject):
     def from_manifest_row(cls, row):
         "convert a CollectionManifest row into a ComputeParameters object"
         is_dna = is_protein = is_dayhoff = is_hp = False
+        is_skipm1n3 = is_skipm2n3 = False
+
         if row["moltype"] == "DNA":
             is_dna = True
         elif row["moltype"] == "protein":
@@ -916,8 +918,12 @@ class ComputeParameters(RustObject):
             is_hp = True
         elif row["moltype"] == "dayhoff":
             is_dayhoff = True
+        elif row["moltype"] == "skipm1n3":
+            is_skipm1n3 = True
+        elif row["moltype"] == "skipm2n3":
+            is_skipm2n3 = True
         else:
-            assert 0
+            assert 0, row["moltype"]
 
         if is_dna:
             ksize = row["ksize"]
@@ -931,6 +937,8 @@ class ComputeParameters(RustObject):
             dayhoff=is_dayhoff,
             hp=is_hp,
             dna=is_dna,
+            skipm1n3=is_skipm1n3,
+            skipm2n3=is_skipm2n3,
             num_hashes=row["num"],
             track_abundance=row["with_abundance"],
             scaled=row["scaled"],
@@ -950,6 +958,10 @@ class ComputeParameters(RustObject):
             pi.append("hp")
         elif self.dayhoff:
             pi.append("dayhoff")
+        elif self.skipm1n3:
+            pi.append("skipm1n3")
+        elif self.skipm2n3:
+            pi.append("skipm2n3")
         else:
             assert 0  # must be one of the previous
 
@@ -979,7 +991,7 @@ class ComputeParameters(RustObject):
         return ",".join(pi)
 
     def __repr__(self):
-        return f"ComputeParameters(ksizes={self.ksizes}, seed={self.seed}, protein={self.protein}, dayhoff={self.dayhoff}, hp={self.hp}, dna={self.dna}, num_hashes={self.num_hashes}, track_abundance={self.track_abundance}, scaled={self.scaled})"
+        return f"ComputeParameters(ksizes={self.ksizes}, seed={self.seed}, protein={self.protein}, dayhoff={self.dayhoff}, hp={self.hp}, dna={self.dna}, skipm1n3={self.skipm1n3}, skipm2n3={self.skipm2n3}, num_hashes={self.num_hashes}, track_abundance={self.track_abundance}, scaled={self.scaled})"
 
     def __eq__(self, other):
         return (
@@ -989,6 +1001,8 @@ class ComputeParameters(RustObject):
             and self.dayhoff == other.dayhoff
             and self.hp == other.hp
             and self.dna == other.dna
+            and self.skipm1n3 == other.skipm1n3
+            and self.skipm2n3 == other.skipm2n3
             and self.num_hashes == other.num_hashes
             and self.track_abundance == other.track_abundance
             and self.scaled == other.scaled
@@ -1078,6 +1092,7 @@ class ComputeParameters(RustObject):
 
     @property
     def moltype(self):
+        # @CTB use match?
         if self.dna:
             moltype = "DNA"
         elif self.protein:
@@ -1086,8 +1101,12 @@ class ComputeParameters(RustObject):
             moltype = "hp"
         elif self.dayhoff:
             moltype = "dayhoff"
+        elif self.skipm1n3:
+            moltype = "skipm1n3"
+        elif self.skipm2n3:
+            moltype = "skipm2n3"
         else:
-            assert 0            # @CTB test
+            assert 0
 
         return moltype
 

--- a/src/sourmash/command_sketch.py
+++ b/src/sourmash/command_sketch.py
@@ -794,6 +794,7 @@ def _compute_individual(args, signatures_factory):
     # and we need to close here.
     if args.output and save_sigs is not None:
         save_sigs.close()
+        print('xXXX', save_sigs.location)
         notify(
             f"saved {len(save_sigs)} signature(s) to '{save_sigs.location}'. Note: signature license is CC0."
         )

--- a/src/sourmash/command_sketch.py
+++ b/src/sourmash/command_sketch.py
@@ -27,6 +27,7 @@ DEFAULTS = dict(
     protein="k=10,scaled=200,noabund",
     dayhoff="k=16,scaled=200,noabund",
     hp="k=42,scaled=200,noabund",
+    # @CTB add skipmers
 )
 
 
@@ -37,6 +38,7 @@ def _parse_params_str(params_str):
     params["ksize"] = []
     items = params_str.split(",")
     for item in items:
+        # @CTB use match?
         if item == "abund":
             params["track_abundance"] = True
         elif item == "noabund":
@@ -80,6 +82,8 @@ def _parse_params_str(params_str):
                 raise ValueError("seed takes a parameter, e.g. 'seed=42'")
             params["seed"] = int(item[5:])
         elif item in ("protein", "dayhoff", "hp", "dna"):
+            moltype = item
+        elif item in ("skipm1n3", "skipm2n3"):
             moltype = item
         else:
             raise ValueError(f"unknown component '{item}' in params string")

--- a/src/sourmash/command_sketch.py
+++ b/src/sourmash/command_sketch.py
@@ -113,11 +113,19 @@ class _signatures_for_sketch_factory:
             # provided.
             for params_str in params_str_list:
                 moltype, params = _parse_params_str(params_str)
-                if moltype and moltype not in ("dna", "skipm1n3", "skipm2n3")  and default_moltype == "dna":
+                if (
+                    moltype
+                    and moltype not in ("dna", "skipm1n3", "skipm2n3")
+                    and default_moltype == "dna"
+                ):
                     raise ValueError(
                         f"Incompatible sketch type ({default_moltype}) and parameter override ({moltype}) in '{params_str}'; maybe use 'sketch translate'?"
                     )
-                elif moltype == "dna" and default_moltype and default_moltype not in ("dna", "skipm1n3", "skipm2n3"):
+                elif (
+                    moltype == "dna"
+                    and default_moltype
+                    and default_moltype not in ("dna", "skipm1n3", "skipm2n3")
+                ):
                     raise ValueError(
                         f"Incompatible sketch type ({default_moltype}) and parameter override ({moltype}) in '{params_str}'"
                     )

--- a/src/sourmash/command_sketch.py
+++ b/src/sourmash/command_sketch.py
@@ -794,7 +794,6 @@ def _compute_individual(args, signatures_factory):
     # and we need to close here.
     if args.output and save_sigs is not None:
         save_sigs.close()
-        print('xXXX', save_sigs.location)
         notify(
             f"saved {len(save_sigs)} signature(s) to '{save_sigs.location}'. Note: signature license is CC0."
         )
@@ -1059,6 +1058,23 @@ class ComputeParameters(RustObject):
 
     @dna.setter
     def dna(self, v):
+        return self._methodcall(lib.computeparams_set_dna, v)
+
+    @property
+    def skipm1n3(self):
+        return self._methodcall(lib.computeparams_dna)
+
+    @skipm1n3.setter
+    def skipm1n3(self, v):
+        print('fiz')
+        return self._methodcall(lib.computeparams_set_dna, v)
+
+    @property
+    def skipm2n3(self):
+        return self._methodcall(lib.computeparams_dna)
+
+    @skipm2n3.setter
+    def skipm2n3(self, v):
         return self._methodcall(lib.computeparams_set_dna, v)
 
     @property

--- a/src/sourmash/command_sketch.py
+++ b/src/sourmash/command_sketch.py
@@ -39,7 +39,6 @@ def _parse_params_str(params_str):
     params["ksize"] = []
     items = params_str.split(",")
     for item in items:
-        # @CTB use match?
         if item == "abund":
             params["track_abundance"] = True
         elif item == "noabund":
@@ -1092,7 +1091,6 @@ class ComputeParameters(RustObject):
 
     @property
     def moltype(self):
-        # @CTB use match?
         if self.dna:
             moltype = "DNA"
         elif self.protein:

--- a/src/sourmash/command_sketch.py
+++ b/src/sourmash/command_sketch.py
@@ -27,7 +27,8 @@ DEFAULTS = dict(
     protein="k=10,scaled=200,noabund",
     dayhoff="k=16,scaled=200,noabund",
     hp="k=42,scaled=200,noabund",
-    # @CTB add skipmers
+    skipm1n3="k=21,scaled=1000,noabund",
+    skipm2n3="k=21,scaled=1000,noabund",
 )
 
 
@@ -112,11 +113,11 @@ class _signatures_for_sketch_factory:
             # provided.
             for params_str in params_str_list:
                 moltype, params = _parse_params_str(params_str)
-                if moltype and moltype != "dna" and default_moltype == "dna":
+                if moltype and moltype not in ("dna", "skipm1n3", "skipm2n3")  and default_moltype == "dna":
                     raise ValueError(
                         f"Incompatible sketch type ({default_moltype}) and parameter override ({moltype}) in '{params_str}'; maybe use 'sketch translate'?"
                     )
-                elif moltype == "dna" and default_moltype and default_moltype != "dna":
+                elif moltype == "dna" and default_moltype and default_moltype not in ("dna", "skipm1n3", "skipm2n3"):
                     raise ValueError(
                         f"Incompatible sketch type ({default_moltype}) and parameter override ({moltype}) in '{params_str}'"
                     )
@@ -148,6 +149,8 @@ class _signatures_for_sketch_factory:
             def_protein = default_params.get("is_protein", moltype == "protein")
             def_dayhoff = default_params.get("is_dayhoff", moltype == "dayhoff")
             def_hp = default_params.get("is_hp", moltype == "hp")
+            def_skipm1n3 = default_params.get("skipm1n3", moltype == "skipm1n3")
+            def_skipm2n3 = default_params.get("skipm2n3", moltype == "skipm2n3")
 
             # handle ksize specially, for now - multiply by three?
             def_ksizes = default_params["ksize"]
@@ -167,6 +170,8 @@ class _signatures_for_sketch_factory:
                     dayhoff=def_dayhoff,
                     hp=def_hp,
                     dna=def_dna,
+                    skipm1n3=def_skipm1n3,
+                    skipm2n3=def_skipm2n3,
                     num_hashes=params_d.get("num", def_num),
                     track_abundance=params_d.get("track_abundance", def_abund),
                     scaled=params_d.get("scaled", def_scaled),
@@ -655,6 +660,8 @@ class _signatures_for_compute_factory:
             dayhoff=args.dayhoff,
             hp=args.hp,
             dna=args.dna,
+            skipm1n3=args.skipm1n3,
+            skipm2n3=args.skipm2n3,
             num_hashes=args.num_hashes,
             track_abundance=args.track_abundance,
             scaled=args.scaled,
@@ -877,6 +884,8 @@ class ComputeParameters(RustObject):
         dayhoff=False,
         hp=False,
         dna=True,
+        skipm1n3=False,
+        skipm2n3=False,
         num_hashes=500,
         track_abundance=False,
         scaled=0,
@@ -889,6 +898,8 @@ class ComputeParameters(RustObject):
         self.dayhoff = dayhoff
         self.hp = hp
         self.dna = dna
+        self.skipm1n3 = skipm1n3
+        self.skipm2n3 = skipm2n3
         self.num_hashes = num_hashes
         self.track_abundance = track_abundance
         self.scaled = scaled

--- a/src/sourmash/command_sketch.py
+++ b/src/sourmash/command_sketch.py
@@ -1062,20 +1062,19 @@ class ComputeParameters(RustObject):
 
     @property
     def skipm1n3(self):
-        return self._methodcall(lib.computeparams_dna)
+        return self._methodcall(lib.computeparams_skipm1n3)
 
     @skipm1n3.setter
     def skipm1n3(self, v):
-        print('fiz')
-        return self._methodcall(lib.computeparams_set_dna, v)
+        return self._methodcall(lib.computeparams_set_skipm1n3, v)
 
     @property
     def skipm2n3(self):
-        return self._methodcall(lib.computeparams_dna)
+        return self._methodcall(lib.computeparams_skipm2n3)
 
     @skipm2n3.setter
     def skipm2n3(self, v):
-        return self._methodcall(lib.computeparams_set_dna, v)
+        return self._methodcall(lib.computeparams_set_skipm2n3, v)
 
     @property
     def moltype(self):
@@ -1088,7 +1087,7 @@ class ComputeParameters(RustObject):
         elif self.dayhoff:
             moltype = "dayhoff"
         else:
-            assert 0
+            assert 0            # @CTB test
 
         return moltype
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,12 @@ def runtmp():
         yield RunnerContext(location)
 
 
+@pytest.fixture(scope="session")
+def runtmp_session():
+    with TempDirectory() as location:
+        yield RunnerContext(location)
+
+
 @pytest.fixture
 def run():
     yield RunnerContext(os.getcwd())

--- a/tests/test_moltypes.py
+++ b/tests/test_moltypes.py
@@ -1,0 +1,71 @@
+import pytest
+import sourmash_tst_utils as utils
+from collections import namedtuple
+
+MoltypeHolder = namedtuple("MoltypeHolder", ['moltype_descr',
+                                             'genome_sketch',
+                                             'metag_sketch',
+                                             'cli_moltype_arg',
+                                             'molecule'])
+
+@pytest.fixture(scope="session",
+                params=["dna", "protein", "hp", "dayhoff", "skipm1n3"])
+def moltype(request):
+    yield request.param
+
+
+# build and return genome & metagenome sketches of the given moltype
+@pytest.fixture(scope="session")
+def moltype_sketches(runtmp_session, moltype):
+    genome = utils.get_test_data('genome-s10+s11.fa.gz')
+
+    # @CTB use match!
+    if moltype == "dna":
+        outfile = f"genome.dna.sig.zip"
+        runtmp_session.sourmash('sketch', 'dna', genome, '-o', outfile)
+        mt = MoltypeHolder("dna", outfile, "", "--dna", "DNA")
+    elif moltype == "protein":
+        outfile = f"genome.{moltype}.sig.zip"
+        runtmp_session.sourmash('sketch', 'translate', genome, '-o', outfile)
+        mt = MoltypeHolder("dna", outfile, "", "--protein", "protein")
+    elif moltype == "hp":
+        outfile = f"genome.{moltype}.sig.zip"
+        runtmp_session.sourmash('sketch', 'translate', genome, '-o', outfile,
+                                "-p", "hp")
+        mt = MoltypeHolder("dna", outfile, "", "--hp", "hp")
+    elif moltype == "dayhoff":
+        outfile = f"genome.{moltype}.sig.zip"
+        runtmp_session.sourmash('sketch', 'translate', genome, '-o', outfile,
+                                "-p", "dayhoff")
+        mt = MoltypeHolder("dna", outfile, "", "--dayhoff", "dayhoff")
+    elif moltype == "skipm1n3":
+        outfile = f"genome.{moltype}.sig.zip"
+        runtmp_session.sourmash('sketch', 'dna', genome, '-o', outfile,
+                                "-p", "skipm1n3")
+        mt = MoltypeHolder("dna", outfile, "", "--skipm1n3", "skipm1n3")
+    else:
+        assert 0
+    
+    yield (mt, runtmp_session)
+
+
+def test_sig_cat(moltype_sketches):
+    mt, rts = moltype_sketches
+    rts.sourmash('sig', 'cat', mt.cli_moltype_arg, mt.genome_sketch,
+                 '-o', rts.output('sig_cat.out.zip'))
+
+
+def test_sig_describe(moltype_sketches):
+    mt, rts = moltype_sketches
+    rts.sourmash('sig', 'describe', mt.cli_moltype_arg, mt.genome_sketch)
+    print(rts.last_result.out)
+    assert f"molecule={mt.molecule}" in rts.last_result.out
+
+
+#def test_sketch_file(runtmp, moltype):
+#    genome = utils.get_test_data('genome-s10+s11.fa.gz')
+#    runtmp.sourmash('sketch', moltype, genome, '-o', f'xxx.{moltype}.sig.zip')
+#
+#    print(moltype)
+#    assert 0
+

--- a/tests/test_moltypes.py
+++ b/tests/test_moltypes.py
@@ -8,7 +8,8 @@ MoltypeHolder = namedtuple(
 )
 
 
-@pytest.fixture(scope="session", params=["dna", "protein", "hp", "dayhoff", "skipm1n3"])
+#@pytest.fixture(scope="session", params=["dna", "protein", "hp", "dayhoff", "skipm1n3"])
+@pytest.fixture(scope="session", params=["dna", "protein", "hp", "dayhoff"])
 def moltype(request):
     yield request.param
 
@@ -16,29 +17,42 @@ def moltype(request):
 # build and return genome & metagenome sketches of the given moltype
 @pytest.fixture(scope="session")
 def moltype_sketches(runtmp_session, moltype):
-    genome = utils.get_test_data("genome-s10+s11.fa.gz")
+    genome = utils.get_test_data("genome-s10.fa.gz")
+    metagenome = utils.get_test_data("genome-s10+s11.fa.gz")
 
     # @CTB use match!
     if moltype == "dna":
         outfile = "genome.dna.sig.zip"
         runtmp_session.sourmash("sketch", "dna", genome, "-o", outfile)
-        mt = MoltypeHolder("dna", outfile, "", "--dna", "DNA")
+        outfile2 = "metagenome.dna.sig.zip"
+        runtmp_session.sourmash("sketch", "dna", metagenome, "-o", outfile2)
+        mt = MoltypeHolder("dna", outfile, outfile2, "--dna", "DNA")
     elif moltype == "protein":
         outfile = f"genome.{moltype}.sig.zip"
         runtmp_session.sourmash("sketch", "translate", genome, "-o", outfile)
-        mt = MoltypeHolder("dna", outfile, "", "--protein", "protein")
+        outfile2 = f"metagenome.{moltype}.sig.zip"
+        runtmp_session.sourmash("sketch", "translate", metagenome, "-o", outfile2)
+        mt = MoltypeHolder("dna", outfile, outfile2, "--protein", "protein")
     elif moltype == "hp":
         outfile = f"genome.{moltype}.sig.zip"
         runtmp_session.sourmash(
             "sketch", "translate", genome, "-o", outfile, "-p", "hp"
         )
-        mt = MoltypeHolder("dna", outfile, "", "--hp", "hp")
+        outfile2 = f"metagenome.{moltype}.sig.zip"
+        runtmp_session.sourmash(
+            "sketch", "translate", metagenome, "-o", outfile2, "-p", "hp"
+        )
+        mt = MoltypeHolder("dna", outfile, outfile2, "--hp", "hp")
     elif moltype == "dayhoff":
         outfile = f"genome.{moltype}.sig.zip"
         runtmp_session.sourmash(
             "sketch", "translate", genome, "-o", outfile, "-p", "dayhoff"
         )
-        mt = MoltypeHolder("dna", outfile, "", "--dayhoff", "dayhoff")
+        outfile2 = f"metagenome.{moltype}.sig.zip"
+        runtmp_session.sourmash(
+            "sketch", "translate", metagenome, "-o", outfile2, "-p", "dayhoff"
+        )
+        mt = MoltypeHolder("dna", outfile, outfile2, "--dayhoff", "dayhoff")
     elif moltype == "skipm1n3":
         outfile = f"genome.{moltype}.sig.zip"
         runtmp_session.sourmash(
@@ -47,6 +61,10 @@ def moltype_sketches(runtmp_session, moltype):
         mt = MoltypeHolder("dna", outfile, "", "--skipm1n3", "skipm1n3")
     else:
         assert 0
+
+    assert mt.genome_sketch
+    assert mt.metag_sketch
+    assert mt.genome_sketch != mt.metag_sketch
 
     yield (mt, runtmp_session)
 

--- a/tests/test_moltypes.py
+++ b/tests/test_moltypes.py
@@ -12,8 +12,7 @@ MoltypeHolder = namedtuple(
 )
 
 
-#@pytest.fixture(scope="session", params=["dna", "protein", "hp", "dayhoff", "skipm1n3"])
-@pytest.fixture(scope="session", params=["dna", "protein", "hp", "dayhoff"])
+@pytest.fixture(scope="session", params=["dna", "protein", "hp", "dayhoff", "skipm1n3", "skipm2n3"])
 def moltype(request):
     yield request.param
 
@@ -35,7 +34,7 @@ def moltype_sketches(runtmp_session, moltype):
     elif moltype == "protein":
         runtmp_session.sourmash("sketch", "translate", genome, "-o", outfile)
         runtmp_session.sourmash("sketch", "translate", metagenome, "-o", outfile2)
-        mt = MoltypeHolder("dna", outfile, outfile2, "--protein", "protein")
+        mt = MoltypeHolder("protein", outfile, outfile2, "--protein", "protein")
     elif moltype == "hp":
         runtmp_session.sourmash(
             "sketch", "translate", genome, "-o", outfile, "-p", "hp"
@@ -43,7 +42,7 @@ def moltype_sketches(runtmp_session, moltype):
         runtmp_session.sourmash(
             "sketch", "translate", metagenome, "-o", outfile2, "-p", "hp"
         )
-        mt = MoltypeHolder("dna", outfile, outfile2, "--hp", "hp")
+        mt = MoltypeHolder("hp", outfile, outfile2, "--hp", "hp")
     elif moltype == "dayhoff":
         runtmp_session.sourmash(
             "sketch", "translate", genome, "-o", outfile, "-p", "dayhoff"
@@ -51,15 +50,23 @@ def moltype_sketches(runtmp_session, moltype):
         runtmp_session.sourmash(
             "sketch", "translate", metagenome, "-o", outfile2, "-p", "dayhoff"
         )
-        mt = MoltypeHolder("dna", outfile, outfile2, "--dayhoff", "dayhoff")
+        mt = MoltypeHolder("dayhoff", outfile, outfile2, "--dayhoff", "dayhoff")
     elif moltype == "skipm1n3":
         runtmp_session.sourmash(
             "sketch", "dna", genome, "-o", outfile, "-p", "skipm1n3"
         )
         runtmp_session.sourmash(
-            "sketch", "translate", metagenome, "-o", outfile2, "-p", "skipm1n3"
+            "sketch", "dna", metagenome, "-o", outfile2, "-p", "skipm1n3"
         )
-        mt = MoltypeHolder("dna", outfile, "", "--skipm1n3", "skipm1n3")
+        mt = MoltypeHolder("skipm1n3", outfile, outfile2, "--skipm1n3", "skipm1n3")
+    elif moltype == "skipm2n3":
+        runtmp_session.sourmash(
+            "sketch", "dna", genome, "-o", outfile, "-p", "skipm2n3"
+        )
+        runtmp_session.sourmash(
+            "sketch", "dna", metagenome, "-o", outfile2, "-p", "skipm2n3"
+        )
+        mt = MoltypeHolder("skipm2n3", outfile, outfile2, "--skipm2n3", "skipm2n3")
     else:
         assert 0
 

--- a/tests/test_moltypes.py
+++ b/tests/test_moltypes.py
@@ -2,14 +2,13 @@ import pytest
 import sourmash_tst_utils as utils
 from collections import namedtuple
 
-MoltypeHolder = namedtuple("MoltypeHolder", ['moltype_descr',
-                                             'genome_sketch',
-                                             'metag_sketch',
-                                             'cli_moltype_arg',
-                                             'molecule'])
+MoltypeHolder = namedtuple(
+    "MoltypeHolder",
+    ["moltype_descr", "genome_sketch", "metag_sketch", "cli_moltype_arg", "molecule"],
+)
 
-@pytest.fixture(scope="session",
-                params=["dna", "protein", "hp", "dayhoff", "skipm1n3"])
+
+@pytest.fixture(scope="session", params=["dna", "protein", "hp", "dayhoff", "skipm1n3"])
 def moltype(request):
     yield request.param
 
@@ -17,55 +16,63 @@ def moltype(request):
 # build and return genome & metagenome sketches of the given moltype
 @pytest.fixture(scope="session")
 def moltype_sketches(runtmp_session, moltype):
-    genome = utils.get_test_data('genome-s10+s11.fa.gz')
+    genome = utils.get_test_data("genome-s10+s11.fa.gz")
 
     # @CTB use match!
     if moltype == "dna":
-        outfile = f"genome.dna.sig.zip"
-        runtmp_session.sourmash('sketch', 'dna', genome, '-o', outfile)
+        outfile = "genome.dna.sig.zip"
+        runtmp_session.sourmash("sketch", "dna", genome, "-o", outfile)
         mt = MoltypeHolder("dna", outfile, "", "--dna", "DNA")
     elif moltype == "protein":
         outfile = f"genome.{moltype}.sig.zip"
-        runtmp_session.sourmash('sketch', 'translate', genome, '-o', outfile)
+        runtmp_session.sourmash("sketch", "translate", genome, "-o", outfile)
         mt = MoltypeHolder("dna", outfile, "", "--protein", "protein")
     elif moltype == "hp":
         outfile = f"genome.{moltype}.sig.zip"
-        runtmp_session.sourmash('sketch', 'translate', genome, '-o', outfile,
-                                "-p", "hp")
+        runtmp_session.sourmash(
+            "sketch", "translate", genome, "-o", outfile, "-p", "hp"
+        )
         mt = MoltypeHolder("dna", outfile, "", "--hp", "hp")
     elif moltype == "dayhoff":
         outfile = f"genome.{moltype}.sig.zip"
-        runtmp_session.sourmash('sketch', 'translate', genome, '-o', outfile,
-                                "-p", "dayhoff")
+        runtmp_session.sourmash(
+            "sketch", "translate", genome, "-o", outfile, "-p", "dayhoff"
+        )
         mt = MoltypeHolder("dna", outfile, "", "--dayhoff", "dayhoff")
     elif moltype == "skipm1n3":
         outfile = f"genome.{moltype}.sig.zip"
-        runtmp_session.sourmash('sketch', 'dna', genome, '-o', outfile,
-                                "-p", "skipm1n3")
+        runtmp_session.sourmash(
+            "sketch", "dna", genome, "-o", outfile, "-p", "skipm1n3"
+        )
         mt = MoltypeHolder("dna", outfile, "", "--skipm1n3", "skipm1n3")
     else:
         assert 0
-    
+
     yield (mt, runtmp_session)
 
 
 def test_sig_cat(moltype_sketches):
     mt, rts = moltype_sketches
-    rts.sourmash('sig', 'cat', mt.cli_moltype_arg, mt.genome_sketch,
-                 '-o', rts.output('sig_cat.out.zip'))
+    rts.sourmash(
+        "sig",
+        "cat",
+        mt.cli_moltype_arg,
+        mt.genome_sketch,
+        "-o",
+        rts.output("sig_cat.out.zip"),
+    )
 
 
 def test_sig_describe(moltype_sketches):
     mt, rts = moltype_sketches
-    rts.sourmash('sig', 'describe', mt.cli_moltype_arg, mt.genome_sketch)
+    rts.sourmash("sig", "describe", mt.cli_moltype_arg, mt.genome_sketch)
     print(rts.last_result.out)
     assert f"molecule={mt.molecule}" in rts.last_result.out
 
 
-#def test_sketch_file(runtmp, moltype):
+# def test_sketch_file(runtmp, moltype):
 #    genome = utils.get_test_data('genome-s10+s11.fa.gz')
 #    runtmp.sourmash('sketch', moltype, genome, '-o', f'xxx.{moltype}.sig.zip')
 #
 #    print(moltype)
 #    assert 0
-

--- a/tests/test_moltypes.py
+++ b/tests/test_moltypes.py
@@ -8,8 +8,6 @@ import sourmash_tst_utils as utils
 from sourmash.sourmash_args import load_one_signature
 from sourmash.command_sketch import _signatures_for_sketch_factory, ComputeParameters
 
-# @CTB test: sketch fromfile
-
 
 MoltypeHolder = namedtuple(
     "MoltypeHolder",

--- a/tests/test_moltypes.py
+++ b/tests/test_moltypes.py
@@ -1,14 +1,20 @@
+import os
 import pytest
 from collections import namedtuple
+import numpy
 
 import sourmash
 import sourmash_tst_utils as utils
 from sourmash.sourmash_args import load_one_signature
+from sourmash.command_sketch import (_signatures_for_sketch_factory,
+                                     ComputeParameters)
+
+# @CTB test: sketch fromfile
 
 
 MoltypeHolder = namedtuple(
     "MoltypeHolder",
-    ["moltype_descr", "genome_sketch", "metag_sketch", "cli_moltype_arg", "molecule"],
+    ["moltype", "genome_sketch", "metag_sketch", "cli_moltype_arg", "molecule"],
 )
 
 
@@ -17,7 +23,13 @@ def moltype(request):
     yield request.param
 
 
-# build and return genome & metagenome sketches of the given moltype
+@pytest.fixture(scope="session", params=["dna", "protein", "hp", "dayhoff", "skipm1n3", "skipm2n3"])
+def moltype2(request):
+    yield request.param
+
+
+# build and return genome & metagenome sketches of the given moltype, using
+# MoltypeHolder.
 @pytest.fixture(scope="session")
 def moltype_sketches(runtmp_session, moltype):
     genome = utils.get_test_data("genome-s10.fa.gz")
@@ -25,6 +37,8 @@ def moltype_sketches(runtmp_session, moltype):
 
     outfile = runtmp_session.output(f"genome.{moltype}.sig.zip")
     outfile2 = runtmp_session.output(f"metagenome.{moltype}.sig.zip")
+    assert not os.path.exists(outfile)
+    assert not os.path.exists(outfile2)
         
     # @CTB use match!
     if moltype == "dna":
@@ -68,13 +82,87 @@ def moltype_sketches(runtmp_session, moltype):
         )
         mt = MoltypeHolder("skipm2n3", outfile, outfile2, "--skipm2n3", "skipm2n3")
     else:
-        assert 0
+        assert 0, "unknown moltype!?"
 
     assert mt.genome_sketch
     assert mt.metag_sketch
     assert mt.genome_sketch != mt.metag_sketch
 
     yield (mt, runtmp_session)
+
+
+#
+# all the actual tests
+#
+
+
+def test_factory_moltype(moltype):
+    factory = _signatures_for_sketch_factory([moltype], None)
+    params_list = list(factory.get_compute_params())
+    assert len(params_list) == 1
+
+    params = params_list[0]
+    assert getattr(params, moltype)
+
+
+def test_factory_moltype_equal(moltype):
+    factory1 = _signatures_for_sketch_factory([moltype], None)
+    params_list1 = list(factory1.get_compute_params())
+    assert len(params_list1) == 1
+    params1 = params_list1[0]
+
+    factory2 = _signatures_for_sketch_factory([], moltype)
+    params_list2 = list(factory2.get_compute_params())
+    assert len(params_list2) == 1
+    params2 = params_list2[0]
+
+    assert params1 == params2
+    assert repr(params1) == repr(params2)
+
+    descr = repr(params1)
+    assert f"{moltype}=True" in descr
+
+
+def test_factory_moltype_ne(moltype, moltype2):
+    # make sure that params are different for different moltypes
+    # (tests that __eq__ fails properly ;)
+    if moltype == moltype2:
+        return
+
+    factory1 = _signatures_for_sketch_factory([moltype], None)
+    params_list1 = list(factory1.get_compute_params())
+    assert len(params_list1) == 1
+    params1 = params_list1[0]
+
+    factory2 = _signatures_for_sketch_factory([moltype2], None)
+    params_list2 = list(factory2.get_compute_params())
+    assert len(params_list2) == 1
+    params2 = params_list2[0]
+
+    assert params1 != params2
+    assert repr(params1) != repr(params2)
+
+
+def test_manifest_row_to_compute_parameters(moltype, moltype2):
+    if moltype == moltype2:
+        return
+
+    # test ComputeParameters.from_manifest_row with moltype
+    if moltype == "dna":
+        moltype_str = "DNA"
+    else:
+        moltype_str = moltype
+
+    row = dict(moltype=moltype_str,
+               ksize=21, num=0, scaled=1000, with_abundance=1)
+    p = ComputeParameters.from_manifest_row(row)
+    assert getattr(p, moltype)
+    assert not getattr(p, moltype2)
+    assert p.moltype.lower() == moltype
+    assert p.num_hashes == 0
+    assert p.scaled == 1000
+    assert p.track_abundance
+    assert p.seed == 42
 
 
 def test_api_load(moltype_sketches):
@@ -105,6 +193,7 @@ def test_api_overlap(moltype_sketches):
 
 
 def test_sig_cat(moltype_sketches):
+    # test: cat works
     mt, rts = moltype_sketches
     rts.sourmash(
         "sig",
@@ -112,20 +201,106 @@ def test_sig_cat(moltype_sketches):
         mt.cli_moltype_arg,
         mt.genome_sketch,
         "-o",
-        rts.output("sig_cat.out.zip"),
+        rts.output(f"sig_cat.out.{mt.moltype}.zip"),
     )
 
 
 def test_sig_describe(moltype_sketches):
+    # test: describe works
     mt, rts = moltype_sketches
     rts.sourmash("sig", "describe", mt.cli_moltype_arg, mt.genome_sketch)
     print(rts.last_result.out)
     assert f"molecule={mt.molecule}" in rts.last_result.out
 
 
-# def test_sketch_file(runtmp, moltype):
-#    genome = utils.get_test_data('genome-s10+s11.fa.gz')
-#    runtmp.sourmash('sketch', moltype, genome, '-o', f'xxx.{moltype}.sig.zip')
-#
-#    print(moltype)
-#    assert 0
+def test_search(moltype_sketches):
+    # test: search finds matches.
+    mt, rts = moltype_sketches
+
+    output = rts.output(f"search.{mt.moltype}.csv")
+    assert not os.path.exists(output)
+
+    rts.sourmash("search", mt.cli_moltype_arg, mt.genome_sketch,
+                 mt.metag_sketch, "-o", output)
+
+    with open(output, newline="") as fp:
+        x = fp.readlines()
+    print(x)
+    assert len(x) == 2
+
+
+def test_compare(moltype_sketches):
+    # test: compare finds matches.
+    mt, rts = moltype_sketches
+
+    output = rts.output(f"compare.{mt.moltype}.cmp")
+    assert not os.path.exists(output)
+
+    rts.sourmash("compare", mt.cli_moltype_arg, mt.genome_sketch,
+                 mt.metag_sketch, "-o", output)
+
+    with open(output, "rb") as fp:
+        arr = numpy.load(fp)
+    print(arr)
+    assert arr[0,1] > 0
+
+
+def test_index(moltype_sketches, disk_index_type):
+    # test: 'index' works
+    mt, rts = moltype_sketches
+
+    outfile = rts.output(f"index.{mt.moltype}.{disk_index_type}")
+    assert not os.path.exists(outfile)
+
+    rts.sourmash("index", mt.cli_moltype_arg, "-F", disk_index_type,
+                 outfile, mt.genome_sketch)
+    print(rts.last_result.err)
+    assert "loaded 1 sigs; saving" in rts.last_result.err
+
+
+def test_gather(moltype_sketches):
+    # test: 'gather' works
+    mt, rts = moltype_sketches
+
+    output = rts.output(f"gather.{mt.moltype}.csv")
+    assert not os.path.exists(output)
+
+    rts.sourmash("gather", mt.cli_moltype_arg, mt.metag_sketch,
+                 mt.genome_sketch, "-o", output)
+
+    with open(output, newline="") as fp:
+        x = fp.readlines()
+    print(x)
+    assert len(x) == 2
+
+
+def test_prefetch(moltype_sketches):
+    # test: 'prefetch' works
+    mt, rts = moltype_sketches
+
+    output = rts.output(f"prefetch.{mt.moltype}.csv")
+    assert not os.path.exists(output)
+
+    rts.sourmash("prefetch", mt.cli_moltype_arg, mt.metag_sketch,
+                 mt.genome_sketch, "-o", output)
+
+    with open(output, newline="") as fp:
+        x = fp.readlines()
+    print(x)
+    assert len(x) == 2
+
+
+def test_sig_manifest(moltype_sketches):
+    # test: 'sig manifest' works
+    mt, rts = moltype_sketches
+
+    output = rts.output(f"manifest.{mt.moltype}.csv")
+    assert not os.path.exists(output)
+
+    rts.sourmash("sig", "manifest", mt.genome_sketch, "-o", output)
+
+    with open(output, newline="") as fp:
+        x = fp.readlines()
+    print(x)
+    assert len(x) == 3
+    assert f",{mt.molecule}," in x[-1]

--- a/tests/test_moltypes.py
+++ b/tests/test_moltypes.py
@@ -1,6 +1,10 @@
 import pytest
-import sourmash_tst_utils as utils
 from collections import namedtuple
+
+import sourmash
+import sourmash_tst_utils as utils
+from sourmash.sourmash_args import load_one_signature
+
 
 MoltypeHolder = namedtuple(
     "MoltypeHolder",
@@ -20,43 +24,40 @@ def moltype_sketches(runtmp_session, moltype):
     genome = utils.get_test_data("genome-s10.fa.gz")
     metagenome = utils.get_test_data("genome-s10+s11.fa.gz")
 
+    outfile = runtmp_session.output(f"genome.{moltype}.sig.zip")
+    outfile2 = runtmp_session.output(f"metagenome.{moltype}.sig.zip")
+        
     # @CTB use match!
     if moltype == "dna":
-        outfile = "genome.dna.sig.zip"
         runtmp_session.sourmash("sketch", "dna", genome, "-o", outfile)
-        outfile2 = "metagenome.dna.sig.zip"
         runtmp_session.sourmash("sketch", "dna", metagenome, "-o", outfile2)
         mt = MoltypeHolder("dna", outfile, outfile2, "--dna", "DNA")
     elif moltype == "protein":
-        outfile = f"genome.{moltype}.sig.zip"
         runtmp_session.sourmash("sketch", "translate", genome, "-o", outfile)
-        outfile2 = f"metagenome.{moltype}.sig.zip"
         runtmp_session.sourmash("sketch", "translate", metagenome, "-o", outfile2)
         mt = MoltypeHolder("dna", outfile, outfile2, "--protein", "protein")
     elif moltype == "hp":
-        outfile = f"genome.{moltype}.sig.zip"
         runtmp_session.sourmash(
             "sketch", "translate", genome, "-o", outfile, "-p", "hp"
         )
-        outfile2 = f"metagenome.{moltype}.sig.zip"
         runtmp_session.sourmash(
             "sketch", "translate", metagenome, "-o", outfile2, "-p", "hp"
         )
         mt = MoltypeHolder("dna", outfile, outfile2, "--hp", "hp")
     elif moltype == "dayhoff":
-        outfile = f"genome.{moltype}.sig.zip"
         runtmp_session.sourmash(
             "sketch", "translate", genome, "-o", outfile, "-p", "dayhoff"
         )
-        outfile2 = f"metagenome.{moltype}.sig.zip"
         runtmp_session.sourmash(
             "sketch", "translate", metagenome, "-o", outfile2, "-p", "dayhoff"
         )
         mt = MoltypeHolder("dna", outfile, outfile2, "--dayhoff", "dayhoff")
     elif moltype == "skipm1n3":
-        outfile = f"genome.{moltype}.sig.zip"
         runtmp_session.sourmash(
             "sketch", "dna", genome, "-o", outfile, "-p", "skipm1n3"
+        )
+        runtmp_session.sourmash(
+            "sketch", "translate", metagenome, "-o", outfile2, "-p", "skipm1n3"
         )
         mt = MoltypeHolder("dna", outfile, "", "--skipm1n3", "skipm1n3")
     else:
@@ -67,6 +68,33 @@ def moltype_sketches(runtmp_session, moltype):
     assert mt.genome_sketch != mt.metag_sketch
 
     yield (mt, runtmp_session)
+
+
+def test_api_load(moltype_sketches):
+    # can we load exactly one sketch? yay.
+    mt, rts = moltype_sketches
+
+    gsig = load_one_signature(mt.genome_sketch, select_moltype=mt.molecule)
+    msig = load_one_signature(mt.metag_sketch, select_moltype=mt.molecule)
+
+    assert gsig.minhash.moltype == mt.molecule
+    assert msig.minhash.moltype == mt.molecule
+
+
+def test_api_overlap(moltype_sketches):
+    # test basic overlap calculations
+    mt, rts = moltype_sketches
+
+    gsig = load_one_signature(mt.genome_sketch, select_moltype=mt.molecule)
+    msig = load_one_signature(mt.metag_sketch, select_moltype=mt.molecule)
+
+    mh1 = gsig.minhash
+    mh2 = msig.minhash
+
+    assert mh1.contained_by(mh2) == 1.0
+    assert mh2.contained_by(mh1) > 0
+    assert mh1.jaccard(mh2) > 0
+    assert mh1.jaccard(mh2) < 1
 
 
 def test_sig_cat(moltype_sketches):

--- a/tests/test_moltypes.py
+++ b/tests/test_moltypes.py
@@ -6,8 +6,7 @@ import numpy
 import sourmash
 import sourmash_tst_utils as utils
 from sourmash.sourmash_args import load_one_signature
-from sourmash.command_sketch import (_signatures_for_sketch_factory,
-                                     ComputeParameters)
+from sourmash.command_sketch import _signatures_for_sketch_factory, ComputeParameters
 
 # @CTB test: sketch fromfile
 
@@ -18,12 +17,16 @@ MoltypeHolder = namedtuple(
 )
 
 
-@pytest.fixture(scope="session", params=["dna", "protein", "hp", "dayhoff", "skipm1n3", "skipm2n3"])
+@pytest.fixture(
+    scope="session", params=["dna", "protein", "hp", "dayhoff", "skipm1n3", "skipm2n3"]
+)
 def moltype(request):
     yield request.param
 
 
-@pytest.fixture(scope="session", params=["dna", "protein", "hp", "dayhoff", "skipm1n3", "skipm2n3"])
+@pytest.fixture(
+    scope="session", params=["dna", "protein", "hp", "dayhoff", "skipm1n3", "skipm2n3"]
+)
 def moltype2(request):
     yield request.param
 
@@ -39,7 +42,7 @@ def moltype_sketches(runtmp_session, moltype):
     outfile2 = runtmp_session.output(f"metagenome.{moltype}.sig.zip")
     assert not os.path.exists(outfile)
     assert not os.path.exists(outfile2)
-        
+
     # @CTB use match!
     if moltype == "dna":
         runtmp_session.sourmash("sketch", "dna", genome, "-o", outfile)
@@ -153,8 +156,7 @@ def test_manifest_row_to_compute_parameters(moltype, moltype2):
     else:
         moltype_str = moltype
 
-    row = dict(moltype=moltype_str,
-               ksize=21, num=0, scaled=1000, with_abundance=1)
+    row = dict(moltype=moltype_str, ksize=21, num=0, scaled=1000, with_abundance=1)
     p = ComputeParameters.from_manifest_row(row)
     assert getattr(p, moltype)
     assert not getattr(p, moltype2)
@@ -220,8 +222,9 @@ def test_search(moltype_sketches):
     output = rts.output(f"search.{mt.moltype}.csv")
     assert not os.path.exists(output)
 
-    rts.sourmash("search", mt.cli_moltype_arg, mt.genome_sketch,
-                 mt.metag_sketch, "-o", output)
+    rts.sourmash(
+        "search", mt.cli_moltype_arg, mt.genome_sketch, mt.metag_sketch, "-o", output
+    )
 
     with open(output, newline="") as fp:
         x = fp.readlines()
@@ -236,13 +239,14 @@ def test_compare(moltype_sketches):
     output = rts.output(f"compare.{mt.moltype}.cmp")
     assert not os.path.exists(output)
 
-    rts.sourmash("compare", mt.cli_moltype_arg, mt.genome_sketch,
-                 mt.metag_sketch, "-o", output)
+    rts.sourmash(
+        "compare", mt.cli_moltype_arg, mt.genome_sketch, mt.metag_sketch, "-o", output
+    )
 
     with open(output, "rb") as fp:
         arr = numpy.load(fp)
     print(arr)
-    assert arr[0,1] > 0
+    assert arr[0, 1] > 0
 
 
 def test_index(moltype_sketches, disk_index_type):
@@ -252,8 +256,9 @@ def test_index(moltype_sketches, disk_index_type):
     outfile = rts.output(f"index.{mt.moltype}.{disk_index_type}")
     assert not os.path.exists(outfile)
 
-    rts.sourmash("index", mt.cli_moltype_arg, "-F", disk_index_type,
-                 outfile, mt.genome_sketch)
+    rts.sourmash(
+        "index", mt.cli_moltype_arg, "-F", disk_index_type, outfile, mt.genome_sketch
+    )
     print(rts.last_result.err)
     assert "loaded 1 sigs; saving" in rts.last_result.err
 
@@ -265,8 +270,9 @@ def test_gather(moltype_sketches):
     output = rts.output(f"gather.{mt.moltype}.csv")
     assert not os.path.exists(output)
 
-    rts.sourmash("gather", mt.cli_moltype_arg, mt.metag_sketch,
-                 mt.genome_sketch, "-o", output)
+    rts.sourmash(
+        "gather", mt.cli_moltype_arg, mt.metag_sketch, mt.genome_sketch, "-o", output
+    )
 
     with open(output, newline="") as fp:
         x = fp.readlines()
@@ -281,8 +287,9 @@ def test_prefetch(moltype_sketches):
     output = rts.output(f"prefetch.{mt.moltype}.csv")
     assert not os.path.exists(output)
 
-    rts.sourmash("prefetch", mt.cli_moltype_arg, mt.metag_sketch,
-                 mt.genome_sketch, "-o", output)
+    rts.sourmash(
+        "prefetch", mt.cli_moltype_arg, mt.metag_sketch, mt.genome_sketch, "-o", output
+    )
 
     with open(output, newline="") as fp:
         x = fp.readlines()

--- a/tests/test_sourmash_sketch.py
+++ b/tests/test_sourmash_sketch.py
@@ -1735,18 +1735,19 @@ def test_fromfile_dna(runtmp):
     assert "** 1 total requested; output 1, skipped 0" in runtmp.last_result.err
 
 
-def test_fromfile_dna_csv_gz(runtmp):
-    # test with a gzipped csv
+def test_fromfile_dna(runtmp):
+    # does it run? yes, hopefully.
     test_inp = utils.get_test_data("sketch_fromfile")
     shutil.copytree(test_inp, runtmp.output("sketch_fromfile"))
 
-    # gzip the CSV file
-    with open(runtmp.output("sketch_fromfile/salmonella.csv"), "rb") as infp:
-        with gzip.open(runtmp.output("salmonella.csv.gz"), "w") as outfp:
-            outfp.write(infp.read())
-
     runtmp.sourmash(
-        "sketch", "fromfile", "salmonella.csv.gz", "-o", "out.zip", "-p", "dna"
+        "sketch",
+        "fromfile",
+        "sketch_fromfile/salmonella.csv",
+        "-o",
+        "out.zip",
+        "-p",
+        "dna",
     )
 
     print(runtmp.last_result.out)
@@ -1760,6 +1761,64 @@ def test_fromfile_dna_csv_gz(runtmp):
     ss = siglist[0]
     assert ss.name == "GCA_903797575 Salmonella enterica"
     assert ss.minhash.moltype == "DNA"
+    assert "** 1 total requested; output 1, skipped 0" in runtmp.last_result.err
+
+
+def test_fromfile_skipm1n3(runtmp):
+    # does it run? yes, hopefully.
+    test_inp = utils.get_test_data("sketch_fromfile")
+    shutil.copytree(test_inp, runtmp.output("sketch_fromfile"))
+
+    runtmp.sourmash(
+        "sketch",
+        "fromfile",
+        "sketch_fromfile/salmonella.csv",
+        "-o",
+        "out.zip",
+        "-p",
+        "skipm1n3",
+    )
+
+    print(runtmp.last_result.out)
+    print(runtmp.last_result.err)
+
+    assert os.path.exists(runtmp.output("out.zip"))
+    idx = sourmash.load_file_as_index(runtmp.output("out.zip"))
+    siglist = list(idx.signatures())
+
+    assert len(siglist) == 1
+    ss = siglist[0]
+    assert ss.name == "GCA_903797575 Salmonella enterica"
+    assert ss.minhash.moltype == "skipm1n3"
+    assert "** 1 total requested; output 1, skipped 0" in runtmp.last_result.err
+
+
+def test_fromfile_skipm2n3(runtmp):
+    # does it run? yes, hopefully.
+    test_inp = utils.get_test_data("sketch_fromfile")
+    shutil.copytree(test_inp, runtmp.output("sketch_fromfile"))
+
+    runtmp.sourmash(
+        "sketch",
+        "fromfile",
+        "sketch_fromfile/salmonella.csv",
+        "-o",
+        "out.zip",
+        "-p",
+        "skipm2n3",
+    )
+
+    print(runtmp.last_result.out)
+    print(runtmp.last_result.err)
+
+    assert os.path.exists(runtmp.output("out.zip"))
+    idx = sourmash.load_file_as_index(runtmp.output("out.zip"))
+    siglist = list(idx.signatures())
+
+    assert len(siglist) == 1
+    ss = siglist[0]
+    assert ss.name == "GCA_903797575 Salmonella enterica"
+    assert ss.minhash.moltype == "skipm2n3"
     assert "** 1 total requested; output 1, skipped 0" in runtmp.last_result.err
 
 

--- a/tests/test_sourmash_sketch.py
+++ b/tests/test_sourmash_sketch.py
@@ -472,6 +472,8 @@ def test_multiple_moltypes():
         ("dna,num=500", "dna,k=31,num=500"),
         ("scaled=1100,dna", "dna,k=31,scaled=1100"),
         ("dna,abund", "dna,k=31,scaled=1000,abund"),
+        ("skipm1n3", "skipm1n3,k=21,scaled=1000"),
+        ("skipm2n3", "skipm2n3,k=21,scaled=1000"),
     ],
 )
 def test_compute_parameters_to_param_str(input_param_str, expected_output):


### PR DESCRIPTION
This PR finishes adding full access to `skipm1n3` and `skipm2n3` skip-mer molecule types to the Python layer; moreover, it provides a fixture-based framework for testing addition of new moltypes.

Specifically,
* adds new `tests/test_moltypes.py` that systematically tests each supported moltype at the python layer and CLI layer;
* updates FFI layer to support skip-mers;
* adds documentation.

Fixes https://github.com/sourmash-bio/sourmash/issues/3449.
Related issues and PRs:
* #3446
* https://github.com/sourmash-bio/sourmash_plugin_branchwater/issues/549

TODO:
- [x] add tests for 'sketch fromfile'

