### PR TITLE
MRG: try fixing inline variables in rust `println!`

### DIFF
--- a/src/core/src/collection.rs
+++ b/src/core/src/collection.rs
@@ -163,7 +163,7 @@ impl Collection {
         let records: Vec<_> = iter
             .enumerate()
             .flat_map(|(i, sig)| {
-                let path = format!("{}", i);
+                let path = format!("{i}");
                 let mut record = Record::from_sig(&sig, &path);
                 let path = storage.save_sig(&path, sig).expect("Error saving sig");
                 record.iter_mut().for_each(|rec| {

--- a/src/core/src/ffi/utils.rs
+++ b/src/core/src/ffi/utils.rs
@@ -185,7 +185,7 @@ pub unsafe fn set_panic_hook() {
                 location.file(),
                 location.line()
             ),
-            None => format!("thread '{}' panicked with '{}'", thread, message),
+            None => format!("thread '{thread}' panicked with '{message}'"),
         };
 
         set_last_error(Panic(description).into())

--- a/src/core/src/index/linear.rs
+++ b/src/core/src/index/linear.rs
@@ -65,13 +65,13 @@ impl LinearIndex {
 
             let i = processed_sigs.fetch_add(1, Ordering::SeqCst);
             if i % 1000 == 0 {
-                info!("Processed {} reference sigs", i);
+                info!("Processed {i} reference sigs");
             }
 
             let search_sig = self
                 .collection
                 .sig_for_dataset(dataset_id)
-                .unwrap_or_else(|_| panic!("error loading {:?}", filename));
+                .unwrap_or_else(|_| panic!("error loading {filename:?}"));
 
             let mut search_mh = None;
             if let Some(Sketch::MinHash(mh)) = search_sig.select_sketch(template) {
@@ -87,7 +87,7 @@ impl LinearIndex {
 
             let (size, _) = small_mh
                 .intersection_size(large_mh)
-                .unwrap_or_else(|_| panic!("error computing intersection for {:?}", filename));
+                .unwrap_or_else(|_| panic!("error computing intersection for {filename:?}"));
 
             if size == 0 {
                 None

--- a/src/core/src/index/mod.rs
+++ b/src/core/src/index/mod.rs
@@ -238,7 +238,7 @@ pub fn calculate_gather_stats(
         .intersection(&remaining_query)
         .expect("could not do intersection");
     let isect_size = isect.0.len();
-    trace!("isect_size: {}", isect_size);
+    trace!("isect_size: {isect_size}");
     trace!("query.size: {}", remaining_query.size());
 
     //bp remaining in subtracted query

--- a/src/core/src/manifest.rs
+++ b/src/core/src/manifest.rs
@@ -322,7 +322,7 @@ impl From<&[PathBuf]> for Manifest {
         let records: Vec<Record> = iter
             .flat_map(|p| {
                 let recs: Vec<Record> = Signature::from_path(p)
-                    .unwrap_or_else(|_| panic!("Error processing {:?}", p))
+                    .unwrap_or_else(|_| panic!("Error processing {p:?}"))
                     .into_iter()
                     .flat_map(|v| Record::from_sig(&v, p.as_str()))
                     .collect();
@@ -336,12 +336,12 @@ impl From<&[PathBuf]> for Manifest {
 
 impl From<&PathBuf> for Manifest {
     fn from(pathlist: &PathBuf) -> Self {
-        let file = File::open(pathlist).unwrap_or_else(|_| panic!("Failed to open {:?}", pathlist));
+        let file = File::open(pathlist).unwrap_or_else(|_| panic!("Failed to open {pathlist:?}"));
         let reader = BufReader::new(file);
 
         let paths: Vec<PathBuf> = reader
             .lines()
-            .map(|line| line.unwrap_or_else(|_| panic!("Failed to read line from {:?}", pathlist)))
+            .map(|line| line.unwrap_or_else(|_| panic!("Failed to read line from {pathlist:?}")))
             .map(PathBuf::from)
             .collect();
 

--- a/src/core/src/signature.rs
+++ b/src/core/src/signature.rs
@@ -186,13 +186,12 @@ impl std::fmt::Display for ReadingFrame {
                 let rc_str = String::from_utf8_lossy(rc).to_string();
                 write!(
                     f,
-                    "Type: DNA ({}bp), Forward: {}, Reverse Complement: {}",
-                    len, fw_str, rc_str
+                    "Type: DNA ({len}bp), Forward: {fw_str}, Reverse Complement: {rc_str}"
                 )
             }
             ReadingFrame::Protein { fw, len } => {
                 let fw_str = String::from_utf8_lossy(fw).to_string();
-                write!(f, "Type: Protein ({}aa), Forward: {}", len, fw_str)
+                write!(f, "Type: Protein ({len}aa), Forward: {fw_str}")
             }
         }
     }
@@ -347,7 +346,7 @@ impl SeqToHashes {
             Self::skipmer_frames(seq, &hash_function, ksize)?
         } else {
             return Err(SourmashError::InvalidHashFunction {
-                function: format!("{:?}", hash_function),
+                function: format!("{hash_function:?}"),
             });
         };
 

--- a/src/core/src/sketch/minhash.rs
+++ b/src/core/src/sketch/minhash.rs
@@ -306,7 +306,7 @@ impl KmerMinHash {
             md5_ctx.consume(&buffer);
             buffer.clear();
             for x in &self.mins {
-                write!(&mut buffer, "{}", x).unwrap();
+                write!(&mut buffer, "{x}").unwrap();
                 md5_ctx.consume(&buffer);
                 buffer.clear();
             }
@@ -1261,7 +1261,7 @@ impl KmerMinHashBTree {
             md5_ctx.consume(&buffer);
             buffer.clear();
             for x in &self.mins {
-                write!(&mut buffer, "{}", x).unwrap();
+                write!(&mut buffer, "{x}").unwrap();
                 md5_ctx.consume(&buffer);
                 buffer.clear();
             }


### PR DESCRIPTION
Our beta Rust tests are failing with:
```
error: variables can be used directly in the `format!` string
   --> src/core/src/collection.rs:166:28
    |
166 |                 let path = format!("{}", i);
    |                            ^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
    = note: `-D clippy::uninlined-format-args` implied by `-D warnings`
```
so I'm seeing if we are ok with fixing these for the rest of the tests.