### PR TITLE
MRG: add cANI to `sig overlap`

### DIFF
--- a/src/sourmash/minhash.py
+++ b/src/sourmash/minhash.py
@@ -851,9 +851,11 @@ class MinHash(RustObject):
             raise TypeError(
                 "Error: Angular (cosine) similarity requires both sketches to track hash abundance."
             )
-        #return self._methodcall(lib.kmerminhash_angular_similarity, other._get_objptr())
+        # return self._methodcall(lib.kmerminhash_angular_similarity, other._get_objptr())
         # use similarity so we can downsample
-        return self._methodcall(lib.kmerminhash_similarity, other._get_objptr(), False, downsample)
+        return self._methodcall(
+            lib.kmerminhash_similarity, other._get_objptr(), False, downsample
+        )
 
     def is_compatible(self, other):
         return self._methodcall(lib.kmerminhash_is_compatible, other._get_objptr())

--- a/src/sourmash/minhash.py
+++ b/src/sourmash/minhash.py
@@ -845,13 +845,15 @@ class MinHash(RustObject):
             downsample,
         )
 
-    def angular_similarity(self, other):
+    def angular_similarity(self, other, downsample=False):
         "Calculate the angular similarity."
         if not (self.track_abundance and other.track_abundance):
             raise TypeError(
                 "Error: Angular (cosine) similarity requires both sketches to track hash abundance."
             )
-        return self._methodcall(lib.kmerminhash_angular_similarity, other._get_objptr())
+        #return self._methodcall(lib.kmerminhash_angular_similarity, other._get_objptr())
+        # use similarity so we can downsample
+        return self._methodcall(lib.kmerminhash_similarity, other._get_objptr(), False, downsample)
 
     def is_compatible(self, other):
         return self._methodcall(lib.kmerminhash_is_compatible, other._get_objptr())

--- a/src/sourmash/minhash.py
+++ b/src/sourmash/minhash.py
@@ -884,6 +884,26 @@ class MinHash(RustObject):
         else:
             return containment
 
+    def contained_by_weighted(self, other):
+        """
+        Calculate how much of self is contained by other; weight by self.
+        Note: automatically downsamples as needed -- is this ok?
+        """
+        # should we debias this like standard containment?
+        if not (self.scaled and other.scaled):
+            raise TypeError(
+                "Error: can only calculate containment for scaled MinHashes"
+            )
+        self_mh = self.copy()
+        self_ds = self_mh.downsample(scaled=other.scaled)
+        self_mh = self_ds.flatten()
+        other_mh = flatten_and_downsample_scaled(other, self.scaled)
+
+        intersect_mh = other_mh.inflate(self)
+        weighted_common = intersect_mh.sum_abundances
+        weighted_total = self_ds.sum_abundances
+        return weighted_common / weighted_total
+
     def containment_ani(
         self,
         other,

--- a/src/sourmash/sig/__main__.py
+++ b/src/sourmash/sig/__main__.py
@@ -401,6 +401,10 @@ def overlap(args):
     cont1 = sig1.contained_by(sig2)
     cont2 = sig2.contained_by(sig1)
 
+    cANI1 = sig1.containment_ani(sig2).ani
+    cANI2 = sig2.containment_ani(sig1).ani
+    avg_cANI = (cANI1 + cANI2) / 2
+
     sig1_file = args.signature1
     sig2_file = args.signature2
 
@@ -442,8 +446,9 @@ second signature:
   k={ksize} molecule={moltype} num={num} scaled={scaled}
 
 similarity:                  {similarity:.5f}
-first contained in second:   {cont1:.5f}
-second contained in first:   {cont2:.5f}
+first contained in second:   {cont1:.5f} (cANI: {cANI1:.5f})
+second contained in first:   {cont2:.5f} (cANI: {cANI2:.5f})
+average containment ANI:     {avg_cANI:.5f}
 
 number of hashes in first:   {size1}
 number of hashes in second:  {size2}
@@ -452,7 +457,9 @@ number of hashes in common:  {num_common}
 only in first:               {disjoint_1}
 only in second:              {disjoint_2}
 total (union):               {num_union}
-""".format(**locals())
+""".format(
+            **locals()
+        )
     )
 
 

--- a/src/sourmash/sig/__main__.py
+++ b/src/sourmash/sig/__main__.py
@@ -462,7 +462,7 @@ total (union):               {num_union}
 
     # if we have abundance for both sketches, calculate abundance-weighted measures
     if sig1.minhash.track_abundance and sig2.minhash.track_abundance:
-        angular_similarity = sig1.similarity(sig2)
+        angular_similarity = sig1.angular_similarity(sig2)
         print(
             f"""\
 Measurements with abundance:

--- a/src/sourmash/sig/__main__.py
+++ b/src/sourmash/sig/__main__.py
@@ -394,7 +394,7 @@ def overlap(args):
     notify(f"loaded one signature each from {args.signature1} and {args.signature2}")
 
     try:
-        similarity = sig1.similarity(sig2)
+        jaccard = sig1.jaccard(sig2)
     except ValueError:
         raise
 
@@ -432,7 +432,7 @@ def overlap(args):
     num_union = len(hashes_1.union(hashes_2))
 
     print(
-        """\
+        f"""\
 first signature:
   signature filename: {sig1_file}
   signature: {name1}
@@ -445,7 +445,7 @@ second signature:
   md5: {md5_2}
   k={ksize} molecule={moltype} num={num} scaled={scaled}
 
-similarity:                  {similarity:.5f}
+jaccard similarity:          {jaccard:.5f}
 first contained in second:   {cont1:.5f} (cANI: {cANI1:.5f})
 second contained in first:   {cont2:.5f} (cANI: {cANI2:.5f})
 average containment ANI:     {avg_cANI:.5f}
@@ -457,10 +457,18 @@ number of hashes in common:  {num_common}
 only in first:               {disjoint_1}
 only in second:              {disjoint_2}
 total (union):               {num_union}
-""".format(
-            **locals()
-        )
+"""
     )
+
+    # if we have abundance for both sketches, calculate abundance-weighted measures
+    if sig1.minhash.track_abundance and sig2.minhash.track_abundance:
+        angular_similarity = sig1.similarity(sig2)
+        print(
+            f"""\
+Measurements with abundance:
+angular similarity:          {angular_similarity:.5f}
+"""
+        )
 
 
 def merge(args):

--- a/src/sourmash/sig/__main__.py
+++ b/src/sourmash/sig/__main__.py
@@ -403,11 +403,24 @@ def overlap(args):
         cont1 = sig1.contained_by(sig2)
         cont2 = sig2.contained_by(sig1)
 
-        cANI1 = sig1.containment_ani(sig2).ani
-        cANI2 = sig2.containment_ani(sig1).ani
-        avg_cANI = (cANI1 + cANI2) / 2
+        cANI_result = sig1.containment_ani(sig2)
+        size_estimate_inaccurate = cANI_result.size_is_inaccurate
+        print("size_estimate_inaccurate:", size_estimate_inaccurate)
+        if size_estimate_inaccurate:
+            similarity_info = f"""\
+--- Similarity measures ---
+jaccard similarity:          {jaccard:.5f}
+first contained in second:   {cont1:.5f}
+second contained in first:   {cont2:.5f}
 
-        similarity_info = f"""\
+Note: cANI values not reported. One or more sketches contains too few hashes for accurate size estimation.
+"""
+        else:
+            cANI1 = cANI_result.ani
+            cANI2 = sig2.containment_ani(sig1).ani
+            avg_cANI = (cANI1 + cANI2) / 2
+
+            similarity_info = f"""\
 --- Similarity measures ---
 jaccard similarity:          {jaccard:.5f}
 first contained in second:   {cont1:.5f} (cANI: {cANI1:.5f})

--- a/src/sourmash/sig/__main__.py
+++ b/src/sourmash/sig/__main__.py
@@ -408,6 +408,7 @@ def overlap(args):
         avg_cANI = (cANI1 + cANI2) / 2
 
         similarity_info = f"""\
+--- Similarity measures ---
 jaccard similarity:          {jaccard:.5f}
 first contained in second:   {cont1:.5f} (cANI: {cANI1:.5f})
 second contained in first:   {cont2:.5f} (cANI: {cANI2:.5f})
@@ -415,6 +416,7 @@ average containment ANI:     {avg_cANI:.5f}
 """
     else:
         similarity_info = f"""\
+--- Similarity measures ---
 jaccard similarity:          {jaccard:.5f}
 containment and ANI not available (one or both signatures are not scaled)
 """
@@ -430,13 +432,34 @@ containment and ANI not available (one or both signatures are not scaled)
     disjoint_2 = len(hashes_2 - hashes_1)
     num_union = len(hashes_1.union(hashes_2))
 
+    hash_counts_info = f"""\
+--- Hash overlap summary ---
+number of hashes in first:   {size1}
+number of hashes in second:  {size2}
+
+number of hashes in common:  {num_common}
+only in first:               {disjoint_1}
+only in second:              {disjoint_2}
+total (union):               {num_union}
+"""
+
     # --- conditional abundance info ---
     abundance_info = ""
     if sig1.minhash.track_abundance and sig2.minhash.track_abundance:
         angular_similarity = sig1.angular_similarity(sig2)
+        sum_hashes1 =  sum(sig1.minhash.hashes.values())
+        sum_hashes2 = sum(sig2.minhash.hashes.values())
+        weighted_containment1 = sig1.contained_by_weighted(sig2)
+        weighted_containment2 = sig2.contained_by_weighted(sig1)
         abundance_info = f"""\
-Measurements with abundance:
+--- Abundance-weighted similarity: ---
 angular similarity:          {angular_similarity:.5f}
+first contained in second (weighted): {weighted_containment1:.5f}
+second contained in first (weighted): {weighted_containment2:.5f}
+
+number of hashes in first (weighted): {sum_hashes1}
+number of hashes in second (weighted): {sum_hashes2}
+
     """
     # --- output ---
     print("first signature:")
@@ -447,13 +470,8 @@ angular similarity:          {angular_similarity:.5f}
     print(
         f"""\
 {similarity_info}
-number of hashes in first:   {size1}
-number of hashes in second:  {size2}
 
-number of hashes in common:  {num_common}
-only in first:               {disjoint_1}
-only in second:              {disjoint_2}
-total (union):               {num_union}
+{hash_counts_info}
 
 {abundance_info}
 """

--- a/src/sourmash/sig/__main__.py
+++ b/src/sourmash/sig/__main__.py
@@ -457,9 +457,7 @@ number of hashes in common:  {num_common}
 only in first:               {disjoint_1}
 only in second:              {disjoint_2}
 total (union):               {num_union}
-""".format(
-            **locals()
-        )
+""".format(**locals())
     )
 
 

--- a/src/sourmash/sig/__main__.py
+++ b/src/sourmash/sig/__main__.py
@@ -447,7 +447,7 @@ total (union):               {num_union}
     abundance_info = ""
     if sig1.minhash.track_abundance and sig2.minhash.track_abundance:
         angular_similarity = sig1.angular_similarity(sig2)
-        sum_hashes1 =  sum(sig1.minhash.hashes.values())
+        sum_hashes1 = sum(sig1.minhash.hashes.values())
         sum_hashes2 = sum(sig2.minhash.hashes.values())
         weighted_containment1 = sig1.contained_by_weighted(sig2)
         weighted_containment2 = sig2.contained_by_weighted(sig1)

--- a/src/sourmash/sig/__main__.py
+++ b/src/sourmash/sig/__main__.py
@@ -440,9 +440,9 @@ angular similarity:          {angular_similarity:.5f}
     """
     # --- output ---
     print("first signature:")
-    sig1.display()
+    sig1.display(args.signature1)
     print("second signature:")
-    sig2.display()
+    sig2.display(args.signature2)
 
     print(
         f"""\

--- a/src/sourmash/sig/__main__.py
+++ b/src/sourmash/sig/__main__.py
@@ -413,12 +413,14 @@ jaccard similarity:          {jaccard:.5f}
 first contained in second:   {cont1:.5f} (cANI: {cANI1:.5f})
 second contained in first:   {cont2:.5f} (cANI: {cANI2:.5f})
 average containment ANI:     {avg_cANI:.5f}
+
 """
     else:
         similarity_info = f"""\
 --- Similarity measures ---
 jaccard similarity:          {jaccard:.5f}
 containment and ANI not available (one or both signatures are not scaled)
+
 """
 
     # --- hash counts and overlaps ---
@@ -441,6 +443,7 @@ number of hashes in common:  {num_common}
 only in first:               {disjoint_1}
 only in second:              {disjoint_2}
 total (union):               {num_union}
+
 """
 
     # --- conditional abundance info ---
@@ -459,7 +462,6 @@ second contained in first (weighted): {weighted_containment2:.5f}
 
 number of hashes in first (weighted): {sum_hashes1}
 number of hashes in second (weighted): {sum_hashes2}
-
     """
     # --- output ---
     print("first signature:")
@@ -469,10 +471,9 @@ number of hashes in second (weighted): {sum_hashes2}
 
     print(
         f"""\
+
 {similarity_info}
-
 {hash_counts_info}
-
 {abundance_info}
 """
     )

--- a/src/sourmash/sig/__main__.py
+++ b/src/sourmash/sig/__main__.py
@@ -398,58 +398,55 @@ def overlap(args):
     except ValueError:
         raise
 
-    cont1 = sig1.contained_by(sig2)
-    cont2 = sig2.contained_by(sig1)
+    # --- conditional containment info ---
+    if sig1.minhash.scaled > 0 and sig2.minhash.scaled > 0:
+        cont1 = sig1.contained_by(sig2)
+        cont2 = sig2.contained_by(sig1)
 
-    cANI1 = sig1.containment_ani(sig2).ani
-    cANI2 = sig2.containment_ani(sig1).ani
-    avg_cANI = (cANI1 + cANI2) / 2
+        cANI1 = sig1.containment_ani(sig2).ani
+        cANI2 = sig2.containment_ani(sig1).ani
+        avg_cANI = (cANI1 + cANI2) / 2
 
-    sig1_file = args.signature1
-    sig2_file = args.signature2
+        similarity_info = f"""\
+jaccard similarity:          {jaccard:.5f}
+first contained in second:   {cont1:.5f} (cANI: {cANI1:.5f})
+second contained in first:   {cont2:.5f} (cANI: {cANI2:.5f})
+average containment ANI:     {avg_cANI:.5f}
+"""
+    else:
+        similarity_info = f"""\
+jaccard similarity:          {jaccard:.5f}
+containment and ANI not available (one or both signatures are not scaled)
+"""
 
-    name1 = sig1.name
-    name2 = sig2.name
-
-    md5_1 = sig1.md5sum()
-    md5_2 = sig2.md5sum()
-
-    ksize = sig1.minhash.ksize
-    moltype = sig1.minhash.moltype
-
-    num = sig1.minhash.num
-    size1 = len(sig1.minhash)
-    size2 = len(sig2.minhash)
-
-    scaled = sig1.minhash.scaled
-
+    # --- hash counts and overlaps ---
     hashes_1 = set(sig1.minhash.hashes)
     hashes_2 = set(sig2.minhash.hashes)
 
+    size1 = len(hashes_1)
+    size2 = len(hashes_2)
     num_common = len(hashes_1 & hashes_2)
     disjoint_1 = len(hashes_1 - hashes_2)
     disjoint_2 = len(hashes_2 - hashes_1)
     num_union = len(hashes_1.union(hashes_2))
 
+    # --- conditional abundance info ---
+    abundance_info = ""
+    if sig1.minhash.track_abundance and sig2.minhash.track_abundance:
+        angular_similarity = sig1.angular_similarity(sig2)
+        abundance_info = f"""\
+Measurements with abundance:
+angular similarity:          {angular_similarity:.5f}
+    """
+    # --- output ---
+    print("first signature:")
+    sig1.display()
+    print("second signature:")
+    sig2.display()
+
     print(
         f"""\
-first signature:
-  signature filename: {sig1_file}
-  signature: {name1}
-  md5: {md5_1}
-  k={ksize} molecule={moltype} num={num} scaled={scaled}
-
-second signature:
-  signature filename: {sig2_file}
-  signature: {name2}
-  md5: {md5_2}
-  k={ksize} molecule={moltype} num={num} scaled={scaled}
-
-jaccard similarity:          {jaccard:.5f}
-first contained in second:   {cont1:.5f} (cANI: {cANI1:.5f})
-second contained in first:   {cont2:.5f} (cANI: {cANI2:.5f})
-average containment ANI:     {avg_cANI:.5f}
-
+{similarity_info}
 number of hashes in first:   {size1}
 number of hashes in second:  {size2}
 
@@ -457,18 +454,10 @@ number of hashes in common:  {num_common}
 only in first:               {disjoint_1}
 only in second:              {disjoint_2}
 total (union):               {num_union}
+
+{abundance_info}
 """
     )
-
-    # if we have abundance for both sketches, calculate abundance-weighted measures
-    if sig1.minhash.track_abundance and sig2.minhash.track_abundance:
-        angular_similarity = sig1.angular_similarity(sig2)
-        print(
-            f"""\
-Measurements with abundance:
-angular similarity:          {angular_similarity:.5f}
-"""
-        )
 
 
 def merge(args):

--- a/src/sourmash/signature.py
+++ b/src/sourmash/signature.py
@@ -187,7 +187,7 @@ class SourmashSignature(RustObject):
         return self.minhash.contained_by(other.minhash, downsample=downsample)
 
     def contained_by_weighted(self, other):
-        "Compuite containment by the other signature. Weight by abundance in self."
+        "Compute containment by the other signature. Weight by abundance in self."
         return self.minhash.contained_by_weighted(other.minhash)
 
     def containment_ani(

--- a/src/sourmash/signature.py
+++ b/src/sourmash/signature.py
@@ -136,8 +136,8 @@ class SourmashSignature(RustObject):
 
         print(
             f"""\
-signature: {self.name}
-  filename: {self.filename or 'N/A'}
+  signature filename: {self.filename or 'N/A'}
+  signature name: {self.name}
   md5: {self.md5sum()}
   k={mh.ksize} molecule={mh.moltype} num={mh.num} scaled={mh.scaled}
   track_abundance={mh.track_abundance}

--- a/src/sourmash/signature.py
+++ b/src/sourmash/signature.py
@@ -163,12 +163,8 @@ class SourmashSignature(RustObject):
     def angular_similarity(self, other, downsample=False):
         "Compute angular similarity with the other signature."
         # check that both have abunds
-        if not (self.track_abundance and other.track_abundance):
-            raise TypeError(
-                "Error: Angular (cosine) similarity requires both sketches to track hash abundance."
-            )
-        return self.minhash.similarity(
-            other.minhash, ignore_abundance=False, downsample=downsample
+        return self.minhash.angular_similarity(
+            other.minhash, downsample=downsample
         )
 
     def contained_by(self, other, downsample=False):

--- a/src/sourmash/signature.py
+++ b/src/sourmash/signature.py
@@ -139,8 +139,7 @@ class SourmashSignature(RustObject):
   signature filename: {self.filename or "N/A"}
   signature name: {self.name}
   md5: {self.md5sum()}
-  k={mh.ksize} molecule={mh.moltype} num={mh.num} scaled={mh.scaled}
-  track_abundance={mh.track_abundance}
+  k={mh.ksize} molecule={mh.moltype} num={mh.num} scaled={mh.scaled} track_abundance={mh.track_abundance}
   hash count: {len(mh)}
 """
         )

--- a/src/sourmash/signature.py
+++ b/src/sourmash/signature.py
@@ -187,6 +187,10 @@ class SourmashSignature(RustObject):
         "Compute containment by the other signature. Note: ignores abundance."
         return self.minhash.contained_by(other.minhash, downsample=downsample)
 
+    def contained_by_weighted(self, other):
+        "Compuite containment by the other signature. Weight by abundance in self."
+        return self.minhash.contained_by_weighted(other.minhash)
+
     def containment_ani(
         self,
         other,

--- a/src/sourmash/signature.py
+++ b/src/sourmash/signature.py
@@ -137,7 +137,7 @@ class SourmashSignature(RustObject):
         print(
             f"""\
 signature: {self.name}
-  filename: {self.filename or 'N/A'}
+  filename: {self.filename or "N/A"}
   md5: {self.md5sum()}
   k={mh.ksize} molecule={mh.moltype} num={mh.num} scaled={mh.scaled}
   track_abundance={mh.track_abundance}
@@ -178,9 +178,7 @@ signature: {self.name}
     def angular_similarity(self, other, downsample=False):
         "Compute angular similarity with the other signature."
         # check that both have abunds
-        return self.minhash.angular_similarity(
-            other.minhash, downsample=downsample
-        )
+        return self.minhash.angular_similarity(other.minhash, downsample=downsample)
 
     def contained_by(self, other, downsample=False):
         "Compute containment by the other signature. Note: ignores abundance."

--- a/src/sourmash/signature.py
+++ b/src/sourmash/signature.py
@@ -130,17 +130,21 @@ class SourmashSignature(RustObject):
         assert not max_length or len(name) <= max_length
         return name
 
-    def display(self):
+    def display(self, location=None):
         "Print a summary of this signature."
         mh = self.minhash
+        sum_hashes = sum(mh.hashes.values())
 
         print(
             f"""\
-  signature filename: {self.filename or "N/A"}
+  signature filename: {location or "N/A"}
   signature name: {self.name}
+  source filename: {self.filename or "N/A"}
   md5: {self.md5sum()}
   k={mh.ksize} molecule={mh.moltype} num={mh.num} scaled={mh.scaled} track_abundance={mh.track_abundance}
-  hash count: {len(mh)}
+  size: {len(mh)}
+  sum hashes: {sum_hashes}
+  signature license: {self.license}
 """
         )
 

--- a/src/sourmash/signature.py
+++ b/src/sourmash/signature.py
@@ -130,6 +130,21 @@ class SourmashSignature(RustObject):
         assert not max_length or len(name) <= max_length
         return name
 
+    def display(self):
+        "Print a summary of this signature."
+        mh = self.minhash
+
+        print(
+            f"""\
+signature: {self.name}
+  filename: {self.filename or 'N/A'}
+  md5: {self.md5sum()}
+  k={mh.ksize} molecule={mh.moltype} num={mh.num} scaled={mh.scaled}
+  track_abundance={mh.track_abundance}
+  hash count: {len(mh)}
+"""
+        )
+
     def similarity(self, other, ignore_abundance=False, downsample=False):
         "Compute similarity with the other signature."
         return self.minhash.similarity(

--- a/src/sourmash/signature.py
+++ b/src/sourmash/signature.py
@@ -136,10 +136,10 @@ class SourmashSignature(RustObject):
             other.minhash, ignore_abundance=ignore_abundance, downsample=downsample
         )
 
-    def jaccard(self, other):
+    def jaccard(self, other, downsample=False):
         "Compute Jaccard similarity with the other MinHash signature."
         return self.minhash.similarity(
-            other.minhash, ignore_abundance=True, downsample=False
+            other.minhash, ignore_abundance=True, downsample=downsample
         )
 
     def jaccard_ani(
@@ -158,6 +158,17 @@ class SourmashSignature(RustObject):
             jaccard=jaccard,
             prob_threshold=prob_threshold,
             err_threshold=err_threshold,
+        )
+
+    def angular_similarity(self, other, downsample=False):
+        "Compute angular similarity with the other signature."
+        # check that both have abunds
+        if not (self.track_abundance and other.track_abundance):
+            raise TypeError(
+                "Error: Angular (cosine) similarity requires both sketches to track hash abundance."
+            )
+        return self.minhash.similarity(
+            other.minhash, ignore_abundance=False, downsample=downsample
         )
 
     def contained_by(self, other, downsample=False):

--- a/src/sourmash/signature.py
+++ b/src/sourmash/signature.py
@@ -180,7 +180,6 @@ class SourmashSignature(RustObject):
 
     def angular_similarity(self, other, downsample=False):
         "Compute angular similarity with the other signature."
-        # check that both have abunds
         return self.minhash.angular_similarity(other.minhash, downsample=downsample)
 
     def contained_by(self, other, downsample=False):

--- a/tests/test_cmd_signature.py
+++ b/tests/test_cmd_signature.py
@@ -3996,6 +3996,31 @@ def test_sig_overlap_2(runtmp):
     assert "number of hashes in common:  2529" in out
 
 
+def test_sig_overlap_inaccurate_size_estimate(runtmp):
+    c= runtmp
+    # make tiny sigs to test containment ANI with inaccurate size estimate
+    # (i.e. not enough hashes to estimate size)
+    mh1 = sourmash.MinHash(0, 31, scaled=100, track_abundance=False)
+    mh2 = sourmash.MinHash(0, 31, scaled=100, track_abundance=False)
+
+    mh1.add_many((1, 3, 4))
+    mh2.add_many((1, 2, 3, 4))
+    sig1 = sourmash.SourmashSignature(mh1, name="sig1")
+    sig2 = sourmash.SourmashSignature(mh2, name="sig2")
+    # save signatures
+    sig1_file = runtmp.output("sig1.sig")
+    sig2_file = runtmp.output("sig2.sig")
+    with open(sig1_file, "w") as fp:
+        save_signatures_to_json([sig1], fp)
+    with open(sig2_file, "w") as fp:
+        save_signatures_to_json([sig2], fp)
+
+    c.run_sourmash("sig", "overlap", sig1_file, sig2_file, '-k', '31')
+    out = c.last_result.out
+    print(out)
+    assert "cANI values not reported. One or more sketches contains too few hashes for accurate size estimation." in out
+
+
 def test_sig_overlap_abund(runtmp):
     c = runtmp
     # get overlap details

--- a/tests/test_cmd_signature.py
+++ b/tests/test_cmd_signature.py
@@ -3971,7 +3971,7 @@ def test_sig_overlap(runtmp):
     assert "09a08691ce52952152f0e866a59f6261" in out
     assert "38729c6374925585db28916b82a6f513" in out
 
-    assert "similarity:                  0.32069" in out
+    assert "jaccard similarity:          0.32069" in out
     assert "number of hashes in common:  2529" in out
 
 
@@ -3989,7 +3989,7 @@ def test_sig_overlap_2(runtmp):
     assert "09a08691ce52952152f0e866a59f6261" in out
     assert "38729c6374925585db28916b82a6f513" in out
 
-    assert "similarity:                  0.32069" in out
+    assert "jaccard similarity:          0.32069" in out
     assert "number of hashes in common:  2529" in out
 
 

--- a/tests/test_cmd_signature.py
+++ b/tests/test_cmd_signature.py
@@ -4015,6 +4015,11 @@ def test_sig_overlap_abund(runtmp):
 
     assert "number of hashes in common:  2529" in out
     assert "angular similarity:          0.32983" in out
+    assert "first contained in second (weighted): 0.49169" in out
+    assert "second contained in first (weighted): 0.49126" in out
+
+    assert "number of hashes in first (weighted): 5292" in out
+    assert "number of hashes in second (weighted): 5433" in out
 
 
 def test_sig_overlap_num(runtmp):

--- a/tests/test_cmd_signature.py
+++ b/tests/test_cmd_signature.py
@@ -3997,7 +3997,7 @@ def test_sig_overlap_2(runtmp):
 
 
 def test_sig_overlap_inaccurate_size_estimate(runtmp):
-    c= runtmp
+    c = runtmp
     # make tiny sigs to test containment ANI with inaccurate size estimate
     # (i.e. not enough hashes to estimate size)
     mh1 = sourmash.MinHash(0, 31, scaled=100, track_abundance=False)
@@ -4015,10 +4015,13 @@ def test_sig_overlap_inaccurate_size_estimate(runtmp):
     with open(sig2_file, "w") as fp:
         save_signatures_to_json([sig2], fp)
 
-    c.run_sourmash("sig", "overlap", sig1_file, sig2_file, '-k', '31')
+    c.run_sourmash("sig", "overlap", sig1_file, sig2_file, "-k", "31")
     out = c.last_result.out
     print(out)
-    assert "cANI values not reported. One or more sketches contains too few hashes for accurate size estimation." in out
+    assert (
+        "cANI values not reported. One or more sketches contains too few hashes for accurate size estimation."
+        in out
+    )
 
 
 def test_sig_overlap_abund(runtmp):

--- a/tests/test_cmd_signature.py
+++ b/tests/test_cmd_signature.py
@@ -4023,7 +4023,7 @@ def test_sig_overlap_num(runtmp):
     # get overlap details
     sig47 = utils.get_test_data("num/47.fa.sig")
     sig63 = utils.get_test_data("num/63.fa.sig")
-    c.run_sourmash("sig", "overlap", sig47, sig63, '-k', '31')
+    c.run_sourmash("sig", "overlap", sig47, sig63, "-k", "31")
     out = c.last_result.out
     print(out)
     # md5s

--- a/tests/test_cmd_signature.py
+++ b/tests/test_cmd_signature.py
@@ -3993,6 +3993,23 @@ def test_sig_overlap_2(runtmp):
     assert "number of hashes in common:  2529" in out
 
 
+def test_sig_overlap_abund(runtmp):
+    c = runtmp
+    # get overlap details
+    sig47 = utils.get_test_data("track_abund/47.fa.sig")
+    sig63 = utils.get_test_data("track_abund/63.fa.sig")
+    c.run_sourmash("sig", "overlap", sig47, sig63)
+    out = c.last_result.out
+    print(out)
+    # md5s
+    assert "09a08691ce52952152f0e866a59f6261" in out
+    assert "38729c6374925585db28916b82a6f513" in out
+
+    assert "jaccard similarity:          0.32069" in out
+    assert "number of hashes in common:  2529" in out
+    assert "angular similarity:          0.32983" in out
+
+
 @utils.in_tempdir
 def test_import_export_1(c):
     # check to make sure we can import what we've exported!

--- a/tests/test_cmd_signature.py
+++ b/tests/test_cmd_signature.py
@@ -3990,6 +3990,9 @@ def test_sig_overlap_2(runtmp):
     assert "38729c6374925585db28916b82a6f513" in out
 
     assert "jaccard similarity:          0.32069" in out
+    assert "first contained in second:   0.48851 (cANI: 0.97716)" in out
+    assert "second contained in first:   0.48282 (cANI: 0.97679)" in out
+    assert "average containment ANI:     0.97697" in out
     assert "number of hashes in common:  2529" in out
 
 
@@ -4006,8 +4009,30 @@ def test_sig_overlap_abund(runtmp):
     assert "38729c6374925585db28916b82a6f513" in out
 
     assert "jaccard similarity:          0.32069" in out
+    assert "first contained in second:   0.48851 (cANI: 0.97716)" in out
+    assert "second contained in first:   0.48282 (cANI: 0.97679)" in out
+    assert "average containment ANI:     0.97697" in out
+
     assert "number of hashes in common:  2529" in out
     assert "angular similarity:          0.32983" in out
+
+
+def test_sig_overlap_num(runtmp):
+    # test sig overlap with num signatures
+    c = runtmp
+    # get overlap details
+    sig47 = utils.get_test_data("num/47.fa.sig")
+    sig63 = utils.get_test_data("num/63.fa.sig")
+    c.run_sourmash("sig", "overlap", sig47, sig63, '-k', '31')
+    out = c.last_result.out
+    print(out)
+    # md5s
+    assert "091475b51432957736461bed0a02937f" in out
+    assert "89dc40f63698afbf06e3db9d3c9c3dd8" in out
+
+    assert "jaccard similarity:          0.35000" in out
+    assert "containment and ANI not available (signatures are not scaled)"
+    assert "number of hashes in common:  247"
 
 
 @utils.in_tempdir


### PR DESCRIPTION
Fixes #3643. Now that I think about it, we probably didn't do this earlier because of num minhashes?

### Changes to `sig overlap`:
- separates jaccard and angular similarity reporting
- adds containment, containment ANI, weighted containment output to `sig overlap`
- allows `num` minhashes to work with `sig overlap` by only calculating containment values if sigs are scaled
- adds testing for new outputs, including num minhashes and abundance-weighted comparisons

### Other internal changes:
- Additions to `signature.py`:
  - adds a `sig.display()` function to print relevant info about a signature. This simplifies the `overlap` printing a bit, but I also think it'd be useful when working with sigs interactively via the python API (unless I'm missing something we already have?). `__str__` just prints the name.
    - note: this was very similar to the printout with `sig describe`, so I added `sum_hashes` and `signature_license` to make it match. **Does that make this too long?**
  - adds `angular_similarity` function which calls minhash angular similarity
- Changes to `minhash.py`:
  -  use rust `similarity` for both `jaccard` and `angular_similarity` to allow downsampling
  -  add `contained_by_weighted` (`self.contained_by_weighted(other)` weights by self)

#### To do:
- [x] don't calc/print cANI for num minhashes? behavior in latest: num minhash fail.
- [x] separate jaccard and angular similarity
- [x] test num minhashes, containment, containment ANI, abund
- [x] add abundance-weighted containment via python
- [x] don't print cANI if sketches are too small (too few hashes) for good estimate

Updated `sig overlap` output:

no abundances:
```
sourmash sig overlap GCF_002251655.sig.zip GCF_001373295.sig.zip -k 21
```

```
loaded one signature each from GCF_002251655.sig.zip and GCF_001373295.sig.zip
first signature:
  signature filename: GCF_002251655.sig.zip
  signature name: GCF_002251655.1 Ralstonia solanacearum UW700
  source filename: GCF_002251655.1_genomic.fna.gz
  md5: 300caf3b8076a59bbcce38a7126913d5
  k=21 molecule=DNA num=0 scaled=1000 track_abundance=False
  size: 5174
  sum hashes: 5174
  signature license: CC0

second signature:
  signature filename: GCF_001373295.sig.zip
  signature name: GCF_001373295.1 Ralstonia solanacearum RS2
  source filename: GCF_001373295.1_genomic.fna.gz
  md5: 39496de2377be295389d5fcad1caafe5
  k=21 molecule=DNA num=0 scaled=1000 track_abundance=False
  size: 4717
  sum hashes: 4717
  signature license: CC0


--- Similarity measures ---
jaccard similarity:          0.89519
first contained in second:   0.90298 (cANI: 0.99515)
second contained in first:   0.99046 (cANI: 0.99954)
average containment ANI:     0.99735


--- Hash overlap summary ---
number of hashes in first:   5174
number of hashes in second:  4717

number of hashes in common:  4672
only in first:               502
only in second:              45
total (union):               5219
```

sigs with abund:
```
sourmash sig overlap GCF_002251655.abund.sig.zip GCF_001373295.abund.sig.zip -k 21 
```
```
loaded one signature each from GCF_002251655.abund.sig.zip and GCF_001373295.abund.sig.zip
first signature:
  signature filename: GCF_002251655.abund.sig.zip
  signature name: GCF_002251655.1 Ralstonia solanacearum UW700
  source filename: GCF_002251655.1_genomic.fna.gz
  md5: 300caf3b8076a59bbcce38a7126913d5
  k=21 molecule=DNA num=0 scaled=1000 track_abundance=True
  size: 5174
  sum hashes: 5342
  signature license: CC0

second signature:
  signature filename: GCF_001373295.abund.sig.zip
  signature name: GCF_001373295.1 Ralstonia solanacearum RS2
  source filename: GCF_001373295.1_genomic.fna.gz
  md5: 39496de2377be295389d5fcad1caafe5
  k=21 molecule=DNA num=0 scaled=1000 track_abundance=True
  size: 4717
  sum hashes: 4742
  signature license: CC0


--- Similarity measures ---
jaccard similarity:          0.89519
first contained in second:   0.90298 (cANI: 0.99515)
second contained in first:   0.99046 (cANI: 0.99954)
average containment ANI:     0.99735


--- Hash overlap summary ---
number of hashes in first:   5174
number of hashes in second:  4717

number of hashes in common:  4672
only in first:               502
only in second:              45
total (union):               5219


--- Abundance-weighted similarity: ---
angular similarity:          0.72662
first contained in second (weighted): 0.90359
second contained in first (weighted): 0.99051

number of hashes in first (weighted): 5342
number of hashes in second (weighted): 4742
```