### PR TITLE
EXP: Revert "Build(deps): Bump pypa/cibuildwheel from 2.23.3 to 3.0.0 (#3687)

### DIFF
--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -46,7 +46,7 @@ jobs:
           python-version: '3.12'
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3.0.0
+        uses: pypa/cibuildwheel@v2.23.3
         env:
           CIBW_ENVIRONMENT_MACOS: ${{ matrix.macos_target }}
           CIBW_ARCHS_LINUX: ${{ matrix.arch }}
@@ -63,7 +63,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3.0.0
+        uses: pypa/cibuildwheel@v2.23.3
         env:
           CIBW_PLATFORM: pyodide 
           CIBW_BUILD: 'cp312-pyodide_wasm32'


### PR DESCRIPTION
#3687 seems to have broken the ubuntu x86_64 wheel builds.