### PR TITLE
MRG: 4.9.3 release branch

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -63,7 +63,7 @@
 
           sourmash = python.buildPythonPackage ( commonArgs // rec {
             pname = "sourmash";
-            version = "4.9.2";
+            version = "4.9.3";
             format = "pyproject";
 
             cargoDeps = rustPlatform.importCargoLock {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = 'maturin'
 name = "sourmash"
 description = "tools for comparing biological sequences with k-mer sketches"
 readme = "README.md"
-version = "4.9.2"
+version = "4.9.3"
 license = "BSD-3-Clause"
 
 authors = [


### PR DESCRIPTION
Cleanup and documentation updates:

* minor updates to release docs (#3695)
* small docs fixes and updates (#3681)

Developer updates:

* release core 0.21.0 (#3712)

Dependabot updates:

* Build(deps): Bump camino from 1.1.9 to 1.1.10 (#3669)
* Build(deps): Bump cfg-if from 1.0.0 to 1.0.1 (#3689)
* Build(deps): Bump conda-incubator/setup-miniconda from 3.1.1 to 3.2.0 (#3676)
* Build(deps): Bump getset from 0.1.5 to 0.1.6 (#3700)
* Build(deps): Bump prefix-dev/setup-pixi from 0.8.8 to 0.8.10 (#3688)
* Build(deps): Bump proptest from 1.6.0 to 1.7.0 (#3674)
* Build(deps): Bump pypa/cibuildwheel from 2.23.3 to 3.0.0 (#3687)
* Build(deps): Bump roaring from 0.10.12 to 0.11.0 (#3702)
* Build(deps): Update maturin requirement from <1.9.0,>=1 to >=1,<1.10.0 (#3699)
* Build(deps): Update pytest requirement from <8.4.0,>=6.2.4 to >=6.2.4,<8.5.0 (#3670)
* EXP: Revert "Build(deps): Bump pypa/cibuildwheel from 2.23.3 to 3.0.0 (#3687) (#3691)
* [pre-commit.ci] pre-commit autoupdate (#3668)
* [pre-commit.ci] pre-commit autoupdate (#3673)
* [pre-commit.ci] pre-commit autoupdate (#3698)