### PR TITLE
CI: update to cibuildwheel 3.1.1

### DIFF
--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -43,10 +43,10 @@ jobs:
       - uses: actions/setup-python@v5
         name: Install Python
         with:
-          python-version: '3.12'
+          python-version: '3.13'
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.23.3
+        uses: pypa/cibuildwheel@v3.1.1
         env:
           CIBW_ENVIRONMENT_MACOS: ${{ matrix.macos_target }}
           CIBW_ARCHS_LINUX: ${{ matrix.arch }}
@@ -57,21 +57,21 @@ jobs:
           name: wheel-${{ matrix.build }}-${{ matrix.os }}
           path: './wheelhouse/sourmash*.whl'
 
-#  build_wasm:
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v4
-#
-#      - name: Build wheels
-#        uses: pypa/cibuildwheel@v2.23.3
-#        env:
-#          CIBW_PLATFORM: pyodide 
-#          CIBW_BUILD: 'cp312-pyodide_wasm32'
-#
-#      - uses: actions/upload-artifact@v4
-#        with:
-#          name: wheel-wasm
-#          path: './wheelhouse/sourmash*.whl'
+  build_wasm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v3.1.1
+        env:
+          CIBW_PLATFORM: pyodide
+          CIBW_BUILD: 'cp313-pyodide_wasm32'
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheel-wasm
+          path: './wheelhouse/sourmash*.whl'
 
   release:
     name: Publish wheels

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -59,6 +59,7 @@ jobs:
 
   build_wasm:
     runs-on: ubuntu-latest
+    if: false  # disable for now, need to fix emsdk with Rust: https://github.com/emscripten-core/emscripten/pull/24359
     steps:
       - uses: actions/checkout@v4
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -244,11 +244,7 @@ PATH="$HOME/.cargo/bin:$PATH"
 before-all = [
   "curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain=stable",
   "cargo update --dry-run",
-  "if [ -f /etc/system-release ]; then yum -y install llvm-toolset-7.0; fi",
-]
-before-build = [
-  "if [ -f /etc/system-release ]; then source scl_source enable llvm-toolset-7.0; fi",
-  "if [ -f /etc/system-release ]; then source scl_source enable devtoolset-10; fi",
+  "if [ -f /etc/system-release ]; then dnf -y install llvm-compat-libs; fi",
 ]
 
 [tool.cibuildwheel.pyodide.environment]
@@ -263,9 +259,9 @@ before-build = [
 [tool.cibuildwheel.linux.environment]
 CARGO_REGISTRIES_CRATES_IO_PROTOCOL="sparse"
 PATH="$HOME/.cargo/bin:$PATH"
-LIBCLANG_PATH="/opt/rh/llvm-toolset-7.0/root/usr/lib64"
-LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/opt/rh/llvm-toolset-7.0/root/usr/lib64"
-C_INCLUDE_PATH="/opt/rh/devtoolset-10/root/usr/lib/gcc/aarch64-redhat-linux/10/include:/opt/rh/devtoolset-10/root/usr/lib/gcc/x86_64-redhat-linux/10/include"
+LIBCLANG_PATH="/usr/lib64/llvm17/lib"
+LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/opt/rh/gcc-toolset-14/root/usr/lib64"
+C_INCLUDE_PATH="/opt/rh/gcc-toolset-14/root/usr/lib/gcc/x86_64-redhat-linux/14/include/:/opt/rh/gcc-toolset-14/root/usr/lib/gcc/aarch64-redhat-linux/14/include/"
 
 [tool.pytest.ini_options]
 addopts = "--doctest-glob='doc/*.md' -n4"


### PR DESCRIPTION
- Base image for manylinux wheels changed, now it is based on AlmaLinux 8 (for `2_28`).
- Update configs to install and use libclang as AL8 expects.
- Pyodide still not working, but update CI definition to use `if: false` and avoid commenting out code