### PR TITLE
MRG: handle (ignore) empty taxids for `bioboxes` format

### DIFF
--- a/doc/command-line.md
+++ b/doc/command-line.md
@@ -923,7 +923,7 @@ Note: this output format requires a single sample only. For a similar output wit
 
 #### `bioboxes` output format
 
-When using standard taxonomic ranks (not lins), you can choose to output a 'bioboxes' profile, `{base}.bioboxes.profile`, where `{base}` is the name provided via the `-o/--output-base` option. This output is organized according to the [bioboxes profile specifications](https://github.com/bioboxes/rfc/tree/master/data-format) so that this file can be used for CAMI challenges.
+When using standard taxonomic ranks (not lins), you can choose to output a 'bioboxes' profile, `{base}.bioboxes.profile`, where `{base}` is the name provided via the `-o/--output-base` option. This output is organized according to the [bioboxes profile specifications](https://github.com/bioboxes/rfc/tree/master/data-format) so that this file can be used for CAMI challenges. As of v4.9.4, `bioboxes` will support taxonomies with missing ranks, as seen in some NCBI taxonomies (e.g. taxpath: 2|1239|||||2292892|). In these cases, the (missing) rank-taxid combinations will be omitted from the output.
 
 This output format starts with some header information:
 ```

--- a/doc/command-line.md
+++ b/doc/command-line.md
@@ -936,7 +936,7 @@ Note: this output format requires a single sample only. For a similar output wit
 
 #### `bioboxes` output format
 
-When using standard taxonomic ranks (not lins), you can choose to output a 'bioboxes' profile, `{base}.bioboxes.profile`, where `{base}` is the name provided via the `-o/--output-base` option. This output is organized according to the [bioboxes profile specifications](https://github.com/bioboxes/rfc/tree/master/data-format) so that this file can be used for CAMI challenges. As of v4.9.4, `bioboxes` will support taxonomies with missing ranks, as seen in some NCBI taxonomies (e.g. taxpath: 2|1239|||||2292892|). In these cases, the (missing) rank-taxid combinations will be omitted from the output.
+When using standard taxonomic ranks (not lins), you can choose to output a 'bioboxes' profile, `{base}.bioboxes.profile`, where `{base}` is the name provided via the `-o/--output-base` option. This output is organized according to the [bioboxes profile specifications](https://github.com/bioboxes/rfc/tree/master/data-format) so that this file can be used for CAMI challenges. As of v4.9.4, `bioboxes` will support taxonomies with missing ranks, as seen in some NCBI taxonomies (e.g. taxpath: 2|1239|||||2292892|). In these cases, the missing rank-taxid combinations will be omitted from the output.
 
 This output format starts with some header information:
 ```

--- a/src/sourmash/tax/tax_utils.py
+++ b/src/sourmash/tax/tax_utils.py
@@ -1107,7 +1107,7 @@ def write_bioboxes(header_lines, results, out_fp, *, sep="\t"):
     for res in results:
         # NCBI lineages can often have empty taxids at e.g. order level or strain level
         # without a taxid, we cannot write the row to bioboxes format; here we just skip those rows.
-        if res[0] == "": # no taxid for this results row -- skip!
+        if res[0] == "":  # no taxid for this results row -- skip!
             continue
         res = sep.join(res) + "\n"
         out_fp.write(res)

--- a/src/sourmash/tax/tax_utils.py
+++ b/src/sourmash/tax/tax_utils.py
@@ -1105,6 +1105,10 @@ def write_bioboxes(header_lines, results, out_fp, *, sep="\t"):
     for inf in header_lines:
         out_fp.write(inf + "\n")
     for res in results:
+        # NCBI lineages can often have empty taxids at e.g. order level or strain level
+        # without a taxid, we cannot write the row to bioboxes format; here we just skip those rows.
+        if res[0] == "": # no taxid for this results row -- skip!
+            continue
         res = sep.join(res) + "\n"
         out_fp.write(res)
 

--- a/tests/test_tax.py
+++ b/tests/test_tax.py
@@ -1280,6 +1280,122 @@ def test_metagenome_bioboxes_outfile(runtmp):
     ] == bb_results[16]
 
 
+def test_metagenome_bioboxes_stdout_missing_ranktaxinfo(runtmp):
+    # test CAMI bioboxes format output
+    g_csv = utils.get_test_data("tax/test1.gather.v450.csv")
+    tax = utils.get_test_data("tax/test.ncbi-taxonomy.csv")
+    tax_mod = runtmp.output("missingtaxranks.taxonomy.csv")
+
+    # modify the taxonomy CSV to remove some ranks
+#    GCF_001881345.1,562,Bacteria,Pseudomonadota,Gammaproteobacteria,Enterobacterales,Enterobacteriaceae,Escherichia,Escherichia coli,,2|1224|1236|91347|543|561|562|
+    # GCF_009494285.1,165179,Bacteria,Bacteroidota,Bacteroidia,Bacteroidales,Prevotellaceae,Prevotella,Prevotella copri,,2|976|200643|171549|171552|838|165179|
+    with open(tax, "r") as fp:
+        csv_reader = csv.DictReader(fp)
+        with open(tax_mod, "w") as fp_out:
+            csv_writer = csv.DictWriter(
+                fp_out, fieldnames=csv_reader.fieldnames, delimiter=","
+            )
+            csv_writer.writeheader()
+            # now remove genus from Escherichia order from Prevotella
+            for row in csv_reader:
+                if row["taxid"] == "562":
+                    row["genus"] = ""
+                    row["taxpath"] = "2|1224|1236|91347|543||562"
+                elif row["taxid"] == "165179":
+                    row["order"] = ""
+                    row["taxpath"] = "2|976|200643||171552|838|165179"
+                csv_writer.writerow(row)
+
+    runtmp.run_sourmash(
+        "tax",
+        "metagenome",
+        "--gather-csv",
+        g_csv,
+        "--taxonomy-csv",
+        tax_mod,
+        "-F",
+        "bioboxes",
+    )
+
+    print(runtmp.last_result.status)
+    print(runtmp.last_result.out)
+    print(runtmp.last_result.err)
+
+    assert runtmp.last_result.status == 0
+
+    assert "# Taxonomic Profiling Output" in runtmp.last_result.out
+    assert "@SampleID:test1" in runtmp.last_result.out
+    assert "@Version:0.10.0" in runtmp.last_result.out
+    assert (
+        "@Ranks:superkingdom|phylum|class|order|family|genus|species|strain"
+        in runtmp.last_result.out
+    )
+    assert "@__program__:sourmash" in runtmp.last_result.out
+    assert "2	superkingdom	2	Bacteria	13.08" in runtmp.last_result.out
+    assert (
+        "976	phylum	2|976	Bacteria|Bacteroidota	7.27"
+        in runtmp.last_result.out
+    )
+    assert (
+        "1224	phylum	2|1224	Bacteria|Pseudomonadota	5.82"
+        in runtmp.last_result.out
+    )
+    assert (
+        "200643	class	2|976|200643	Bacteria|Bacteroidota|Bacteroidia	7.27"
+        in runtmp.last_result.out
+    )
+    assert (
+        "1236	class	2|1224|1236	Bacteria|Pseudomonadota|Gammaproteobacteria	5.82"
+        in runtmp.last_result.out
+    )
+    # this one is NOT in the output, because Bacteroidales order is missing from tax
+    assert (
+        "171549	order	2|976|200643|171549	Bacteria|Bacteroidota|Bacteroidia|Bacteroidales	7.27"
+        not in runtmp.last_result.out
+    )
+    assert (
+        "91347	order	2|1224|1236|91347	Bacteria|Pseudomonadota|Gammaproteobacteria|Enterobacterales	5.82"
+        in runtmp.last_result.out
+    )
+    assert (
+        "171552	family	2|976|200643||171552	Bacteria|Bacteroidota|Bacteroidia||Prevotellaceae	5.70"
+        in runtmp.last_result.out
+    )
+    assert (
+        "543	family	2|1224|1236|91347|543	Bacteria|Pseudomonadota|Gammaproteobacteria|Enterobacterales|Enterobacteriaceae	5.82"
+        in runtmp.last_result.out
+    )
+    assert (
+        "815	family	2|976|200643|171549|815	Bacteria|Bacteroidota|Bacteroidia|Bacteroidales|Bacteroidaceae	1.56"
+        in runtmp.last_result.out
+    )
+    assert (
+        "838	genus	2|976|200643||171552|838	Bacteria|Bacteroidota|Bacteroidia||Prevotellaceae|Prevotella	5.70"
+        in runtmp.last_result.out
+    )
+    # this one is NOT in the output, because Escherichia genus is missing from tax
+    assert (
+        "561	genus	2|1224|1236|91347|543|561	Bacteria|Pseudomonadota|Gammaproteobacteria|Enterobacterales|Enterobacteriaceae|Escherichia	5.82"
+        not in runtmp.last_result.out
+    )
+    assert (
+        "909656	genus	2|976|200643|171549|815|909656	Bacteria|Bacteroidota|Bacteroidia|Bacteroidales|Bacteroidaceae|Phocaeicola	1.56"
+        in runtmp.last_result.out
+    )
+    assert (
+        "165179	species	2|976|200643||171552|838|165179	Bacteria|Bacteroidota|Bacteroidia||Prevotellaceae|Prevotella|Prevotella copri	5.70"
+        in runtmp.last_result.out
+    )
+    assert (
+        "562	species	2|1224|1236|91347|543||562	Bacteria|Pseudomonadota|Gammaproteobacteria|Enterobacterales|Enterobacteriaceae||Escherichia coli	5.82"
+        in runtmp.last_result.out
+    )
+    assert (
+        "821	species	2|976|200643|171549|815|909656|821	Bacteria|Bacteroidota|Bacteroidia|Bacteroidales|Bacteroidaceae|Phocaeicola|Phocaeicola vulgatus	1.56"
+        in runtmp.last_result.out
+    )
+
+
 def test_metagenome_krona_tsv_out(runtmp):
     g_csv = utils.get_test_data("tax/test1.gather.csv")
     tax = utils.get_test_data("tax/test.taxonomy.csv")

--- a/tests/test_tax.py
+++ b/tests/test_tax.py
@@ -1287,9 +1287,9 @@ def test_metagenome_bioboxes_stdout_missing_ranktaxinfo(runtmp):
     tax_mod = runtmp.output("missingtaxranks.taxonomy.csv")
 
     # modify the taxonomy CSV to remove some ranks
-#    GCF_001881345.1,562,Bacteria,Pseudomonadota,Gammaproteobacteria,Enterobacterales,Enterobacteriaceae,Escherichia,Escherichia coli,,2|1224|1236|91347|543|561|562|
+    #    GCF_001881345.1,562,Bacteria,Pseudomonadota,Gammaproteobacteria,Enterobacterales,Enterobacteriaceae,Escherichia,Escherichia coli,,2|1224|1236|91347|543|561|562|
     # GCF_009494285.1,165179,Bacteria,Bacteroidota,Bacteroidia,Bacteroidales,Prevotellaceae,Prevotella,Prevotella copri,,2|976|200643|171549|171552|838|165179|
-    with open(tax, "r") as fp:
+    with open(tax) as fp:
         csv_reader = csv.DictReader(fp)
         with open(tax_mod, "w") as fp_out:
             csv_writer = csv.DictWriter(

--- a/tests/test_tax_utils.py
+++ b/tests/test_tax_utils.py
@@ -4501,6 +4501,32 @@ def test_make_cami_results_with_taxids():
     ]
 
 
+def test_make_cami_results_with_taxids_missing_ranks():
+    taxD = make_mini_taxonomy_with_taxids(
+        [("gA", "a;b;c", "1;2;3"), ("gB", "a;b;c;d;;f;", "1;2;3;4;;6;")]
+    )
+    print(taxD)
+    # need to go down to species to check that `num_bp_assigned` is happening correctly
+    gather_results = [
+        {"total_weighted_hashes": 100},
+        {"name": "gB", "total_weighted_hashes": 100},
+    ]
+    q_res = make_QueryTaxResults(
+        gather_info=gather_results, taxD=taxD, single_query=True, summarize=True
+    )
+    header, camires = q_res.make_cami_bioboxes()
+    print(camires)
+    assert camires == [
+        ["1", "superkingdom", "1", "a", "40.00"],
+        ["2", "phylum", "1|2", "a|b", "40.00"],
+        ["3", "class", "1|2|3", "a|b|c", "40.00"],
+        ["4", "order", "1|2|3|4", "a|b|c|d", "20.00"],
+        ["", "family", None, "a|b|c|d|", "20.00"],
+        ["6", "genus", "1|2|3|4||6", "a|b|c|d||f", "20.00"],
+        ["", "species", None, "a|b|c|d||f|", "20.00"],
+    ]
+
+
 def test_make_lingroup_results():
     taxD = make_mini_taxonomy(
         [("gA", "1;0;0"), ("gB", "1;0;1"), ("gC", "1;1;0")], LIN=True


### PR DESCRIPTION
- bioboxes format relies on having a `taxid`, so it fails with empty/missing `taxids`. Some NCBI lineages have missing/empty internal tax ranks, e.g. order, genus, etc. Here we ignore (do not print) results from empty taxids, which allows us to bypass these problematic ranks and still get output from the classifiable ranks.

example taxonomy with missing ranks (lineage from an older CAMI db):

```
GCF_003480425.1,2292892,2|1239|||||2292892|,Bacteria,Firmicutes,unclassified Firmicutes class,unclassified Firmicutes order,unclassified Firmicutes family,unclassified Firmicutes genus,Firmicutes bacterium AM31-12AC,unclassified Firmicutes bacterium AM31-12AC subspecies/strain
```
