### PR TITLE
MRG: improve summary_csv for lingroups

### DIFF
--- a/src/sourmash/tax/tax_utils.py
+++ b/src/sourmash/tax/tax_utils.py
@@ -2107,9 +2107,9 @@ class SummarizedGatherResult:
     def as_summary_dict(self, query_info, limit_float=False, lingroups=None):
         sD = asdict(self)
         sD["lineage"] = self.lineage.display_lineage(null_as_unclassified=True)
-        # if lingroups, convert lingroup number to lingroup name
+        # if lingroups, add 'lingroup' column linking lingroup number to lingroup name
         if lingroups is not None and sD["lineage"] in lingroups.keys():
-            sD["lineage"] = lingroups[sD["lineage"]]
+            sD["lingroup"] = lingroups[sD["lineage"]]
         elif (
             lingroups
             and sD["lineage"] != "unclassified"
@@ -2647,6 +2647,7 @@ class QueryTaxResult:
 
             lingroup_ranks = set()
             if lingroups is not None:
+                header.append("lingroup")
                 for lin in lingroups.keys():
                     # e.g. "14;1;0;0;0;0;0;0;0;0" => 9
                     lin_rank = len(lin.split(";")) - 1

--- a/tests/test_tax.py
+++ b/tests/test_tax.py
@@ -7035,9 +7035,9 @@ def test_metagenome_LIN_lingroups_summary(runtmp):
         out.write("0;0;0,lg1\n")
         out.write("1;0;0,lg2\n")
         out.write("2;0;0,lg3\n")
-        out.write("1;0;1,lg3\n")
+        out.write("1;0;1,lg4\n")
         # write a 19 so we can check the end
-        out.write("1;0;1;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0,lg4\n")
+        out.write("1;0;1;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0,lg5\n")
 
     c.run_sourmash(
         "tax",
@@ -7071,35 +7071,35 @@ def test_metagenome_LIN_lingroups_summary(runtmp):
     print(sum_gather_results)
     assert f"saving 'csv_summary' output to '{csvout}'" in runtmp.last_result.err
     assert (
-        "query_name,rank,fraction,lineage,query_md5,query_filename,f_weighted_at_rank,bp_match_at_rank"
+        "query_name,rank,fraction,lineage,query_md5,query_filename,f_weighted_at_rank,bp_match_at_rank,query_ani_at_rank,total_weighted_hashes,lingroup"
         in sum_gather_results[0]
     )
     assert (
-        "test1,2,0.08815317112086159,lg1,9687eeed,outputs/abundtrim/HSMA33MX.abundtrim.fq.gz,0.05815279361459521,442000,0.9246458342627294,6139"
+        "test1,2,0.08815317112086159,0;0;0,9687eeed,outputs/abundtrim/HSMA33MX.abundtrim.fq.gz,0.05815279361459521,442000,0.9246458342627294,6139,lg1"
         in sum_gather_results[1]
     )
     assert (
-        "test1,2,0.07778220981252493,lg2,9687eeed,outputs/abundtrim/HSMA33MX.abundtrim.fq.gz,0.050496823586903404,390000,0.920920083987624,6139"
+        "test1,2,0.07778220981252493,1;0;0,9687eeed,outputs/abundtrim/HSMA33MX.abundtrim.fq.gz,0.050496823586903404,390000,0.920920083987624,6139,lg2"
         in sum_gather_results[2]
     )
     assert (
-        "test1,2,0.027522935779816515,lg3,9687eeed,outputs/abundtrim/HSMA33MX.abundtrim.fq.gz,0.015637726014008795,138000,0.8905689983332759,6139"
+        "test1,2,0.027522935779816515,2;0;0,9687eeed,outputs/abundtrim/HSMA33MX.abundtrim.fq.gz,0.015637726014008795,138000,0.8905689983332759,6139,lg3"
         in sum_gather_results[3]
     )
     assert (
-        "test1,2,0.010769844435580374,lg3,9687eeed,outputs/abundtrim/HSMA33MX.abundtrim.fq.gz,0.006515719172503665,54000,0.8640181883213995,6139"
+        "test1,2,0.010769844435580374,1;0;1,9687eeed,outputs/abundtrim/HSMA33MX.abundtrim.fq.gz,0.006515719172503665,54000,0.8640181883213995,6139,lg4"
         in sum_gather_results[4]
     )
     assert (
-        "test1,2,0.7957718388512166,unclassified,9687eeed,outputs/abundtrim/HSMA33MX.abundtrim.fq.gz,0.8691969376119889,3990000,,6139"
+        "test1,2,0.7957718388512166,unclassified,9687eeed,outputs/abundtrim/HSMA33MX.abundtrim.fq.gz,0.8691969376119889,3990000,,6139,"
         in sum_gather_results[5]
     )
     assert (
-        "test1,19,0.010769844435580374,lg4,9687eeed,outputs/abundtrim/HSMA33MX.abundtrim.fq.gz,0.006515719172503665,54000,0.8640181883213995,6139"
+        "test1,19,0.010769844435580374,1;0;1;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0,9687eeed,outputs/abundtrim/HSMA33MX.abundtrim.fq.gz,0.006515719172503665,54000,0.8640181883213995,6139,lg5"
         in sum_gather_results[6]
     )
     assert (
-        "test1,19,0.7957718388512166,unclassified,9687eeed,outputs/abundtrim/HSMA33MX.abundtrim.fq.gz,0.8691969376119889,3990000,,6139"
+        "test1,19,0.7957718388512166,unclassified,9687eeed,outputs/abundtrim/HSMA33MX.abundtrim.fq.gz,0.8691969376119889,3990000,,6139,"
         in sum_gather_results[7]
     )
 


### PR DESCRIPTION
- Fixes #3757, needed for sankey plots from csv_summary w/ LINs and LINgroups #https://github.com/sourmash-bio/sourmash_plugin_betterplot/pull/81
- ref: https://github.com/sourmash-bio/sourmash/issues/3361

- summary_csv: revert to lingroup LIN in lineage column (change in #3311 introduced this ~bug) 
- add lingroup column for lingroup name

NOTE: this PR adds the `lingroup` column to the `csv_summary` output for `tax metagenome` ONLY when we're using LINs and lingroups. I'm not sure this is the best approach, but I also don't want to add an empty useless column for everybody else? We could leave out the lingroup names, but then we're left with the LIN only, e.g. `0;1;1;8;1;0` rather than a nice, human-readable name (which is one of the key reasons to use `lingroup` file).