### PR TITLE
build: fix pixi task for wasm-pack

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           pixi-version: ${{ env.PIXI_VERSION }}
           cache: true
-          #cache-write: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
+          cache-write: ${{ github.event_name == 'push' && github.ref_name == 'latest' }}
           frozen: true
 
       - uses: Swatinem/rust-cache@v2
@@ -82,7 +82,7 @@ jobs:
         with:
           pixi-version: ${{ env.PIXI_VERSION }}
           cache: true
-          #cache-write: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
+          cache-write: ${{ github.event_name == 'push' && github.ref_name == 'latest' }}
           frozen: true
 
       - uses: Swatinem/rust-cache@v2
@@ -100,7 +100,7 @@ jobs:
         with:
           pixi-version: ${{ env.PIXI_VERSION }}
           cache: true
-          #cache-write: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
+          cache-write: ${{ github.event_name == 'push' && github.ref_name == 'latest' }}
           frozen: true
       - uses: Swatinem/rust-cache@v2
 
@@ -157,7 +157,7 @@ jobs:
         with:
           pixi-version: ${{ env.PIXI_VERSION }}
           cache: true
-          #cache-write: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
+          cache-write: ${{ github.event_name == 'push' && github.ref_name == 'latest' }}
           frozen: true
       - uses: Swatinem/rust-cache@v2
 
@@ -193,7 +193,7 @@ jobs:
         with:
           pixi-version: ${{ env.PIXI_VERSION }}
           cache: true
-          #cache-write: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
+          cache-write: ${{ github.event_name == 'push' && github.ref_name == 'latest' }}
           frozen: true
       - uses: Swatinem/rust-cache@v2
 
@@ -223,7 +223,7 @@ jobs:
         with:
           pixi-version: ${{ env.PIXI_VERSION }}
           cache: true
-          #cache-write: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
+          cache-write: ${{ github.event_name == 'push' && github.ref_name == 'latest' }}
           frozen: true
       - uses: Swatinem/rust-cache@v2
 
@@ -244,7 +244,7 @@ jobs:
         with:
           pixi-version: ${{ env.PIXI_VERSION }}
           cache: true
-          #cache-write: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
+          cache-write: ${{ github.event_name == 'push' && github.ref_name == 'latest' }}
           frozen: true
       - uses: Swatinem/rust-cache@v2
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -332,14 +332,14 @@ bitstring = ">=3.1.9,<5"
 make = ">=4.4.1,<5"
 
 [tool.pixi.feature.dev.tasks.install-tools]
-cmd = "echo $CARGO_HOME && cargo install cargo-binstall@1.14.4 && cargo binstall -y cargo-semver-checks && cargo binstall -y cargo-feature-combinations && cargo binstall -y wasm-pack && cargo binstall -y cbindgen --version 0.26.0"
-#outputs = [
-#  "$CARGO_HOME/bin/cbindgen",
-#  "$CARGO_HOME/bin/cargo-semver-checks",
-#  "$CARGO_HOME/bin/cargo-binstall",
-#  "$CARGO_HOME/bin/cargo-feature-combinations",
-#  "$CARGO_HOME/bin/wasm-pack",
-#]
+cmd = "cargo install cargo-binstall@1.14.4 && cargo binstall -y cargo-semver-checks && cargo binstall -y cargo-feature-combinations && cargo binstall -y wasm-pack && cargo binstall -y cbindgen --version 0.26.0"
+outputs = [
+  "$CARGO_HOME/bin/cbindgen",
+  "$CARGO_HOME/bin/cargo-semver-checks",
+  "$CARGO_HOME/bin/cargo-binstall",
+  "$CARGO_HOME/bin/cargo-feature-combinations",
+  "$CARGO_HOME/bin/wasm-pack",
+]
 
 [tool.pixi.feature.dev.tasks.semver-check]
 cmd = "cargo semver-checks check-release --default-features --features branchwater"
@@ -381,6 +381,10 @@ outputs = [
   "pkg/sourmash.d.ts",
   "pkg/sourmash.js",
 ]
+
+[tool.pixi.feature.wasm.activation.env]
+CARGO_HOME = "$CONDA_PREFIX/.cargo_cache"
+PATH = "$PATH:$CARGO_HOME/bin"
 
 [tool.pixi.feature.wasm.tasks]
 test-wasm = { cmd = "wasm-pack test --node src/core -- --features 'niffler/wasm'" , depends-on = ["install-tools"] }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -333,13 +333,13 @@ make = ">=4.4.1,<5"
 
 [tool.pixi.feature.dev.tasks.install-tools]
 cmd = "echo $CARGO_HOME && cargo install cargo-binstall@1.14.4 && cargo binstall -y cargo-semver-checks && cargo binstall -y cargo-feature-combinations && cargo binstall -y wasm-pack && cargo binstall -y cbindgen --version 0.26.0"
-outputs = [
-  "$CARGO_HOME/bin/cbindgen",
-  "$CARGO_HOME/bin/cargo-semver-checks",
-  "$CARGO_HOME/bin/cargo-binstall",
-  "$CARGO_HOME/bin/cargo-feature-combinations",
-  "$CARGO_HOME/bin/wasm-pack",
-]
+#outputs = [
+#  "$CARGO_HOME/bin/cbindgen",
+#  "$CARGO_HOME/bin/cargo-semver-checks",
+#  "$CARGO_HOME/bin/cargo-binstall",
+#  "$CARGO_HOME/bin/cargo-feature-combinations",
+#  "$CARGO_HOME/bin/wasm-pack",
+#]
 
 [tool.pixi.feature.dev.tasks.semver-check]
 cmd = "cargo semver-checks check-release --default-features --features branchwater"


### PR DESCRIPTION
CI for building the NPM wasm package broke after #3561

Solution is to activate env vars per feature (in this case `wasm`), on top of the `default` environment activation that was already set up.