### PR TITLE
WIP: add exception for unkown manifest output format

### DIFF
--- a/src/sourmash/manifest.py
+++ b/src/sourmash/manifest.py
@@ -125,6 +125,8 @@ class BaseCollectionManifest:
             SqliteCollectionManifest.load_from_manifest(
                 self, dbfile=filename, append=ok_if_exists
             )
+        else:
+            raise Exception("unknown output format for manifest")
 
     @classmethod
     def write_csv_header(cls, fp):


### PR DESCRIPTION
A minor fix to add error message for unknown output format. Noticed during https://github.com/sourmash-bio/sourmash/issues/3801