### PR TITLE
MRG: add picklist to sig collect

### DIFF
--- a/src/sourmash/cli/sig/collect.py
+++ b/src/sourmash/cli/sig/collect.py
@@ -83,6 +83,7 @@ def subparser(subparsers):
     add_ksize_arg(subparser)
     add_moltype_args(subparser)
     add_v5_args(subparser)
+    add_picklist_args(subparser)
 
 
 def main(args):

--- a/src/sourmash/sig/__main__.py
+++ b/src/sourmash/sig/__main__.py
@@ -1709,15 +1709,15 @@ def collect(args):
             row["internal_location"] = new_iloc
             collected_mf.add_row(row)
 
-
     # select using picklist (or could do this earlier and avoid loading?)
     from sourmash.picklist import PickStyle
+
     picklist = sourmash_args.load_picklist(args)
     sub_manifest = collected_mf.select_to_manifest(picklist=picklist)
     if _debug:
-            debug_literal(
-                f"examined {len(collected_mf)} new rows, found {len(sub_manifest)} matching rows"
-            )
+        debug_literal(
+            f"examined {len(collected_mf)} new rows, found {len(sub_manifest)} matching rows"
+        )
     sourmash_args.report_picklist(args, picklist)
     collected_mf = sub_manifest
 

--- a/src/sourmash/sig/__main__.py
+++ b/src/sourmash/sig/__main__.py
@@ -1603,6 +1603,7 @@ def check(args):
 def collect(args):
     "Collect signature metadata across many locations, save to manifest"
     set_quiet(False, args.debug)
+    picklist = sourmash_args.load_picklist(args)
 
     if args.cli_version == "v5":
         if args.abspath is None:  # not set by user
@@ -1707,19 +1708,13 @@ def collect(args):
 
         for row in mf.rows:
             row["internal_location"] = new_iloc
+
+            if picklist and not picklist.matches_manifest_row(row):
+                continue
+
             collected_mf.add_row(row)
 
-    # select using picklist (or could do this earlier and avoid loading?)
-    from sourmash.picklist import PickStyle
-
-    picklist = sourmash_args.load_picklist(args)
-    sub_manifest = collected_mf.select_to_manifest(picklist=picklist)
-    if _debug:
-        debug_literal(
-            f"examined {len(collected_mf)} new rows, found {len(sub_manifest)} matching rows"
-        )
     sourmash_args.report_picklist(args, picklist)
-    collected_mf = sub_manifest
 
     if args.manifest_format == "csv":
         collected_mf.write_to_filename(

--- a/src/sourmash/sig/__main__.py
+++ b/src/sourmash/sig/__main__.py
@@ -1709,6 +1709,18 @@ def collect(args):
             row["internal_location"] = new_iloc
             collected_mf.add_row(row)
 
+
+    # select using picklist (or could do this earlier and avoid loading?)
+    from sourmash.picklist import PickStyle
+    picklist = sourmash_args.load_picklist(args)
+    sub_manifest = collected_mf.select_to_manifest(picklist=picklist)
+    if _debug:
+            debug_literal(
+                f"examined {len(collected_mf)} new rows, found {len(sub_manifest)} matching rows"
+            )
+    sourmash_args.report_picklist(args, picklist)
+    collected_mf = sub_manifest
+
     if args.manifest_format == "csv":
         collected_mf.write_to_filename(
             args.output, database_format="csv", ok_if_exists=args.merge_previous

--- a/src/sourmash/sig/__main__.py
+++ b/src/sourmash/sig/__main__.py
@@ -1714,8 +1714,6 @@ def collect(args):
 
             collected_mf.add_row(row)
 
-    sourmash_args.report_picklist(args, picklist)
-
     if args.manifest_format == "csv":
         collected_mf.write_to_filename(
             args.output, database_format="csv", ok_if_exists=args.merge_previous
@@ -1724,6 +1722,8 @@ def collect(args):
         collected_mf.close()
 
     notify(f"saved {len(collected_mf)} manifest rows to '{args.output}'")
+    if picklist:
+        sourmash_args.report_picklist(args, picklist)
 
     return 0
 

--- a/tests/test_cmd_signature_collect.py
+++ b/tests/test_cmd_signature_collect.py
@@ -751,3 +751,111 @@ def test_sig_collect_6_path_subdir_subdir(
     )
 
     runtmp.sourmash("sig", "cat", mf_path)
+
+
+def test_sig_collect_picklist_include(runtmp, manifest_db_format):
+    # collect a manifest from three .zip files
+    # then use a picklist to select a subset
+    protzip = utils.get_test_data("prot/protein.zip")
+    hpzip = utils.get_test_data("prot/hp.zip")
+    dayzip = utils.get_test_data("prot/dayhoff.zip")
+
+    # write a temp picklist file
+    picklist_path = runtmp.output("pick.txt")
+    with open(picklist_path, "w") as fp:
+        fp.write("md5sum\n")
+        fp.write("16869d2c8a1d29d1c8e56f5c561e585e\n")
+        fp.write("ea2a1ad233c2908529d124a330bcb672\n")
+        fp.write("fbca5e5211e4d58427997fd5c8343e9a\n")
+
+    ext = "sqlmf" if manifest_db_format == "sql" else "csv"
+
+    runtmp.sourmash(
+        "sig",
+        "collect",
+        protzip,
+        hpzip,
+        dayzip,
+        "-o",
+        f"mf.{ext}",
+        "--picklist",
+        f"{picklist_path}:md5sum:md5",
+        "-F",
+        manifest_db_format,
+    )
+
+    manifest_fn = runtmp.output(f"mf.{ext}")
+    manifest = BaseCollectionManifest.load_from_filename(manifest_fn)
+
+    # print manifest
+    print(manifest)
+
+    assert len(manifest) == 3
+    md5_list = [row["md5"] for row in manifest.rows]
+    assert "16869d2c8a1d29d1c8e56f5c561e585e" in md5_list
+    assert "ea2a1ad233c2908529d124a330bcb672" in md5_list
+    assert "fbca5e5211e4d58427997fd5c8343e9a" in md5_list
+
+    assert "120d311cc785cc9d0df9dc0646b2b857" not in md5_list
+    assert "bb0e6d90df01b7bd5d0956a5f9e3ed12" not in md5_list
+    assert "1cbd888bf910f83ad8f1715509183223" not in md5_list
+
+    locations = set([row["internal_location"] for row in manifest.rows])
+    assert protzip in locations
+    assert hpzip in locations
+    assert dayzip in locations
+    assert len(locations) == 3, locations
+
+
+def test_sig_collect_picklist_exclude(runtmp, manifest_db_format):
+    # collect a manifest from three .zip files
+    # then use a picklist to select a subset
+    protzip = utils.get_test_data("prot/protein.zip")
+    hpzip = utils.get_test_data("prot/hp.zip")
+    dayzip = utils.get_test_data("prot/dayhoff.zip")
+
+    # write a temp picklist file
+    picklist_path = runtmp.output("pick.txt")
+    with open(picklist_path, "w") as fp:
+        fp.write("md5sum\n")
+        fp.write("16869d2c8a1d29d1c8e56f5c561e585e\n")
+        fp.write("ea2a1ad233c2908529d124a330bcb672\n")
+        fp.write("fbca5e5211e4d58427997fd5c8343e9a\n")
+
+    ext = "sqlmf" if manifest_db_format == "sql" else "csv"
+
+    runtmp.sourmash(
+        "sig",
+        "collect",
+        protzip,
+        hpzip,
+        dayzip,
+        "-o",
+        f"mf.{ext}",
+        "--picklist",
+        f"{picklist_path}:md5sum:md5:exclude",
+        "-F",
+        manifest_db_format,
+    )
+
+    manifest_fn = runtmp.output(f"mf.{ext}")
+    manifest = BaseCollectionManifest.load_from_filename(manifest_fn)
+
+    # print manifest
+    print(manifest)
+
+    assert len(manifest) == 3
+    md5_list = [row["md5"] for row in manifest.rows]
+    assert "16869d2c8a1d29d1c8e56f5c561e585e" not in md5_list
+    assert "ea2a1ad233c2908529d124a330bcb672" not in md5_list
+    assert "fbca5e5211e4d58427997fd5c8343e9a" not in md5_list
+
+    assert "120d311cc785cc9d0df9dc0646b2b857" in md5_list
+    assert "bb0e6d90df01b7bd5d0956a5f9e3ed12" in md5_list
+    assert "1cbd888bf910f83ad8f1715509183223" in md5_list
+
+    locations = set([row["internal_location"] for row in manifest.rows])
+    assert protzip in locations
+    assert hpzip in locations
+    assert dayzip in locations
+    assert len(locations) == 3, locations


### PR DESCRIPTION
Here, we add picklist arguments to `sig collect` so we can select on the collected sigs.

Is there an alternate way to do this for a standalone manifest?

example usage:

```
/usr/bin/time -v  sourmash sig collect /group/ctbrowngrp5/wort/wort-sra/SOURMASH-MANIFEST.csv.gz --picklist wort-largest-10k.idents.txt:ident:ident -F csv -o wort-largest-10k.mf.csv --abspath                                                                                                                                                                    


== This is sourmash version 4.9.5.dev0. ==
== Please cite Irber et. al (2024), doi:10.21105/joss.06830. ==

picking column 'ident' of type 'ident' from 'wort-largest-10k.idents.txt'
loaded 10000 distinct values into picklist.
Loading signature information from /group/ctbrowngrp5/wort/wort-sra/SOURMASH-MANIFEST.csv.gz.
for given picklist, found 10000 matches to 10000 distinct values
saved 30000 manifest rows to 'wort-largest-10k.mf.csv'
        Command being timed: "sourmash sig collect /group/ctbrowngrp5/wort/wort-sra/SOURMASH-MANIFEST.csv.gz --picklist wort-largest-10k.idents.txt:ident:ident -F csv -o wort-largest-10k.mf.csv --abspath"
        User time (seconds): 256.04
        System time (seconds): 21.11
        Percent of CPU this job got: 98%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 4:41.10
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 15760176
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 24
        Minor (reclaiming a frame) page faults: 4007107
        Voluntary context switches: 4229
        Involuntary context switches: 27503
        Swaps: 0
        File system inputs: 1404408
        File system outputs: 8304
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
```

...and checking the resultant standalone manifest:
```
sourmash sig summarize wort-largest-10k.mf.csv

== This is sourmash version 4.9.5.dev0. ==
== Please cite Irber et. al (2024), doi:10.21105/joss.06830. ==

** loading from 'wort-largest-10k.mf.csv'
path filetype: StandaloneManifestIndex
location: wort-largest-10k.mf.csv
is database? yes
has manifest? yes
num signatures: 30000
** examining manifest...
total hashes: 329265656902
summary of sketches:
   10000 sketches with DNA, k=21, scaled=1000, abund  104490720670 total hashes
   10000 sketches with DNA, k=31, scaled=1000, abund  115363100334 total hashes
   10000 sketches with DNA, k=51, scaled=1000, abund  109411835898 total hashes
```