### PR TITLE
MRG: upgrade grep behavior: make picklist support clearer and add `-l/--print-matched-names`.

### DIFF
--- a/doc/command-line.md
+++ b/doc/command-line.md
@@ -1544,10 +1544,10 @@ Concatenate signature files.
 
 For example,
 ```
-sourmash signature cat file1.sig file2.sig -o all.zip
+sourmash signature cat file1.sig file2.sig -o all.sig.zip
 ```
 will combine all signatures in `file1.sig` and `file2.sig` and put them
-in the file `all.zip`.
+in the file `all.sig.zip`.
 
 #### Using picklists with `sourmash sig cat`
 
@@ -1623,22 +1623,27 @@ on the name, filename, and md5 fields.
 
 For example,
 ```
-sourmash signature grep -i shewanella tests/test-data/prot/all.zip -o shew.zip
+sourmash signature grep -i shewanella tests/test-data/prot/all.zip -o shew.sig.zip
 ```
 will extract the two signatures in `all.zip` with 'Shewanella baltica'
-in their name and save them to `shew.zip`.
+in their name and save them to `shew.sig.zip`.
 
 `grep` will search for substring matches or regular expressions;
 e.g. `sourmash sig grep 'os185|os223' ...` will find matches to either
 of those expressions.
 
-Command line options include `-i` for case-insensitive matching, and `-v`
-for exclusion rather than inclusion.
+`-l/--print-matched-names` will print a list of distinct matching
+sketch names and `-c/--count` will print a count of total matching
+sketches; both imply `--no-sigs` and so will disable signature output .
+
+String matching modifiers include `-i` for case-insensitive matching,
+and `-v` for exclusion rather than inclusion.
 
 A CSV file of the matching sketch information can be saved using
-`--csv <outfile>`; this file is in the sourmash manifest format and can be used as a picklist with `--pickfile <outfile>::manifest`.
+`--csv <outfile>`; this file is in the sourmash manifest format and
+can be used as a picklist with `--pickfile <outfile>::manifest`.
 
-If `--silent` is specified, `sourmash sig grep` will not output matching
+If `--no-sigs` is specified, `sourmash sig grep` will not output matching
 signatures.
 
 `sourmash sig grep` also supports a counting mode, `-c/--count`, in which
@@ -2276,10 +2281,10 @@ slow, especially for many (100s or 1000s) of signatures.
 
 All of the `sourmash` commands support loading collections of
 signatures from zip files.  You can create a compressed collection of
-signatures using `sourmash sig cat *.sig -o collections.zip` and then
-specifying `collections.zip` on the command line in place of `*.sig`;
+signatures using `sourmash sig cat *.sig -o collections.sig.zip` and then
+specifying `collections.sig.zip` on the command line in place of `*.sig`;
 you can also sketch FASTA/FASTQ files directly into a zip file with
-`-o collections.zip`.
+`-o collections.sig.zip`.
 
 ### Choosing signature output formats
 

--- a/doc/command-line.md
+++ b/doc/command-line.md
@@ -1632,12 +1632,13 @@ in their name and save them to `shew.sig.zip`.
 e.g. `sourmash sig grep 'os185|os223' ...` will find matches to either
 of those expressions.
 
-`-l/--print-matched-names` will print a list of distinct matching
-sketch names and `-c/--count` will print a count of total matching
-sketches; both imply `--no-sigs` and so will disable signature output .
-
 String matching modifiers include `-i` for case-insensitive matching,
 and `-v` for exclusion rather than inclusion.
+
+By default, `sig grep` outputs matching sketches. Alternatively,
+`-l/--print-matched-names` prints a list of distinct matching
+sketch names and `-c/--count` prints a count of total matching
+sketches; both disable sketch output by setting `--no-sigs`.
 
 A CSV file of the matching sketch information can be saved using
 `--csv <outfile>`; this file is in the sourmash manifest format and
@@ -1645,23 +1646,6 @@ can be used as a picklist with `--pickfile <outfile>::manifest`.
 
 If `--no-sigs` is specified, `sourmash sig grep` will not output matching
 signatures.
-
-`sourmash sig grep` also supports a counting mode, `-c/--count`, in which
-only the number of matching sketches in files will be displayed; for example,
-
-```
-% sourmash signature grep -ci 'os185|os223' tests/test-data/prot/*.zip 
-```
-will produce the following output:
-```
-2 matches: tests/test-data/prot/all.zip
-0 matches: tests/test-data/prot/dayhoff.sbt.zip
-0 matches: tests/test-data/prot/dayhoff.zip
-0 matches: tests/test-data/prot/hp.sbt.zip
-0 matches: tests/test-data/prot/hp.zip
-0 matches: tests/test-data/prot/protein.sbt.zip
-0 matches: tests/test-data/prot/protein.zip
-```
 
 ### `sourmash signature split` - split signatures into individual files
 

--- a/src/sourmash/cli/sig/grep.py
+++ b/src/sourmash/cli/sig/grep.py
@@ -74,8 +74,9 @@ def subparser(subparsers):
         action="store_true",
     )
     subparser.add_argument(
-        "--csv", "--save-picklist",
-        help="save CSV file containing signature data in manifest format; can be used as a picklist"
+        "--csv",
+        "--save-picklist",
+        help="save CSV file containing signature data in manifest format; can be used as a picklist",
     )
     subparser.add_argument(
         "--no-sigs",

--- a/src/sourmash/cli/sig/grep.py
+++ b/src/sourmash/cli/sig/grep.py
@@ -79,13 +79,20 @@ def subparser(subparsers):
     subparser.add_argument(
         "--silent",
         "--no-signatures-output",
+        "--no-sigs",
         help="do not output signatures",
         action="store_true",
     )
     subparser.add_argument(
         "-c",
         "--count",
-        help="only output a count of discovered signatures; implies --silent",
+        help="only output a count of discovered signatures; implies --no-sigs",
+        action="store_true",
+    )
+    subparser.add_argument(
+        "-l",
+        "--print-matched-names",
+        help="output the full names of matched signatures; implies --no-sigs",
         action="store_true",
     )
     add_ksize_arg(subparser)

--- a/src/sourmash/cli/sig/grep.py
+++ b/src/sourmash/cli/sig/grep.py
@@ -74,12 +74,13 @@ def subparser(subparsers):
         action="store_true",
     )
     subparser.add_argument(
-        "--csv", help="save CSV file containing signature data in manifest format"
+        "--csv", "--save-picklist",
+        help="save CSV file containing signature data in manifest format"
     )
     subparser.add_argument(
+        "--no-sigs",
         "--silent",
         "--no-signatures-output",
-        "--no-sigs",
         help="do not output signatures",
         action="store_true",
     )

--- a/src/sourmash/cli/sig/grep.py
+++ b/src/sourmash/cli/sig/grep.py
@@ -75,7 +75,7 @@ def subparser(subparsers):
     )
     subparser.add_argument(
         "--csv", "--save-picklist",
-        help="save CSV file containing signature data in manifest format"
+        help="save CSV file containing signature data in manifest format; can be used as a picklist"
     )
     subparser.add_argument(
         "--no-sigs",

--- a/src/sourmash/sig/grep.py
+++ b/src/sourmash/sig/grep.py
@@ -52,7 +52,7 @@ def main(args):
     # define output type: signatures, or no?
     if args.no_sigs:
         notify(
-            "(no signatures will be saved because of --no-sigs/--count/--print-matched-names)."
+            "(no signatures will be saved because of --no-sigs/--count/--print-matched-names)"
         )
         save_sigs = sourmash_args.SaveSignaturesToLocation(None)
     else:

--- a/src/sourmash/sig/grep.py
+++ b/src/sourmash/sig/grep.py
@@ -69,6 +69,7 @@ def main(args):
 
     # start loading!
     total_rows_examined = 0
+    seen = set()
     for filename in args.signatures:
         idx = sourmash_args.load_file_as_index(filename, yield_all_files=args.force)
 
@@ -101,11 +102,10 @@ def main(args):
         if args.count:
             print_results(f"{len(sub_manifest)} matches: {filename}")
         elif args.print_matched_names:
-            seen = set()
             for row in sub_manifest.rows:
                 name = row["name"]
                 if name not in seen:
-                    print_results(row["name"])
+                    print_results(name)
                     seen.add(name)
         elif not args.no_sigs:
             # nope - do output signatures. convert manifest to picklist, apply.

--- a/src/sourmash/sig/grep.py
+++ b/src/sourmash/sig/grep.py
@@ -51,7 +51,9 @@ def main(args):
 
     # define output type: signatures, or no?
     if args.silent:
-        notify("(no signatures will be saved because of --silent/--count/--print-matched-names).")
+        notify(
+            "(no signatures will be saved because of --silent/--count/--print-matched-names)."
+        )
         save_sigs = sourmash_args.SaveSignaturesToLocation(None)
     else:
         notify(f"saving matching signatures to '{args.output}'")

--- a/src/sourmash/sig/grep.py
+++ b/src/sourmash/sig/grep.py
@@ -46,12 +46,12 @@ def main(args):
         debug("sig grep: manifest required")
 
     # are we doing --count? if so, enforce --silent so no sigs are printed.
-    if args.count:
+    if args.count or args.print_matched_names:
         args.silent = True
 
     # define output type: signatures, or no?
     if args.silent:
-        notify("(no signatures will be saved because of --silent/--count).")
+        notify("(no signatures will be saved because of --silent/--count/--print-matched-names).")
         save_sigs = sourmash_args.SaveSignaturesToLocation(None)
     else:
         notify(f"saving matching signatures to '{args.output}'")
@@ -98,6 +98,13 @@ def main(args):
         # just print out number of matches?
         if args.count:
             print_results(f"{len(sub_manifest)} matches: {filename}")
+        elif args.print_matched_names:
+            seen = set()
+            for row in sub_manifest.rows:
+                name = row["name"]
+                if name not in seen:
+                    print_results(row["name"])
+                    seen.add(name)
         elif not args.silent:
             # nope - do output signatures. convert manifest to picklist, apply.
             sub_picklist = sub_manifest.to_picklist()

--- a/src/sourmash/sig/grep.py
+++ b/src/sourmash/sig/grep.py
@@ -45,14 +45,14 @@ def main(args):
     else:
         debug("sig grep: manifest required")
 
-    # are we doing --count? if so, enforce --silent so no sigs are printed.
+    # are we doing --count? if so, enforce --no-sigs so no sigs are printed.
     if args.count or args.print_matched_names:
-        args.silent = True
+        args.no_sigs = True
 
     # define output type: signatures, or no?
-    if args.silent:
+    if args.no_sigs:
         notify(
-            "(no signatures will be saved because of --silent/--count/--print-matched-names)."
+            "(no signatures will be saved because of --no-sigs/--count/--print-matched-names)."
         )
         save_sigs = sourmash_args.SaveSignaturesToLocation(None)
     else:
@@ -107,7 +107,7 @@ def main(args):
                 if name not in seen:
                     print_results(row["name"])
                     seen.add(name)
-        elif not args.silent:
+        elif not args.no_sigs:
             # nope - do output signatures. convert manifest to picklist, apply.
             sub_picklist = sub_manifest.to_picklist()
 
@@ -126,7 +126,7 @@ def main(args):
                 save_sigs.add(ss)
     # done with the big loop over all indexes!
 
-    if args.silent:
+    if args.no_sigs:
         pass
     else:
         notify(f"loaded {total_rows_examined} total that matched ksize & molecule type")

--- a/tests/test_cmd_signature_grep.py
+++ b/tests/test_cmd_signature_grep.py
@@ -412,6 +412,42 @@ def test_sig_grep_8_count(runtmp):
         assert line.strip() in out
 
 
+def test_sig_grep_9_name(runtmp):
+    zips = [
+        "prot/all.zip",
+        "prot/dayhoff.sbt.zip",
+        "prot/dayhoff.zip",
+        "prot/hp.sbt.zip",
+        "prot/hp.zip",
+        "prot/protein.sbt.zip",
+        "prot/protein.zip",
+    ]
+
+    zip_src = [utils.get_test_data(x) for x in zips]
+
+    os.mkdir(runtmp.output("prot"))
+    for src, dest in zip(zip_src, zips):
+        shutil.copyfile(src, runtmp.output(dest))
+
+    runtmp.sourmash("sig", "grep", "-l", "0015939", *zips)
+
+    out = runtmp.last_result.out
+    err = runtmp.last_result.err
+
+    print(out)
+    print(err)
+
+    assert "(no signatures will be saved because of " in err
+
+    for line in """\
+GCA_001593925
+GCA_001593935
+""".splitlines():
+        assert line.strip() in out
+
+    assert len(out.splitlines()) == 2, (out,)
+
+
 def test_sig_grep_identical_md5s(runtmp):
     # test that we properly handle different signatures with identical md5s
     sig47 = utils.get_test_data("47.fa.sig")

--- a/tests/test_cmd_signature_grep.py
+++ b/tests/test_cmd_signature_grep.py
@@ -398,7 +398,7 @@ def test_sig_grep_8_count(runtmp):
     print(out)
     print(err)
 
-    assert "(no signatures will be saved because of --silent/--count)." in err
+    assert "(no signatures will be saved because of --silent/--count" in err
 
     for line in """\
 6 matches: prot/all.zip

--- a/tests/test_cmd_signature_grep.py
+++ b/tests/test_cmd_signature_grep.py
@@ -398,7 +398,7 @@ def test_sig_grep_8_count(runtmp):
     print(out)
     print(err)
 
-    assert "(no signatures will be saved because of --silent/--count" in err
+    assert "(no signatures will be saved because of " in err
 
     for line in """\
 6 matches: prot/all.zip


### PR DESCRIPTION
This PR:
* adds `-l/--print-matched-names` which disables sketch output and just prints the unique matching names
* adds `--no-sigs` as an alias for `--silent`
* adds `--save-picklist` as an alias for `--csv`

TODO:
- [x] add tests for `-l`

Tackles https://github.com/sourmash-bio/sourmash/issues/3810