### PR TITLE
[MRG] Lineage methods to allow easier pangenomic ranktable generation

### DIFF
--- a/src/sourmash/tax/tax_utils.py
+++ b/src/sourmash/tax/tax_utils.py
@@ -147,6 +147,12 @@ class BaseLineageInfo:
             return None
         return self.filled_ranks[-1]
 
+    @property
+    def highest_rank(self):
+        if not self.filled_ranks:
+            return None
+        return self.filled_ranks[0]
+
     def rank_index(self, rank):
         self.check_rank_availability(rank)
         return self.ranks.index(rank)
@@ -174,6 +180,13 @@ class BaseLineageInfo:
         if not self.filled_ranks:
             return None
         return self.filled_lineage[-1].name
+
+    @property
+    def highest_lineage_name(self):
+        "Return the name of the highest filled lineage"
+        if not self.filled_ranks:
+            return None
+        return self.filled_lineage[0].name
 
     @property
     def lowest_lineage_taxid(self):
@@ -332,6 +345,34 @@ class BaseLineageInfo:
         rank_idx = self.rank_index(rank)
         return self.filled_lineage[: rank_idx + 1]
 
+    def lineage_above_rank(self, rank):
+        """
+        Return tuple of LineagePairs *above* the specified rank.
+        """
+        if rank == self.highest_rank:
+            return ()
+
+        self.check_rank_availability(rank)
+        if not self.rank_is_filled(rank):
+            return self.filled_lineage
+        rank_idx = self.rank_index(rank)
+        return self.filled_lineage[: rank_idx]
+
+    def lineage_below_rank(self, rank):
+        """
+        Return tuple of LineagePairs *below* the specified rank.
+        """
+        if rank == self.lowest_rank:
+            return ()
+
+        self.check_rank_availability(rank)
+        rank_idx = self.rank_index(rank)
+        lower_rank_idx = rank_idx + 1
+        lower_rank = self.filled_lineage[lower_rank_idx].rank
+        if not self.rank_is_filled(lower_rank):
+            return self.filled_lineage
+        return self.filled_lineage[: lower_rank_idx + 1]
+
     def find_lca(self, other):
         """
         If an LCA match exists between self and other,
@@ -341,6 +382,7 @@ class BaseLineageInfo:
             if self.is_lineage_match(other, rank):
                 return self.pop_to_rank(rank)
         return None
+
 
 
 @dataclass(frozen=True, order=True)

--- a/src/sourmash/tax/tax_utils.py
+++ b/src/sourmash/tax/tax_utils.py
@@ -356,7 +356,7 @@ class BaseLineageInfo:
         if not self.rank_is_filled(rank):
             return self.filled_lineage
         rank_idx = self.rank_index(rank)
-        return self.filled_lineage[: rank_idx]
+        return self.filled_lineage[:rank_idx]
 
     def lineage_below_rank(self, rank):
         """
@@ -382,7 +382,6 @@ class BaseLineageInfo:
             if self.is_lineage_match(other, rank):
                 return self.pop_to_rank(rank)
         return None
-
 
 
 @dataclass(frozen=True, order=True)

--- a/tests/test_tax_utils.py
+++ b/tests/test_tax_utils.py
@@ -2506,6 +2506,7 @@ def test_lineage_at_rank_1():
         LineagePair(rank="order", name="o__d", taxid=None),
     )
 
+
 def test_lineage_at_rank_below_rank():
     lin1 = RankLineageInfo(lineage_str="d__a;p__b;c__c;o__d;f__f")
     print(lin1.lineage_at_rank("superkingdom"))

--- a/tests/test_tax_utils.py
+++ b/tests/test_tax_utils.py
@@ -2489,13 +2489,28 @@ def test_lineage_at_rank_1():
     assert lin1.lineage_at_rank("superkingdom") == (
         LineagePair(rank="superkingdom", name="d__a", taxid=None),
     )
-    print(lin1.lineage_at_rank("class"))
+
+    print("lineage_at_rank:", lin1.lineage_at_rank("genus")[-1].name)
+    #print("lineage_above_rank:", lin1.lineage_above_rank("superkingdom")[-1].name)
+    #print("lineage_below_rank:", lin1.lineage_below_rank("genus")[-1].name)
+
     assert lin1.lineage_at_rank("class") == (
         LineagePair(rank="superkingdom", name="d__a", taxid=None),
         LineagePair(rank="phylum", name="p__b", taxid=None),
         LineagePair(rank="class", name="c__c", taxid=None),
     )
+    assert lin1.lineage_above_rank("class") == (
+        LineagePair(rank="superkingdom", name="d__a", taxid=None),
+        LineagePair(rank="phylum", name="p__b", taxid=None),
+    )
+    assert lin1.lineage_below_rank("class") == (
+        LineagePair(rank="superkingdom", name="d__a", taxid=None),
+        LineagePair(rank="phylum", name="p__b", taxid=None),
+        LineagePair(rank="class", name="c__c", taxid=None),
+        LineagePair(rank="order", name="o__d", taxid=None),
+    )
 
+test_lineage_at_rank_1()
 
 def test_lineage_at_rank_below_rank():
     lin1 = RankLineageInfo(lineage_str="d__a;p__b;c__c;o__d;f__f")

--- a/tests/test_tax_utils.py
+++ b/tests/test_tax_utils.py
@@ -2490,10 +2490,6 @@ def test_lineage_at_rank_1():
         LineagePair(rank="superkingdom", name="d__a", taxid=None),
     )
 
-    print("lineage_at_rank:", lin1.lineage_at_rank("genus")[-1].name)
-    #print("lineage_above_rank:", lin1.lineage_above_rank("superkingdom")[-1].name)
-    #print("lineage_below_rank:", lin1.lineage_below_rank("genus")[-1].name)
-
     assert lin1.lineage_at_rank("class") == (
         LineagePair(rank="superkingdom", name="d__a", taxid=None),
         LineagePair(rank="phylum", name="p__b", taxid=None),
@@ -2509,8 +2505,6 @@ def test_lineage_at_rank_1():
         LineagePair(rank="class", name="c__c", taxid=None),
         LineagePair(rank="order", name="o__d", taxid=None),
     )
-
-test_lineage_at_rank_1()
 
 def test_lineage_at_rank_below_rank():
     lin1 = RankLineageInfo(lineage_str="d__a;p__b;c__c;o__d;f__f")


### PR DESCRIPTION
This PR adds simple methods to find the LineageTuple above and below a given rank.

This does not address any current issue in the issue tracker, but is to facilitate ranktable generation for [sourmash pangenomics](https://github.com/dib-lab/sourmash_plugin_pangenomics)

This PR also adds test of the methods added.
