### PR TITLE
WIP: add code to get matches w/o full signatures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1660,7 +1660,7 @@ checksum = "9f1341053f34bb13b5e9590afb7d94b48b48d4b87467ec28e3c238693bb553de"
 
 [[package]]
 name = "sourmash"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "az",
  "byteorder",

--- a/include/sourmash.h
+++ b/include/sourmash.h
@@ -71,6 +71,8 @@ typedef struct SourmashManifest SourmashManifest;
 
 typedef struct SourmashManifestRowIter SourmashManifestRowIter;
 
+typedef struct SourmashMatchResult SourmashMatchResult;
+
 typedef struct SourmashNodegraph SourmashNodegraph;
 
 typedef struct SourmashRevIndex SourmashRevIndex;
@@ -327,6 +329,12 @@ const SourmashManifestRow *manifest_rows_iter_next(SourmashManifestRowIter *ptr)
 
 void manifestrow_free(SourmashManifestRow *ptr);
 
+void matchresult_free(SourmashMatchResult *ptr);
+
+uintptr_t matchresult_matches(const SourmashMatchResult *ptr);
+
+SourmashStr matchresult_name(const SourmashMatchResult *ptr);
+
 void nodegraph_buffer_free(uint8_t *ptr, uintptr_t insize);
 
 bool nodegraph_count(SourmashNodegraph *ptr, uint64_t h);
@@ -386,9 +394,14 @@ void revindex_countergather_free(SourmashRevIndex_CounterGather *ptr);
 
 uint64_t revindex_countergather_len(SourmashRevIndex_CounterGather *cg_ptr);
 
+const SourmashMatchResult *const *revindex_countergather_matches_from_counter(const SourmashRevIndex_CounterGather *cg_ptr,
+                                                                              const SourmashRevIndex *db_ptr,
+                                                                              uintptr_t threshold_hashes,
+                                                                              uintptr_t *size);
+
 SourmashSignature *revindex_countergather_peek(const SourmashRevIndex_CounterGather *cg_ptr,
                                                const SourmashRevIndex *db_ptr,
-                                               uint64_t threshold_bp);
+                                               uint64_t threshold_hashes);
 
 SourmashSignature **revindex_countergather_signatures(const SourmashRevIndex_CounterGather *cg_ptr,
                                                       const SourmashRevIndex *db_ptr,

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sourmash"
-version = "0.22.0"
+version = "0.22.1"
 authors = ["Luiz Irber <luiz@sourmash.bio>", "N. Tessa Pierce-Ward <tessa@sourmash.bio>", "C. Titus Brown <titus@idyll.org>"]
 description = "tools for comparing biological sequences with k-mer sketches"
 repository = "https://github.com/sourmash-bio/sourmash"

--- a/src/core/src/ffi/index/mod.rs
+++ b/src/core/src/ffi/index/mod.rs
@@ -36,3 +36,26 @@ pub unsafe extern "C" fn searchresult_signature(
     let result = SourmashSearchResult::as_rust(ptr);
     SourmashSignature::from_rust((result.1).clone())
 }
+
+pub struct SourmashMatchResult;
+
+impl ForeignObject for SourmashMatchResult {
+    type RustObject = (usize, String);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn matchresult_free(ptr: *mut SourmashMatchResult) {
+    SourmashMatchResult::drop(ptr);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn matchresult_matches(ptr: *const SourmashMatchResult) -> usize {
+    let result = SourmashMatchResult::as_rust(ptr);
+    result.0
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn matchresult_name(ptr: *const SourmashMatchResult) -> SourmashStr {
+    let result = SourmashMatchResult::as_rust(ptr);
+    (result.1).clone().into()
+}

--- a/src/core/src/ffi/index/revindex.rs
+++ b/src/core/src/ffi/index/revindex.rs
@@ -4,7 +4,7 @@ use std::slice;
 
 use crate::collection::{Collection, CollectionSet};
 use crate::encodings::*;
-use crate::ffi::index::SourmashSearchResult;
+use crate::ffi::index::{SourmashMatchResult, SourmashSearchResult};
 use crate::ffi::index::SourmashStr;
 use crate::ffi::manifest::SourmashManifest;
 use crate::ffi::minhash::SourmashKmerMinHash;
@@ -467,12 +467,12 @@ ffi_fn! {
 unsafe fn revindex_countergather_peek(
     cg_ptr: *const SourmashRevIndex_CounterGather,
     db_ptr: *const SourmashRevIndex,
-    threshold_bp: u64,
+    threshold_hashes: u64,
 ) -> Result<*mut SourmashSignature> {
     let cg: &CounterGather = SourmashRevIndex_CounterGather::as_rust(cg_ptr);
     let revindex = &SourmashRevIndex::as_rust(db_ptr);
 
-    let result = cg.peek(threshold_bp as usize);
+    let result = cg.peek(threshold_hashes as usize);
 
     if let Some((dataset_id, _match_size)) = result {
         let match_sig = revindex
@@ -518,6 +518,37 @@ unsafe fn revindex_countergather_signatures(
     *size = b.len();
 
     Ok(Box::into_raw(b) as *mut *mut SourmashSignature)
+}
+}
+
+ffi_fn! {
+unsafe fn revindex_countergather_matches_from_counter(
+    cg_ptr: *const SourmashRevIndex_CounterGather,
+    db_ptr: *const SourmashRevIndex,
+    threshold_hashes: usize,
+    size: *mut usize,
+) -> Result<*const *const SourmashMatchResult> {
+    let cg: &CounterGather = SourmashRevIndex_CounterGather::as_rust(cg_ptr);
+    let revindex = &SourmashRevIndex::as_rust(db_ptr);
+
+    let matches = revindex.matches_from_counter(cg.counter.clone(), threshold_hashes);
+
+    let matches2: Vec<(usize, String)> = matches
+        .into_iter()
+        .map(|(name, size)| {
+            (size, name.to_owned())
+        })
+        .collect();   
+
+    let ptr_results: Vec<*const SourmashMatchResult> = matches2
+        .into_iter()
+        .map(|x| Box::into_raw(Box::new(x)) as *const SourmashMatchResult)
+        .collect();
+
+    let b = ptr_results.into_boxed_slice();
+    *size = b.len();
+
+    Ok(Box::into_raw(b) as *const *const SourmashMatchResult)
 }
 }
 

--- a/src/core/src/index/revindex/mod.rs
+++ b/src/core/src/index/revindex/mod.rs
@@ -37,7 +37,7 @@ pub struct HashToColor(HashToColorT);
 /// iterative peek/consume.
 #[derive(Debug)]
 pub struct CounterGather {
-    counter: SigCounter,
+    pub counter: SigCounter,
     query_colors: QueryColors,
     hash_to_color: HashToColor,
 }

--- a/src/sourmash/index/revindex.py
+++ b/src/sourmash/index/revindex.py
@@ -714,8 +714,10 @@ class RevIndex_CounterGather_Colors(RustObject):
         "Return (overlap, name)"
         size = ffi.new("uintptr_t *")
         matches_ptr = self._methodcall(
-            lib.revindex_countergather_matches_from_counter, self.db._objptr,
-            threshold_hashes, size
+            lib.revindex_countergather_matches_from_counter,
+            self.db._objptr,
+            threshold_hashes,
+            size,
         )
         size = size[0]
 

--- a/src/sourmash/index/revindex.py
+++ b/src/sourmash/index/revindex.py
@@ -355,6 +355,35 @@ class SearchResult(RustObject):
         return result
 
 
+class MatchResult(RustObject):
+    """
+    Hold MatchResults from Rust.
+    """
+
+    __dealloc_func__ = lib.matchresult_free
+
+    def __repr__(self):
+        return f"MatchResult({self.matches}, {self.name})"
+
+    def __iter__(self):
+        return iter((self.matches, self.name))
+
+    def __getitem__(self, i):
+        return list(self)[i]
+
+    @property
+    def matches(self):
+        x = self._methodcall(lib.matchresult_matches)
+        return x
+
+    @property
+    def name(self):
+        result = decode_str(self._methodcall(lib.matchresult_name))
+        if result == "":
+            return None
+        return result
+
+
 class MemRevIndex(RevIndex):
     """
     Memory-based RevIndex.
@@ -680,6 +709,19 @@ class RevIndex_CounterGather_Colors(RustObject):
         for i in range(size):
             sig = SourmashSignature._from_objptr(sigs_ptr[i])
             yield sig
+
+    def matches(self, *, threshold_hashes=0):
+        "Return (overlap, name)"
+        size = ffi.new("uintptr_t *")
+        matches_ptr = self._methodcall(
+            lib.revindex_countergather_matches_from_counter, self.db._objptr,
+            threshold_hashes, size
+        )
+        size = size[0]
+
+        for i in range(size):
+            match = MatchResult._from_objptr(matches_ptr[i])
+            yield match
 
 
 class RevIndex_DatasetPicklist(RustObject):

--- a/src/sourmash/index/revindex.py
+++ b/src/sourmash/index/revindex.py
@@ -219,6 +219,7 @@ class RevIndex(RustObject, Index):
         pass
 
     def counter_gather(self, query_ss, threshold_bp=0, **kwargs):
+        # @CTB threhsold_bp is ignored!
         """
         Return a CounterGather object that holds interim results for a
         'gather', and can be used to get iterative results.

--- a/tests/test_revindex.py
+++ b/tests/test_revindex.py
@@ -854,12 +854,12 @@ def test_disk_revindex_prefetch_to_cg_colors_9():
 
     x = list(cg.matches())
     assert x[0].matches == 44
-    assert x[0].name.startswith('NC_011663.1')
+    assert x[0].name.startswith("NC_011663.1")
     assert x[1][0] == 41
-    assert x[1].name.startswith('NC_009665.1')
+    assert x[1].name.startswith("NC_009665.1")
     assert x[2][0] == 22
-    assert x[2].name.startswith('CP001071.1')
-    
+    assert x[2].name.startswith("CP001071.1")
+
 
 def test_disk_revindex_union_found():
     # test union_found on db that contains 63 and 2, but not 47

--- a/tests/test_revindex.py
+++ b/tests/test_revindex.py
@@ -842,6 +842,25 @@ def test_disk_revindex_prefetch_to_cg_colors_8():
     assert len(siglist) == 3
 
 
+def test_disk_revindex_prefetch_to_cg_colors_9():
+    # try out matches
+    metag_path = utils.get_test_data("SRR606249.sig.gz")
+    metag = load_one_signature_from_json(metag_path, ksize=31)
+
+    rocksdb_path = utils.get_test_data("3sigs.branch_0913.rocksdb")
+    db = DiskRevIndex(rocksdb_path)
+
+    cg = db.counter_gather(metag, threshold_bp=0)
+
+    x = list(cg.matches())
+    assert x[0].matches == 44
+    assert x[0].name.startswith('NC_011663.1')
+    assert x[1][0] == 41
+    assert x[1].name.startswith('NC_009665.1')
+    assert x[2][0] == 22
+    assert x[2].name.startswith('CP001071.1')
+    
+
 def test_disk_revindex_union_found():
     # test union_found on db that contains 63 and 2, but not 47
     sig47 = utils.get_test_data("47.fa.sig")


### PR DESCRIPTION
This allows Python code to emulate the behavior of `sourmash scripts manysearch` on a RocksDB without full signatures - you can now just get the overlap in hashes & the name of the match without trying to load the signature.
