### PR TITLE
ci: github actions improvements

### DIFF
--- a/.github/workflows/asv.yml
+++ b/.github/workflows/asv.yml
@@ -1,5 +1,8 @@
 name: asv benchmarks
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [latest]

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -1,5 +1,6 @@
 name: cibuildwheel
-permissions: write-all
+permissions:
+  contents: write
 
 on:
   push:

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -61,6 +61,7 @@ jobs:
 
   build_wasm:
     runs-on: ubuntu-latest
+    if: false  # disable for now, need to fix emsdk with Rust: https://github.com/emscripten-core/emscripten/pull/24359
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -61,7 +61,6 @@ jobs:
 
   build_wasm:
     runs-on: ubuntu-latest
-    if: false  # disable for now, need to fix emsdk with Rust: https://github.com/emscripten-core/emscripten/pull/24359
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/build_wheel_all_archs.yml
+++ b/.github/workflows/build_wheel_all_archs.yml
@@ -1,5 +1,6 @@
 name: maturin wheels
-permissions: write-all
+permissions:
+  contents: write
 
 on:
   pull_request:        # use for testing modifications to this action

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -10,7 +10,8 @@ on:
       - "latest"
   # Run on pull requests
   pull_request:
-  merge_group:
+  # TODO: Disabled temporarily for https://github.com/CodSpeedHQ/runner/issues/55
+  # merge_group:
   # `workflow_dispatch` allows CodSpeed to trigger backtest
   # performance analysis in order to generate initial data.
   workflow_dispatch:

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -1,5 +1,8 @@
 name: codspeed-benchmarks
 
+permissions:
+  contents: read
+
 on:
   # Run on pushes to the main branch
   push:

--- a/.github/workflows/dev_envs.yml
+++ b/.github/workflows/dev_envs.yml
@@ -8,6 +8,9 @@ concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/latest' }}
 
+permissions:
+  contents: read
+
 env:
   PIXI_VERSION: "v0.66.0"
 

--- a/.github/workflows/draft-pdf.yml
+++ b/.github/workflows/draft-pdf.yml
@@ -1,5 +1,8 @@
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   paper:
     runs-on: ubuntu-latest

--- a/.github/workflows/hypothesis.yml
+++ b/.github/workflows/hypothesis.yml
@@ -1,5 +1,8 @@
 name: Hypothesis tests
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [latest]

--- a/.github/workflows/metadata.yml
+++ b/.github/workflows/metadata.yml
@@ -1,5 +1,8 @@
 name: Metadata checks 
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [latest]

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -9,6 +9,9 @@ on:
   schedule:
     - cron: "0 0 * * *" # daily
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,8 +11,7 @@ on:
     - cron: "0 0 * * *" # daily
 
 permissions:
-  contents: write
-  id-token: write
+  contents: read
 
 env:
   PIXI_VERSION: "v0.66.0"
@@ -24,6 +23,8 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: set up pixi
         uses: prefix-dev/setup-pixi@v0.9.4
@@ -64,6 +65,8 @@ jobs:
             continue: false
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - uses: dtolnay/rust-toolchain@master
         with:
@@ -81,6 +84,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: set up pixi
         uses: prefix-dev/setup-pixi@v0.9.4
@@ -99,6 +104,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: set up pixi
         uses: prefix-dev/setup-pixi@v0.9.4
@@ -134,6 +141,8 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
@@ -156,6 +165,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: set up pixi
         uses: prefix-dev/setup-pixi@v0.9.4
@@ -187,9 +198,13 @@ jobs:
   publish:
     name: Publish (on tags, dry-run otherwise)
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - name: Checkout sources
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: set up pixi
         uses: prefix-dev/setup-pixi@v0.9.4
@@ -220,6 +235,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: set up pixi
         uses: prefix-dev/setup-pixi@v0.9.4
@@ -241,6 +258,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: set up pixi
         uses: prefix-dev/setup-pixi@v0.9.4

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,6 +10,10 @@ on:
   schedule:
     - cron: "0 0 * * *" # daily
 
+permissions:
+  contents: write
+  id-token: write
+
 env:
   PIXI_VERSION: "v0.66.0"
 
@@ -175,8 +179,6 @@ jobs:
       - name: Publish to NPM
         if: startsWith(github.ref, 'refs/tags/r')
         run: pixi run -e wasm publish-npm
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,8 +39,6 @@ jobs:
           frozen: true
 
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-        with:
-          lookup-only: true
 
       - name: Run cargo check
         run: |
@@ -83,8 +81,6 @@ jobs:
           frozen: true
 
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-        with:
-          lookup-only: true
 
       - name: Run tests
         run: |
@@ -106,8 +102,6 @@ jobs:
           frozen: true
 
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-        with:
-          lookup-only: true
 
       - name: Run tests for all feature combinations
         run: pixi run check-features
@@ -126,9 +120,8 @@ jobs:
           cache: true
           cache-write: ${{ github.event_name == 'push' && github.ref_name == 'latest' }}
           frozen: true
+
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-        with:
-          lookup-only: true
 
       - name: Collect coverage data
         run: pixi run coverage-rust
@@ -167,8 +160,6 @@ jobs:
           frozen: true
 
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-        with:
-          lookup-only: true
 
       - name: Run cargo fmt
         run: |
@@ -195,9 +186,8 @@ jobs:
           cache: true
           cache-write: ${{ github.event_name == 'push' && github.ref_name == 'latest' }}
           frozen: true
+
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-        with:
-          lookup-only: true
 
       - name: run wasm tests
         continue-on-error: true  ## TODO: remove this when tests works again...
@@ -237,8 +227,6 @@ jobs:
           frozen: true
 
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-        with:
-          lookup-only: true
 
       - name: Check semver
         run: pixi run semver-check
@@ -265,9 +253,8 @@ jobs:
           cache: true
           cache-write: ${{ github.event_name == 'push' && github.ref_name == 'latest' }}
           frozen: true
+
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-        with:
-          lookup-only: true
 
       - name: check if README matches MSRV defined here
         run: grep '1.85.0' src/core/README.md
@@ -290,9 +277,8 @@ jobs:
           cache: true
           cache-write: ${{ github.event_name == 'push' && github.ref_name == 'latest' }}
           frozen: true
+
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-        with:
-          lookup-only: true
 
       - run: pixi run cbindgen-generate
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -70,19 +70,21 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@master
+      - name: set up pixi
+        uses: prefix-dev/setup-pixi@v0.9.4
         with:
-          toolchain: ${{ matrix.rust }}
+          pixi-version: ${{ env.PIXI_VERSION }}
+          cache: true
+          cache-write: ${{ github.event_name == 'push' && github.ref_name == 'latest' }}
+          frozen: true
 
       - uses: Swatinem/rust-cache@v2
         with:
           lookup-only: true
 
-      - uses: taiki-e/install-action@nextest
-
       - name: Run tests
         run: |
-          cargo nextest run
+          pixi run cargo nextest run
 
   test_all_features:
     runs-on: ubuntu-latest
@@ -152,11 +154,13 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@master
+      - name: set up pixi
+        uses: prefix-dev/setup-pixi@v0.9.4
         with:
-          toolchain: ${{ matrix.rust }}
-          components: "clippy, rustfmt"
+          pixi-version: ${{ env.PIXI_VERSION }}
+          cache: true
+          cache-write: ${{ github.event_name == 'push' && github.ref_name == 'latest' }}
+          frozen: true
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -164,11 +168,11 @@ jobs:
 
       - name: Run cargo fmt
         run: |
-          cargo fmt --all -- --check
+          pixi run cargo fmt --all -- --check
 
       - name: Run cargo clippy
         run: |
-          cargo clippy --all -- -D warnings
+          pixi run cargo clippy --all -- -D warnings
 
   wasm-pack:
     name: Check if wasm-pack builds a valid package for the sourmash crate
@@ -227,6 +231,7 @@ jobs:
           cache: true
           cache-write: ${{ github.event_name == 'push' && github.ref_name == 'latest' }}
           frozen: true
+
       - uses: Swatinem/rust-cache@v2
         with:
           lookup-only: true

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -84,7 +84,7 @@ jobs:
 
       - name: Run tests
         run: |
-          pixi run cargo nextest run
+          pixi run rust-tests
 
   test_all_features:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,6 +35,8 @@ jobs:
           frozen: true
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          lookup-only: true
 
       - name: Run cargo check
         run: |
@@ -73,6 +75,8 @@ jobs:
           toolchain: ${{ matrix.rust }}
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          lookup-only: true
 
       - uses: taiki-e/install-action@nextest
 
@@ -96,6 +100,8 @@ jobs:
           frozen: true
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          lookup-only: true
 
       - name: Run tests for all feature combinations
         run: pixi run check-features
@@ -115,6 +121,8 @@ jobs:
           cache-write: ${{ github.event_name == 'push' && github.ref_name == 'latest' }}
           frozen: true
       - uses: Swatinem/rust-cache@v2
+        with:
+          lookup-only: true
 
       - name: Collect coverage data
         run: pixi run coverage-rust
@@ -151,6 +159,8 @@ jobs:
           components: "clippy, rustfmt"
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          lookup-only: true
 
       - name: Run cargo fmt
         run: |
@@ -176,6 +186,8 @@ jobs:
           cache-write: ${{ github.event_name == 'push' && github.ref_name == 'latest' }}
           frozen: true
       - uses: Swatinem/rust-cache@v2
+        with:
+          lookup-only: true
 
       - name: run wasm tests
         continue-on-error: true  ## TODO: remove this when tests works again...
@@ -214,6 +226,8 @@ jobs:
           cache-write: ${{ github.event_name == 'push' && github.ref_name == 'latest' }}
           frozen: true
       - uses: Swatinem/rust-cache@v2
+        with:
+          lookup-only: true
 
       - name: Check semver
         run: pixi run semver-check
@@ -246,6 +260,8 @@ jobs:
           cache-write: ${{ github.event_name == 'push' && github.ref_name == 'latest' }}
           frozen: true
       - uses: Swatinem/rust-cache@v2
+        with:
+          lookup-only: true
 
       - name: check if README matches MSRV defined here
         run: grep '1.85.0' src/core/README.md
@@ -269,6 +285,8 @@ jobs:
           cache-write: ${{ github.event_name == 'push' && github.ref_name == 'latest' }}
           frozen: true
       - uses: Swatinem/rust-cache@v2
+        with:
+          lookup-only: true
 
       - run: pixi run cbindgen-generate
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -83,8 +83,16 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Run tests
+        if: matrix.os != 'windows-latest'
         run: |
-          pixi run rust-tests -j${{ case(matrix.os == 'windows-latest', 1, 4) }}
+          pixi run rust-tests
+
+      - name: Run tests (windows)
+        if: matrix.os == 'windows-latest'
+        run: |
+          # branchwater feature triggers a rocksdb error on windows,
+          # need to debug. For now using just default features
+          pixi run cargo nextest run
 
   test_all_features:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,19 +22,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: set up pixi
-        uses: prefix-dev/setup-pixi@v0.9.4
+        uses: prefix-dev/setup-pixi@1b2de7f3351f171c8b4dfeb558c639cb58ed4ec0 # v0.9.5
         with:
           pixi-version: ${{ env.PIXI_VERSION }}
           cache: true
           cache-write: ${{ github.event_name == 'push' && github.ref_name == 'latest' }}
           frozen: true
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           lookup-only: true
 
@@ -66,19 +66,19 @@ jobs:
             rust: stable
             continue: false
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: set up pixi
-        uses: prefix-dev/setup-pixi@v0.9.4
+        uses: prefix-dev/setup-pixi@1b2de7f3351f171c8b4dfeb558c639cb58ed4ec0 # v0.9.5
         with:
           pixi-version: ${{ env.PIXI_VERSION }}
           cache: true
           cache-write: ${{ github.event_name == 'push' && github.ref_name == 'latest' }}
           frozen: true
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           lookup-only: true
 
@@ -89,19 +89,19 @@ jobs:
   test_all_features:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: set up pixi
-        uses: prefix-dev/setup-pixi@v0.9.4
+        uses: prefix-dev/setup-pixi@1b2de7f3351f171c8b4dfeb558c639cb58ed4ec0 # v0.9.5
         with:
           pixi-version: ${{ env.PIXI_VERSION }}
           cache: true
           cache-write: ${{ github.event_name == 'push' && github.ref_name == 'latest' }}
           frozen: true
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           lookup-only: true
 
@@ -111,18 +111,18 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: set up pixi
-        uses: prefix-dev/setup-pixi@v0.9.4
+        uses: prefix-dev/setup-pixi@1b2de7f3351f171c8b4dfeb558c639cb58ed4ec0 # v0.9.5
         with:
           pixi-version: ${{ env.PIXI_VERSION }}
           cache: true
           cache-write: ${{ github.event_name == 'push' && github.ref_name == 'latest' }}
           frozen: true
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           lookup-only: true
 
@@ -130,7 +130,7 @@ jobs:
         run: pixi run coverage-rust
 
       - name: Upload Rust coverage to codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           flags: rust
           fail_ci_if_error: true
@@ -150,19 +150,19 @@ jobs:
             rust: stable
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: set up pixi
-        uses: prefix-dev/setup-pixi@v0.9.4
+        uses: prefix-dev/setup-pixi@1b2de7f3351f171c8b4dfeb558c639cb58ed4ec0 # v0.9.5
         with:
           pixi-version: ${{ env.PIXI_VERSION }}
           cache: true
           cache-write: ${{ github.event_name == 'push' && github.ref_name == 'latest' }}
           frozen: true
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           lookup-only: true
 
@@ -180,18 +180,18 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: set up pixi
-        uses: prefix-dev/setup-pixi@v0.9.4
+        uses: prefix-dev/setup-pixi@1b2de7f3351f171c8b4dfeb558c639cb58ed4ec0 # v0.9.5
         with:
           pixi-version: ${{ env.PIXI_VERSION }}
           cache: true
           cache-write: ${{ github.event_name == 'push' && github.ref_name == 'latest' }}
           frozen: true
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           lookup-only: true
 
@@ -209,7 +209,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/r')
         run: pixi run -e wasm publish-npm
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           path: 'pkg/sourmash*.tgz'
 
@@ -220,19 +220,19 @@ jobs:
       id-token: write
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: set up pixi
-        uses: prefix-dev/setup-pixi@v0.9.4
+        uses: prefix-dev/setup-pixi@1b2de7f3351f171c8b4dfeb558c639cb58ed4ec0 # v0.9.5
         with:
           pixi-version: ${{ env.PIXI_VERSION }}
           cache: true
           cache-write: ${{ github.event_name == 'push' && github.ref_name == 'latest' }}
           frozen: true
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           lookup-only: true
 
@@ -250,18 +250,18 @@ jobs:
   minimum_rust_version:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: set up pixi
-        uses: prefix-dev/setup-pixi@v0.9.4
+        uses: prefix-dev/setup-pixi@1b2de7f3351f171c8b4dfeb558c639cb58ed4ec0 # v0.9.5
         with:
           pixi-version: ${{ env.PIXI_VERSION }}
           cache: true
           cache-write: ${{ github.event_name == 'push' && github.ref_name == 'latest' }}
           frozen: true
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           lookup-only: true
 
@@ -275,18 +275,18 @@ jobs:
     name: "Check if cbindgen runs cleanly for generating the C headers"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: set up pixi
-        uses: prefix-dev/setup-pixi@v0.9.4
+        uses: prefix-dev/setup-pixi@1b2de7f3351f171c8b4dfeb558c639cb58ed4ec0 # v0.9.5
         with:
           pixi-version: ${{ env.PIXI_VERSION }}
           cache: true
           cache-write: ${{ github.event_name == 'push' && github.ref_name == 'latest' }}
           frozen: true
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           lookup-only: true
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,6 +13,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   PIXI_VERSION: "v0.66.0"
 
@@ -178,7 +182,7 @@ jobs:
     name: Check if wasm-pack builds a valid package for the sourmash crate
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
+      id-token: write  # needed to publish to NPM
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -217,7 +221,7 @@ jobs:
     name: Publish (on tags, dry-run otherwise)
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
+      id-token: write  # needed to publish to crates.io
     steps:
       - name: Checkout sources
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -173,6 +173,8 @@ jobs:
   wasm-pack:
     name: Check if wasm-pack builds a valid package for the sourmash crate
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v6
         with:
@@ -234,11 +236,6 @@ jobs:
 
       - name: Make sure we can publish the sourmash crate
         run: pixi run cargo publish --dry-run --manifest-path src/core/Cargo.toml
-
-      # Login to crates.io on tags
-      - name: login to crates.io
-        if: startsWith(github.ref, 'refs/tags/r')
-        run: pixi run cargo login ${{ secrets.CRATES_IO_TOKEN }}
 
       # Publish to crates.io on tags
       - name: Publish to crates.io

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -84,7 +84,7 @@ jobs:
 
       - name: Run tests
         run: |
-          pixi run rust-tests -j2
+          pixi run rust-tests -j${{ case(matrix.os == 'windows-latest', 1, 4) }}
 
   test_all_features:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -84,7 +84,7 @@ jobs:
 
       - name: Run tests
         run: |
-          pixi run rust-tests
+          pixi run rust-tests -j2
 
   test_all_features:
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -409,3 +409,7 @@ macos = "11.0"
 [tool.pixi.activation.env]
 CARGO_HOME = "$CONDA_PREFIX/.cargo_cache"
 PATH = "$PATH:$CARGO_HOME/bin"
+
+[tool.pixi.target.win-64.activation.env]
+CARGO_HOME = "%CONDA_PREFIX%/.cargo_cache"
+PATH = "%PATH%:%CARGO_HOME%/bin"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -366,6 +366,9 @@ depends-on = "install-tools"
 [tool.pixi.feature.dev.tasks.coverage-rust]
 cmd = "cargo llvm-cov nextest --all-features --lcov --output-path lcov.info"
 
+[tool.pixi.feature.dev.tasks.rust-tests]
+cmd = "cargo nextest run --all-features"
+
 [tool.pixi.feature.dev.tasks.develop]
 cmd = "maturin develop --uv"
 


### PR DESCRIPTION
- NPM publish uses [trusted publishers](https://docs.npmjs.com/trusted-publishers)
- limit permissions in workflows