### PR TITLE
ci: prepare for merge queue

### DIFF
--- a/.github/workflows/asv.yml
+++ b/.github/workflows/asv.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [latest]
   pull_request:
+  merge_queue:
   schedule:
     - cron: "0 0 * * *" # daily
 

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -6,6 +6,7 @@ on:
     branches: [latest]
     tags: v*
   pull_request:
+  merge_queue:
   schedule:
     - cron: "0 0 * * *" # daily
 

--- a/.github/workflows/build_wheel_all_archs.yml
+++ b/.github/workflows/build_wheel_all_archs.yml
@@ -3,6 +3,7 @@ permissions: write-all
 
 on:
   pull_request:        # use for testing modifications to this action
+  merge_queue:
   push:
     branches: [latest]
     tags: v*

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -7,6 +7,7 @@ on:
       - "latest"
   # Run on pull requests
   pull_request:
+  merge_queue:
   # `workflow_dispatch` allows CodSpeed to trigger backtest
   # performance analysis in order to generate initial data.
   workflow_dispatch:

--- a/.github/workflows/dev_envs.yml
+++ b/.github/workflows/dev_envs.yml
@@ -1,6 +1,7 @@
 name: "Dev env instructions"
 on:
   pull_request:
+  merge_queue:
   push:
     branches: [latest]
 concurrency:

--- a/.github/workflows/hypothesis.yml
+++ b/.github/workflows/hypothesis.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [latest]
   pull_request:
+  merge_queue:
   schedule:
     - cron: "0 0 * * *" # daily
 

--- a/.github/workflows/metadata.yml
+++ b/.github/workflows/metadata.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [latest]
   pull_request:
+  merge_queue:
   schedule:
     - cron: "0 0 * * *" # daily
 

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches: [latest]
   pull_request:
+  merge_queue:
   schedule:
     - cron: "0 0 * * *" # daily
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,6 +6,7 @@ on:
     tags:
       - 'r*'
   pull_request:
+  merge_queue:
   schedule:
     - cron: "0 0 * * *" # daily
 


### PR DESCRIPTION
Prepare for merge queues:
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions