### PR TITLE
feat(tests): enable --doctest-modules in pytest configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -264,7 +264,7 @@ LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/opt/rh/gcc-toolset-14/root/usr/lib64"
 C_INCLUDE_PATH="/opt/rh/gcc-toolset-14/root/usr/lib/gcc/x86_64-redhat-linux/14/include/:/opt/rh/gcc-toolset-14/root/usr/lib/gcc/aarch64-redhat-linux/14/include/"
 
 [tool.pytest.ini_options]
-addopts = "--doctest-glob='doc/*.md' -n4"
+addopts = "--doctest-glob='doc/*.md' --doctest-modules -n4"
 norecursedirs = [
   "utils",
   "build",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -276,6 +276,7 @@ norecursedirs = [
 testpaths = [
   "tests",
   "doc",
+  "src/sourmash",
 ]
 
 [tool.coverage]


### PR DESCRIPTION
## Summary

Enable automatic doctest discovery for Python source modules by adding `--doctest-modules` to pytest and `src/sourmash` to `testpaths`.

## Changes

**`pyproject.toml`:**
- Add `--doctest-modules` to `[tool.pytest.ini_options] addopts`
- Add `"src/sourmash"` to `testpaths` so pytest collects doctests from source files

## Why

Issue #897 noted that doctests in source files (e.g., `sourmash/minhash.py`, `sourmash/lca/lca_utils.py`) were never executed in CI. The existing config only tested `doc/*.md` doctests via `--doctest-glob`. Adding `--doctest-modules` with `src/sourmash` in `testpaths` ensures source-level doctests are collected and run alongside unit tests.

## Notes

- The `-n4` parallel flag is compatible with `--doctest-modules` (xdist handles collection correctly)
- Source doctests that import `sourmash` require the compiled Rust extension, which is available in CI but not in bare Python environments

Closes #897