### PR TITLE
fix: do not display None in LCA_Database repr

### DIFF
--- a/src/sourmash/lca/lca_db.py
+++ b/src/sourmash/lca/lca_db.py
@@ -205,6 +205,8 @@ class LCA_Database(Index):
         return len(minhash)
 
     def __repr__(self):
+        if self.filename is None:
+            return "LCA_Database()"
         return f"LCA_Database('{self.filename}')"
 
     def signatures(self):

--- a/tests/test_lca.py
+++ b/tests/test_lca.py
@@ -527,6 +527,13 @@ def test_db_repr():
     assert repr(db) == f"LCA_Database('{filename}')"
 
 
+def test_db_repr_no_filename():
+    # An LCA_Database constructed in memory has no filename; the repr should
+    # not display "None" (see #3923).
+    db = sourmash.lca.LCA_Database(ksize=31, scaled=1000)
+    assert repr(db) == "LCA_Database()"
+
+
 def test_lca_index_signatures_method():
     # test 'signatures' method from base class Index
     filename = utils.get_test_data("lca/47+63.lca.json")


### PR DESCRIPTION
When `LCA_Database` is created without loading from a file, `self.filename` is `None`, causing `repr()` to show `LCA_Database('None')` instead of something sensible.

**Before:** `LCA_Database('None')`
**After:** `LCA_Database()`

One-line change in `src/sourmash/lca/lca_db.py`.

Closes #1193