### PR TITLE
Update HPTABLE with correct Gly and Cys mappings

### DIFF
--- a/src/core/src/encodings.rs
+++ b/src/core/src/encodings.rs
@@ -289,28 +289,30 @@ static DAYHOFFTABLE: Lazy<HashMap<u8, u8>> = Lazy::new(|| {
 // | N, C, S, T, D, E, R, H, K, Q          | p       |
 static HPTABLE: Lazy<HashMap<u8, u8>> = Lazy::new(|| {
     [
-        // h
-        (b'A', b'h'),
-        (b'F', b'h'),
-        (b'G', b'h'),
-        (b'I', b'h'),
-        (b'L', b'h'),
-        (b'M', b'h'),
-        (b'P', b'h'),
-        (b'V', b'h'),
-        (b'W', b'h'),
-        (b'Y', b'h'),
-        // p
-        (b'N', b'p'),
-        (b'C', b'p'),
-        (b'S', b'p'),
-        (b'T', b'p'),
-        (b'D', b'p'),
-        (b'E', b'p'),
-        (b'R', b'p'),
-        (b'H', b'p'),
-        (b'K', b'p'),
-        (b'Q', b'p'),
+        // Hydrophobic (h) per PBotC Fig 8.30
+        (b'A', b'h'), // Ala
+        (b'V', b'h'), // Val
+        (b'I', b'h'), // Ile
+        (b'P', b'h'), // Pro
+        (b'L', b'h'), // Leu
+        (b'M', b'h'), // Met
+        (b'F', b'h'), // Phe
+        (b'W', b'h'), // Trp
+        (b'C', b'h'), // Cys
+        (b'Y', b'h'), // Tyr
+        
+        // Polar (p) per PBotC Fig 8.30
+        (b'G', b'p'), // Gly
+        (b'N', b'p'), // Asn
+        (b'S', b'p'), // Ser
+        (b'T', b'p'), // Thr
+        (b'E', b'p'), // Glu
+        (b'H', b'p'), // His
+        (b'R', b'p'), // Arg
+        (b'Q', b'p'), // Gln
+        (b'D', b'p'), // Asp
+        (b'K', b'p'), // Lys
+        
         // stop aa
         (b'*', b'*'),
     ]


### PR DESCRIPTION
I'm embarrassed to say that this table has a mistake. It cites [Physical Biology of the Cell](https://boulderschool.yale.edu/sites/default/files/files/PBoC_Boulder07v2.pdf), but the encoding does not match Figure 8.30 where the HP encoding is defined:

<img width="1485" height="1030" alt="CleanShot 2026-04-21 at 07 13 26" src="https://github.com/user-attachments/assets/7ceda197-d82f-4075-b880-c75068aad76f" />

Cys and Tyr are in parentheses as they are controversial. Sometimes they classified as polar, and other times as hydrophobic.

Changes:
- Gly (G) from hydrophobic to polar
- Cys (C) from polar to hydrophobic


Tyr (Y) stays as hydrophobic.

Apologies for the confusion! 

(Started on GitHub website, will fix tests locally)