### PR TITLE
Feat: Re-enable `repair` and return errors more widely

### DIFF
--- a/.github/workflows/hypothesis.yml
+++ b/.github/workflows/hypothesis.yml
@@ -33,7 +33,7 @@ jobs:
         run: tox -e hypothesis,coverage
 
       - name: Upload Python coverage to codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         with:
           flags: hypothesis-py
           fail_ci_if_error: true

--- a/.github/workflows/hypothesis.yml
+++ b/.github/workflows/hypothesis.yml
@@ -38,3 +38,4 @@ jobs:
           flags: hypothesis-py
           fail_ci_if_error: true
           files: .tox/coverage.xml
+          use_pypi: true

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -87,3 +87,4 @@ jobs:
           flags: python
           fail_ci_if_error: true
           files: .tox/coverage.xml
+          use_pypi: true

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -82,7 +82,7 @@ jobs:
           PYTHONDEVMODE: 1
 
       - name: Upload Python coverage to codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         with:
           flags: python
           fail_ci_if_error: true

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -135,7 +135,7 @@ jobs:
         run: pixi run coverage-rust
 
       - name: Upload Rust coverage to codecov
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         with:
           flags: rust
           fail_ci_if_error: true

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -140,6 +140,7 @@ jobs:
           flags: rust
           fail_ci_if_error: true
           files: lcov.info
+          use_pypi: true
 
   lints:
     name: Lints

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1818,7 +1818,7 @@ checksum = "bceb57dc07c92cdae60f5b27b3fa92ecaaa42fe36c55e22dbfb0b44893e0b1f7"
 
 [[package]]
 name = "sourmash"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "az",
  "byteorder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -536,6 +536,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+ "rayon",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -694,6 +709,12 @@ dependencies = [
  "crunchy",
  "zerocopy",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -918,6 +939,15 @@ name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -1147,9 +1177,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "oorandom"
@@ -1189,6 +1219,19 @@ checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
 ]
 
 [[package]]
@@ -1512,6 +1555,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1661,6 +1713,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1771,6 +1829,7 @@ dependencies = [
  "counter",
  "criterion",
  "csv",
+ "dashmap",
  "enum_dispatch",
  "fixedbitset",
  "getrandom 0.2.17",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -413,6 +413,7 @@ CARGO_HOME = "$CONDA_PREFIX/.cargo_cache"
 PATH = "$PATH:$CARGO_HOME/bin"
 ROCKSDB_INCLUDE_DIR = "$CONDA_PREFIX/include"
 ROCKSDB_LIB_DIR = "${CONDA_PREFIX}/lib"
+DYLD_LIBRARY_PATH= "${CONDA_PREFIX}/lib"
 
 [tool.pixi.target.win-64.activation.env]
 CARGO_HOME = "%CONDA_PREFIX%/.cargo_cache"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -408,12 +408,17 @@ wasm = { features = ["dev", "build", "wasm"], solve-group = "default", no-defaul
 [tool.pixi.system-requirements]
 macos = "11.0"
 
+[tool.pixi.target.linux-64.activation.env]
+ROCKSDB_INCLUDE_DIR = "$CONDA_PREFIX/include"
+ROCKSDB_LIB_DIR = "${CONDA_PREFIX}/lib"
+
+[tool.pixi.target.linux-aarch64.activation.env]
+ROCKSDB_INCLUDE_DIR = "$CONDA_PREFIX/include"
+ROCKSDB_LIB_DIR = "${CONDA_PREFIX}/lib"
+
 [tool.pixi.activation.env]
 CARGO_HOME = "$CONDA_PREFIX/.cargo_cache"
 PATH = "$PATH:$CARGO_HOME/bin"
-ROCKSDB_INCLUDE_DIR = "$CONDA_PREFIX/include"
-ROCKSDB_LIB_DIR = "${CONDA_PREFIX}/lib"
-DYLD_LIBRARY_PATH= "${CONDA_PREFIX}/lib"
 
 [tool.pixi.target.win-64.activation.env]
 CARGO_HOME = "%CONDA_PREFIX%/.cargo_cache"

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -32,6 +32,7 @@ camino = { version = "1.2.2", features = ["serde1"] }
 cfg-if = "1.0"
 counter = "0.6.0"
 csv = "1.4.0"
+dashmap = { version = "6.2.1", features = ["rayon"] }
 enum_dispatch = "0.3.13"
 fixedbitset = "0.4.0"
 getset = "0.1.6"

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sourmash"
-version = "0.22.0"
+version = "0.23.0"
 authors = ["Luiz Irber <luiz@sourmash.bio>", "N. Tessa Pierce-Ward <tessa@sourmash.bio>", "C. Titus Brown <titus@idyll.org>"]
 description = "tools for comparing biological sequences with k-mer sketches"
 repository = "https://github.com/sourmash-bio/sourmash"

--- a/src/core/src/ffi/index/revindex.rs
+++ b/src/core/src/ffi/index/revindex.rs
@@ -295,7 +295,7 @@ unsafe fn revindex_prefetch(
     let dataset_picklist = retrieve_picklist(dataset_picklist_ptr);
 
     // do search & get matches
-    let counter = revindex.counter_for_query(&query_mh, dataset_picklist);
+    let counter = revindex.counter_for_query(&query_mh, dataset_picklist)?;
 
     // right now this iterates over all matches from 'counter.most_common()'.
     // we could probably truncate the search here in some way, yes?
@@ -400,7 +400,7 @@ unsafe fn revindex_best_containment(
     let dataset_picklist = retrieve_picklist(dataset_picklist_ptr);
 
     // do search & get first/best match
-    let counter = revindex.counter_for_query(query_mh, dataset_picklist);
+    let counter = revindex.counter_for_query(query_mh, dataset_picklist)?;
     if !counter.is_empty() {
         let (dataset_id, size) = counter.k_most_common_ordered(1)[0];
 
@@ -439,7 +439,7 @@ unsafe fn revindex_prefetch_to_countergather(
     let dataset_picklist = retrieve_picklist(dataset_picklist_ptr);
 
     // do search & get matches
-    let counter = revindex.prepare_gather_counters(&query_mh, dataset_picklist);
+    let counter = revindex.prepare_gather_counters(&query_mh, dataset_picklist)?;
 
     Ok(SourmashRevIndex_CounterGather::from_rust(counter))
 }

--- a/src/core/src/index/revindex/disk_revindex.rs
+++ b/src/core/src/index/revindex/disk_revindex.rs
@@ -384,7 +384,7 @@ impl RevIndexOps for DiskRevIndex {
         &self,
         query: &KmerMinHash,
         picklist: Option<DatasetPicklist>,
-    ) -> SigCounter {
+    ) -> Result<SigCounter> {
         info!("Collecting hashes");
         let cf_hashes = self.db.cf_handle(HASHES).unwrap();
         let hashes_iter = query.iter_mins().map(|hash| {
@@ -396,12 +396,13 @@ impl RevIndexOps for DiskRevIndex {
         });
 
         info!("Multi get");
-        self.db
+        Ok(self
+            .db
             .multi_get_cf(hashes_iter)
             .into_iter()
             .filter_map(|r| r.ok().unwrap_or(None))
-            .flat_map(|raw_datasets| {
-                let new_vals = Datasets::from_slice(&raw_datasets).unwrap();
+            .map(|raw_datasets| {
+                let new_vals = Datasets::from_slice(&raw_datasets)?;
 
                 // filter against picklist if need be.
                 if let Some(pl) = &picklist {
@@ -409,19 +410,22 @@ impl RevIndexOps for DiskRevIndex {
                         .into_iter()
                         .filter(|&i| pl.dataset_ids.contains(&i))
                         .collect();
-                    Box::new(new_vals.into_iter())
+                    Ok(new_vals.into_iter().collect::<Vec<u32>>())
                 } else {
-                    new_vals.into_iter()
+                    Ok(new_vals.into_iter().collect::<Vec<u32>>())
                 }
             })
-            .collect()
+            .collect::<Result<Vec<_>>>()?
+            .into_iter()
+            .flatten()
+            .collect())
     }
 
     fn prepare_gather_counters(
         &self,
         query: &KmerMinHash,
         picklist: Option<DatasetPicklist>,
-    ) -> CounterGather {
+    ) -> Result<CounterGather> {
         let cf_hashes = self.db.cf_handle(HASHES).unwrap();
         let hashes_iter = query.iter_mins().map(|hash| {
             let mut v = vec![0_u8; 8];
@@ -474,11 +478,11 @@ impl RevIndexOps for DiskRevIndex {
             })
             .collect();
 
-        CounterGather {
+        Ok(CounterGather {
             counter,
             query_colors,
             hash_to_color,
-        }
+        })
     }
 
     fn gather(
@@ -730,7 +734,7 @@ impl RevIndexOps for DiskRevIndex {
         picklist: Option<DatasetPicklist>,
     ) -> Result<Vec<(f64, Signature, String)>> {
         // do search
-        let counter = self.counter_for_query(query_mh, picklist);
+        let counter = self.counter_for_query(query_mh, picklist)?;
 
         // retrieve/convert matches. I don't think there's a simple way to
         // truncate this without going through all the matches, so it's

--- a/src/core/src/index/revindex/disk_revindex.rs
+++ b/src/core/src/index/revindex/disk_revindex.rs
@@ -10,12 +10,13 @@ use log::{info, trace};
 use rayon::prelude::*;
 use rocksdb::MergeOperands;
 
+use crate::HashIntoType;
 use crate::Result;
 use crate::collection::{Collection, CollectionSet};
 use crate::encodings::{Color, Idx};
 use crate::index::revindex::{
-    self as module, CounterGather, DatasetPicklist, Datasets, DbStats, QueryColors, RevIndexOps,
-    stats_for_cf,
+    self as module, CounterGather, DatasetPicklist, Datasets, DbStats, QueryColors, RevIndex,
+    RevIndexOps, stats_for_cf,
 };
 use crate::index::{GatherResult, SigCounter, calculate_gather_stats};
 use crate::manifest::Manifest;
@@ -65,14 +66,6 @@ pub(crate) fn merge_datasets(
     // TODO: optimization! if nothing changed, skip as_bytes()
     datasets.as_bytes()
 }
-
-/* TODO: need the repair_cf variant, not available in rocksdb-rust yet
-pub fn repair(path: &Path) {
-    let opts = db_options();
-
-    DB::repair(&opts, path).unwrap()
-}
-*/
 
 impl DiskRevIndex {
     pub fn create(path: &Path, collection: CollectionSet) -> Result<module::RevIndex> {
@@ -184,6 +177,86 @@ impl DiskRevIndex {
         self.db.clone()
     }
 
+    pub fn repair<P: AsRef<Path>>(path: P, storage_spec: Option<&str>) -> Result<()> {
+        /* TODO: need the repair_cf variant, not available in rocksdb-rust yet
+            let opts = db_options();
+
+            DB::repair_cf(&opts, path).unwrap()
+        */
+
+        let db = Self::open(path.as_ref(), false, storage_spec)?;
+        if let RevIndex::Disk(db) = db {
+            // iterate over all sigs to reconstruct values for each failing hash
+
+            // try to parse all values, in case any error is found
+            // record what is the key (hash)
+            info!("Iterating over DB to collect failing hashes");
+            let stats = stats_for_cf(db.db.clone(), HASHES, true, false);
+
+            // pre-allocate a {hash, datasets} map to populate later
+            let failed_hashes = dashmap::DashMap::<HashIntoType, Datasets>::from_iter(
+                stats
+                    .failed_keys
+                    .into_iter()
+                    .map(|h| (h, Datasets::new(&[]))),
+            );
+
+            if failed_hashes.is_empty() {
+                info!("No failed hashes found, finishing");
+                return Ok(())
+            }
+
+            info!("{} failed hashes to process", failed_hashes.len());
+
+            // iterate over all sigs to reconstruct values for each failing hash
+            info!("Iterating over all sigs to reconstruct dataset lists");
+
+            let processed_sigs = AtomicUsize::new(0);
+
+            db.collection().par_iter().for_each(|(dataset_id, _)| {
+                let all_hashes = db.load_hashes(dataset_id);
+                all_hashes.for_each(|hash| {
+                    failed_hashes
+                        .entry(hash)
+                        .and_modify(|v| v.union(Datasets::new(&[dataset_id])));
+                });
+
+                let i = processed_sigs.fetch_add(1, Ordering::SeqCst);
+                if i % 1000 == 0 {
+                    info!("Processed {} reference sigs", i);
+                }
+            });
+
+            let cf_hashes = db.db.cf_handle(HASHES).unwrap();
+
+            // iterate over failed hashes and update values in the DB
+            info!("Updating values in DB for {} failed hashes", failed_hashes.len());
+
+            let processed_hashes = AtomicUsize::new(0);
+
+            failed_hashes.into_par_iter().for_each(|(hash, value)| {
+                let mut hash_bytes = [0u8; 8];
+                (&mut hash_bytes[..])
+                    .write_u64::<LittleEndian>(hash)
+                    .expect("error writing bytes");
+                db.db
+                    .put_cf(&cf_hashes, &hash_bytes[..], value.as_bytes().unwrap())
+                    .expect("error putting new value");
+
+                let i = processed_hashes.fetch_add(1, Ordering::SeqCst);
+                if i % 1000 == 0 {
+                    info!("Processed {} failed hashes", i);
+                }
+            });
+
+            info!("Triggering compaction");
+            db.compact();
+            db.flush()?;
+        }
+
+        Ok(())
+    }
+
     fn load_processed(
         db: Arc<DB>,
         collection: Arc<CollectionSet>,
@@ -256,22 +329,28 @@ impl DiskRevIndex {
         Ok(())
     }
 
-    fn map_hashes_colors(&self, dataset_id: Idx) {
+    fn load_hashes(&self, dataset_id: Idx) -> impl Iterator<Item = HashIntoType> {
         let search_sig = self
             .collection
             .sig_for_dataset(dataset_id)
             .expect("Couldn't find a compatible Signature");
         let search_mh = &search_sig.sketches()[0];
 
-        let colors = Datasets::new(&[dataset_id]).as_bytes().unwrap();
-
-        let cf_hashes = self.db.cf_handle(HASHES).unwrap();
-
         let hashes = match search_mh {
             Sketch::MinHash(mh) => mh.mins(),
             Sketch::LargeMinHash(mh) => mh.mins(),
             _ => unimplemented!(),
         };
+
+        hashes.into_iter()
+    }
+
+    fn map_hashes_colors(&self, dataset_id: Idx) {
+        let colors = Datasets::new(&[dataset_id]).as_bytes().unwrap();
+
+        let cf_hashes = self.db.cf_handle(HASHES).unwrap();
+
+        let hashes = self.load_hashes(dataset_id);
 
         let mut hash_bytes = [0u8; 8];
         for hash in hashes {

--- a/src/core/src/index/revindex/disk_revindex.rs
+++ b/src/core/src/index/revindex/disk_revindex.rs
@@ -213,19 +213,23 @@ impl DiskRevIndex {
 
             let processed_sigs = AtomicUsize::new(0);
 
-            db.collection().par_iter().for_each(|(dataset_id, _)| {
-                let all_hashes = db.load_hashes(dataset_id);
-                all_hashes.for_each(|hash| {
-                    failed_hashes
-                        .entry(hash)
-                        .and_modify(|v| v.union(Datasets::new(&[dataset_id])));
-                });
+            db.collection()
+                .par_iter()
+                .try_for_each(|(dataset_id, _)| -> Result<()> {
+                    let all_hashes = db.load_hashes(dataset_id)?;
+                    all_hashes.for_each(|hash| {
+                        failed_hashes
+                            .entry(hash)
+                            .and_modify(|v| v.union(Datasets::new(&[dataset_id])));
+                    });
 
-                let i = processed_sigs.fetch_add(1, Ordering::SeqCst);
-                if i % 1000 == 0 {
-                    info!("Processed {} reference sigs", i);
-                }
-            });
+                    let i = processed_sigs.fetch_add(1, Ordering::SeqCst);
+                    if i % 1000 == 0 {
+                        info!("Processed {} reference sigs", i);
+                    }
+
+                    Ok(())
+                })?;
 
             let cf_hashes = db.db.cf_handle(HASHES).unwrap();
 
@@ -237,20 +241,21 @@ impl DiskRevIndex {
 
             let processed_hashes = AtomicUsize::new(0);
 
-            failed_hashes.into_par_iter().for_each(|(hash, value)| {
-                let mut hash_bytes = [0u8; 8];
-                (&mut hash_bytes[..])
-                    .write_u64::<LittleEndian>(hash)
-                    .expect("error writing bytes");
-                db.db
-                    .put_cf(&cf_hashes, &hash_bytes[..], value.as_bytes().unwrap())
-                    .expect("error putting new value");
+            failed_hashes
+                .into_par_iter()
+                .try_for_each(|(hash, value)| -> Result<()> {
+                    let mut hash_bytes = [0u8; 8];
+                    (&mut hash_bytes[..]).write_u64::<LittleEndian>(hash)?;
+                    if let Some(v) = value.as_bytes() {
+                        db.db.put_cf(&cf_hashes, &hash_bytes[..], v)?;
+                    };
 
-                let i = processed_hashes.fetch_add(1, Ordering::SeqCst);
-                if i % 1000 == 0 {
-                    info!("Processed {} failed hashes", i);
-                }
-            });
+                    let i = processed_hashes.fetch_add(1, Ordering::SeqCst);
+                    if i % 1000 == 0 {
+                        info!("Processed {} failed hashes", i);
+                    }
+                    Ok(())
+                })?;
 
             info!("Triggering compaction");
             db.compact();
@@ -332,11 +337,8 @@ impl DiskRevIndex {
         Ok(())
     }
 
-    fn load_hashes(&self, dataset_id: Idx) -> impl Iterator<Item = HashIntoType> {
-        let search_sig = self
-            .collection
-            .sig_for_dataset(dataset_id)
-            .expect("Couldn't find a compatible Signature");
+    fn load_hashes(&self, dataset_id: Idx) -> Result<impl Iterator<Item = HashIntoType>> {
+        let search_sig = self.collection.sig_for_dataset(dataset_id)?;
         let search_mh = &search_sig.sketches()[0];
 
         let hashes = match search_mh {
@@ -345,7 +347,7 @@ impl DiskRevIndex {
             _ => unimplemented!(),
         };
 
-        hashes.into_iter()
+        Ok(hashes.into_iter())
     }
 
     fn map_hashes_colors(&self, dataset_id: Idx) {
@@ -353,7 +355,7 @@ impl DiskRevIndex {
 
         let cf_hashes = self.db.cf_handle(HASHES).unwrap();
 
-        let hashes = self.load_hashes(dataset_id);
+        let hashes = self.load_hashes(dataset_id).unwrap();
 
         let mut hash_bytes = [0u8; 8];
         for hash in hashes {

--- a/src/core/src/index/revindex/disk_revindex.rs
+++ b/src/core/src/index/revindex/disk_revindex.rs
@@ -203,7 +203,7 @@ impl DiskRevIndex {
 
             if failed_hashes.is_empty() {
                 info!("No failed hashes found, finishing");
-                return Ok(())
+                return Ok(());
             }
 
             info!("{} failed hashes to process", failed_hashes.len());
@@ -230,7 +230,10 @@ impl DiskRevIndex {
             let cf_hashes = db.db.cf_handle(HASHES).unwrap();
 
             // iterate over failed hashes and update values in the DB
-            info!("Updating values in DB for {} failed hashes", failed_hashes.len());
+            info!(
+                "Updating values in DB for {} failed hashes",
+                failed_hashes.len()
+            );
 
             let processed_hashes = AtomicUsize::new(0);
 

--- a/src/core/src/index/revindex/mem_revindex.rs
+++ b/src/core/src/index/revindex/mem_revindex.rs
@@ -227,8 +227,8 @@ impl RevIndexOps for MemRevIndex {
         &self,
         query: &KmerMinHash,
         picklist: Option<DatasetPicklist>,
-    ) -> SigCounter {
-        query
+    ) -> Result<SigCounter> {
+        Ok(query
             .iter_mins()
             .filter_map(|hash| self.hash_to_color.get(hash))
             .flat_map(|color| self.colors.indices(color))
@@ -239,7 +239,7 @@ impl RevIndexOps for MemRevIndex {
                     .unwrap_or(true)
             })
             .cloned()
-            .collect()
+            .collect())
     }
 
     /// build a CounterGather struct for a particular query
@@ -247,8 +247,8 @@ impl RevIndexOps for MemRevIndex {
         &self,
         query: &KmerMinHash,
         picklist: Option<DatasetPicklist>,
-    ) -> CounterGather {
-        let counter = self.counter_for_query(query, picklist);
+    ) -> Result<CounterGather> {
+        let counter = self.counter_for_query(query, picklist)?;
         let hash_to_color = self.hash_to_color.clone();
 
         // restrict hash_to_color to hashes contained in query
@@ -272,11 +272,11 @@ impl RevIndexOps for MemRevIndex {
 
         //eprintln!("query_colors: {:?}", query_colors);
 
-        CounterGather {
+        Ok(CounterGather {
             counter,
             query_colors,
             hash_to_color,
-        }
+        })
     }
 
     fn gather(
@@ -370,7 +370,7 @@ impl RevIndexOps for MemRevIndex {
 
         let threshold: usize = (threshold * (query_mh.size() as f64)) as _;
 
-        let counter = self.counter_for_query(&query_mh, picklist);
+        let counter = self.counter_for_query(&query_mh, picklist)?;
 
         debug!(
             "number of matching signatures for hashes: {}",
@@ -571,14 +571,14 @@ mod test {
         }
         let query_mh = query_mh.expect("Couldn't find a compatible MinHash");
 
-        let counter_rev = index.counter_for_query(&query_mh, None);
+        let counter_rev = index.counter_for_query(&query_mh, None)?;
         let counter_lin = index.linear.counter_for_query(&query_mh);
 
         let results_rev = index.search(counter_rev, false, 0).unwrap();
         let results_linear = index.linear.search(counter_lin, false, 0).unwrap();
         assert_eq!(results_rev, results_linear);
 
-        let counter_rev = index.prepare_gather_counters(&query_mh, None);
+        let counter_rev = index.prepare_gather_counters(&query_mh, None)?;
         let counter_lin = index.linear.counter_for_query(&query_mh);
 
         let results_rev = index.gather(counter_rev, 0, &query_mh, None).unwrap();
@@ -615,7 +615,7 @@ mod test {
             _ => unimplemented!(),
         };
 
-        let gather_cg = index.prepare_gather_counters(&query_mh, None);
+        let gather_cg = index.prepare_gather_counters(&query_mh, None)?;
         // eprintln!("gather_cg: {:?}", gather_cg);
         let results = index.gather(gather_cg, 0, &query_mh, None).unwrap();
 
@@ -652,7 +652,7 @@ mod test {
         };
 
         // run the CounterGather-style gather:
-        let gather_cg = index.prepare_gather_counters(&query_mh, None);
+        let gather_cg = index.prepare_gather_counters(&query_mh, None)?;
         // eprintln!("gather_cg: {:?}", gather_cg);
         let results = index.gather(gather_cg, 0, &query_mh, None).unwrap();
         assert_eq!(results.len(), 3);
@@ -711,7 +711,7 @@ mod test {
         }
         let query = query.unwrap();
 
-        let cg = index.prepare_gather_counters(&query, None);
+        let cg = index.prepare_gather_counters(&query, None)?;
 
         let matches = index.gather(
             cg,
@@ -862,7 +862,7 @@ mod test {
         }
         let query = query.unwrap();
 
-        let cg = index.prepare_gather_counters(&query, None);
+        let cg = index.prepare_gather_counters(&query, None)?;
 
         let idxlist = cg.dataset_ids();
         assert_eq!(idxlist.len(), 12);
@@ -923,7 +923,7 @@ mod test {
             dataset_ids: vec![0].into_iter().collect(),
         };
 
-        let cg = index.prepare_gather_counters(&query, Some(pl.clone()));
+        let cg = index.prepare_gather_counters(&query, Some(pl.clone()))?;
 
         let matches = index.gather(
             cg,
@@ -936,11 +936,11 @@ mod test {
         assert_eq!(matches.len(), 1);
 
         // also do a basic test of containment with picklists -
-        let counter = index.counter_for_query(&query, Some(pl.clone()));
+        let counter = index.counter_for_query(&query, Some(pl.clone()))?;
         let matches = index.matches_from_counter(counter, 0);
         assert_eq!(matches, [("NC_003197.2 Salmonella enterica subsp. enterica serovar Typhimurium str. LT2, complete genome".into(), 485)]);
 
-        let counter = index.counter_for_query(&query, Some(pl));
+        let counter = index.counter_for_query(&query, Some(pl))?;
         let records = index.records_from_counter(counter, 0);
         assert_eq!(records.len(), 1);
 

--- a/src/core/src/index/revindex/mod.rs
+++ b/src/core/src/index/revindex/mod.rs
@@ -536,14 +536,14 @@ fn stats_for_cf(db: Arc<DB>, cf_name: &str, deep_check: bool, quick: bool) -> Db
 
     for result in iter {
         let (key, value) = result.unwrap();
-        let _k = (&key[..]).read_u64::<LittleEndian>().unwrap();
+        let k = (&key[..]).read_u64::<LittleEndian>().unwrap();
         kcount += key.len();
 
         //println!("Saw {} {:?}", k, Datasets::from_slice(&value));
         vcount += value.len();
 
         if !quick && deep_check {
-            let v = Datasets::from_slice(&value).expect("Error with value");
+            let v = Datasets::from_slice(&value).expect(format!("Error for key {k} for value").as_str());
             vcounts.increment(v.len() as u64).unwrap();
             datasets.union(v);
         }

--- a/src/core/src/index/revindex/mod.rs
+++ b/src/core/src/index/revindex/mod.rs
@@ -430,9 +430,7 @@ impl Datasets {
 
         if slice.len() == 8 {
             // Unique
-            Ok(Self::Unique(
-                (&slice[..]).read_u32::<LittleEndian>()?
-            ))
+            Ok(Self::Unique((&slice[..]).read_u32::<LittleEndian>()?))
         } else if slice.len() == 1 {
             // Empty
             Ok(Self::Empty)
@@ -544,12 +542,15 @@ fn stats_for_cf(db: Arc<DB>, cf_name: &str, deep_check: bool, quick: bool) -> Db
 
         if !quick && deep_check {
             match Datasets::from_slice(&value) {
-                Err(e) => {dbg!(format!("Error for key {k} for value: {e}"));},
+                Err(e) => {
+                    eprintln!("key {k} error for value: {e}");
+                }
 
                 Ok(v) => {
-            vcounts.increment(v.len() as u64).unwrap();
-            datasets.union(v);}
+                    vcounts.increment(v.len() as u64).unwrap();
+                    datasets.union(v);
                 }
+            }
         }
         //println!("Saw {} {:?}", k, value);
     }

--- a/src/core/src/index/revindex/mod.rs
+++ b/src/core/src/index/revindex/mod.rs
@@ -79,7 +79,7 @@ pub trait RevIndexOps {
         &self,
         query: &KmerMinHash,
         picklist: Option<DatasetPicklist>,
-    ) -> SigCounter;
+    ) -> Result<SigCounter>;
 
     fn matches_from_counter(&self, counter: SigCounter, threshold: usize) -> Vec<(String, usize)> {
         counter
@@ -127,7 +127,7 @@ pub trait RevIndexOps {
         &self,
         query: &KmerMinHash,
         picklist: Option<DatasetPicklist>,
-    ) -> CounterGather;
+    ) -> Result<CounterGather>;
 
     fn update(self, collection: CollectionSet) -> Result<RevIndex>
     where
@@ -615,7 +615,7 @@ mod test {
             output.path().to_str().expect("cannot convert")
         );
 
-        let counter = index.counter_for_query(&query, None);
+        let counter = index.counter_for_query(&query, None)?;
         let matches = index.matches_from_counter(counter, 0);
 
         assert_eq!(matches, [("../genome-s10.fa.gz".into(), 48)]);
@@ -662,7 +662,7 @@ mod test {
         let index =
             RevIndex::open(output.path(), false, None)?.update(new_collection.try_into()?)?;
 
-        let counter = index.counter_for_query(&q, None);
+        let counter = index.counter_for_query(&q, None)?;
         let matches = index.matches_from_counter(counter, 0);
 
         assert!(matches[0].0.ends_with("/genome-s12.fa.gz"));
@@ -703,7 +703,7 @@ mod test {
 
         let index = RevIndex::open(output.path(), true, None)?;
 
-        let cg = index.prepare_gather_counters(&query, None);
+        let cg = index.prepare_gather_counters(&query, None)?;
         assert_eq!(cg.len(), 1);
         assert_eq!(cg.is_empty(), false);
 
@@ -765,7 +765,7 @@ mod test {
         }
         let query = query.unwrap();
 
-        let cg = index.prepare_gather_counters(&query, None);
+        let cg = index.prepare_gather_counters(&query, None)?;
 
         let matches = index.gather(
             cg,
@@ -913,7 +913,7 @@ mod test {
         }
         let query = query.unwrap();
 
-        let cg = index.prepare_gather_counters(&query, None);
+        let cg = index.prepare_gather_counters(&query, None)?;
 
         let matches = index.gather(cg, 0, &query, Some(selection))?;
 
@@ -1010,7 +1010,7 @@ mod test {
             dataset_ids: vec![0].into_iter().collect(),
         };
 
-        let cg = index.prepare_gather_counters(&query, Some(pl.clone()));
+        let cg = index.prepare_gather_counters(&query, Some(pl.clone()))?;
 
         let matches = index.gather(
             cg,
@@ -1023,11 +1023,11 @@ mod test {
         assert_eq!(matches.len(), 1);
 
         // also do a basic test of containment with picklists -
-        let counter = index.counter_for_query(&query, Some(pl.clone()));
+        let counter = index.counter_for_query(&query, Some(pl.clone()))?;
         let matches = index.matches_from_counter(counter, 0);
         assert_eq!(matches, [("NC_003197.2 Salmonella enterica subsp. enterica serovar Typhimurium str. LT2, complete genome".into(), 485)]);
 
-        let counter = index.counter_for_query(&query, Some(pl));
+        let counter = index.counter_for_query(&query, Some(pl))?;
         let records = index.records_from_counter(counter, 0);
         assert_eq!(records.len(), 1);
 
@@ -1115,7 +1115,7 @@ mod test {
         {
             let index = RevIndex::open(output.as_path(), false, None)?;
 
-            let counter = index.counter_for_query(&query, None);
+            let counter = index.counter_for_query(&query, None)?;
             let matches = index.matches_from_counter(counter, 0);
 
             assert!(matches[0].0.starts_with("NC_009665.1"));
@@ -1135,7 +1135,7 @@ mod test {
 
         let index = RevIndex::open(output.as_path(), false, Some(&format!("zip://{}", new_zip)))?;
 
-        let counter = index.counter_for_query(&query, None);
+        let counter = index.counter_for_query(&query, None)?;
         let matches = index.matches_from_counter(counter, 0);
 
         assert!(matches[0].0.starts_with("NC_009665.1"));
@@ -1171,7 +1171,7 @@ mod test {
 
         let index = RevIndex::create(output.as_path(), collection.try_into()?)?;
 
-        let cg = index.prepare_gather_counters(&query, None);
+        let cg = index.prepare_gather_counters(&query, None)?;
 
         let matches_external = index
             .gather(cg, 0, &query, Some(selection.clone()))
@@ -1183,7 +1183,7 @@ mod test {
                 .internalize_storage()
                 .expect("Error internalizing storage");
 
-            let cg = index.prepare_gather_counters(&query, None);
+            let cg = index.prepare_gather_counters(&query, None)?;
 
             let matches_internal = index.gather(cg, 0, &query, Some(selection.clone()))?;
             assert_eq!(matches_external, matches_internal);
@@ -1193,7 +1193,7 @@ mod test {
 
         let index = RevIndex::open(new_path, false, None)?;
 
-        let cg = index.prepare_gather_counters(&query, None);
+        let cg = index.prepare_gather_counters(&query, None)?;
 
         let matches_moved = index.gather(cg, 0, &query, Some(selection.clone()))?;
         assert_eq!(matches_external, matches_moved);
@@ -1320,7 +1320,7 @@ mod test {
             m1.try_into().expect("cannot extract minhash")
         };
 
-        let mut cg = db.prepare_gather_counters(&query_mh, None);
+        let mut cg = db.prepare_gather_counters(&query_mh, None)?;
 
         let (dataset_id, size) = cg.peek(0).unwrap();
 
@@ -1363,6 +1363,7 @@ mod test {
 
     #[test]
     fn disk_revindex_repair() -> Result<()> {
+        use crate::errors::SourmashError;
         use crate::index::revindex::disk_revindex::DiskRevIndex;
         use crate::storage::rocksdb::HASHES;
         use byteorder::{LittleEndian, WriteBytesExt};
@@ -1414,13 +1415,13 @@ mod test {
                 }
             }
         }
-        // TODO: trigger error here
-        /*
+        // trigger error here and verify it
         {
-        let index = RevIndex::open(output.path(), true, None)?;
-        let counter = index.counter_for_query(&query, None);
+            let index = RevIndex::open(output.path(), true, None)?;
+            let res = index.counter_for_query(&query, None);
+            // Custom { kind: Other, error: "unknown cookie value" }
+            assert!(matches!(res, Err(SourmashError::IOError(_))));
         }
-        */
 
         // Repair DB
         {
@@ -1428,7 +1429,7 @@ mod test {
         }
 
         let index = RevIndex::open(output.path(), true, None)?;
-        let counter = index.counter_for_query(&query, None);
+        let counter = index.counter_for_query(&query, None)?;
         let matches = index.matches_from_counter(counter, 0);
 
         assert_eq!(matches, [("../genome-s10.fa.gz".into(), 48)]);

--- a/src/core/src/index/revindex/mod.rs
+++ b/src/core/src/index/revindex/mod.rs
@@ -431,14 +431,14 @@ impl Datasets {
         if slice.len() == 8 {
             // Unique
             Ok(Self::Unique(
-                (&slice[..]).read_u32::<LittleEndian>().unwrap(),
+                (&slice[..]).read_u32::<LittleEndian>()?
             ))
         } else if slice.len() == 1 {
             // Empty
             Ok(Self::Empty)
         } else {
             // Many
-            Ok(Self::Many(RoaringBitmap::deserialize_from(slice).unwrap()))
+            Ok(Self::Many(RoaringBitmap::deserialize_from(slice)?))
         }
     }
 

--- a/src/core/src/index/revindex/mod.rs
+++ b/src/core/src/index/revindex/mod.rs
@@ -543,9 +543,13 @@ fn stats_for_cf(db: Arc<DB>, cf_name: &str, deep_check: bool, quick: bool) -> Db
         vcount += value.len();
 
         if !quick && deep_check {
-            let v = Datasets::from_slice(&value).expect(format!("Error for key {k} for value").as_str());
+            match Datasets::from_slice(&value) {
+                Err(e) => {dbg!(format!("Error for key {k} for value: {e}"));},
+
+                Ok(v) => {
             vcounts.increment(v.len() as u64).unwrap();
-            datasets.union(v);
+            datasets.union(v);}
+                }
         }
         //println!("Saw {} {:?}", k, value);
     }

--- a/src/core/src/index/revindex/mod.rs
+++ b/src/core/src/index/revindex/mod.rs
@@ -55,10 +55,6 @@ pub struct DatasetPicklist {
 
 #[enum_dispatch]
 pub trait RevIndexOps {
-    /* TODO: need the repair_cf variant, not available in rocksdb-rust yet
-      pub fn repair(index: &Path, colors: bool);
-    */
-
     fn location(&self) -> &str;
 
     fn len(&self) -> usize {
@@ -309,15 +305,14 @@ impl FromIterator<(HashIntoType, Color)> for HashToColor {
 }
 
 impl RevIndex {
-    /* TODO: need the repair_cf variant, not available in rocksdb-rust yet
-         pub fn repair(index: &Path, colors: bool) {
-            if colors {
-                color_revindex::repair(index);
-            } else {
-                disk_revindex::repair(index);
-            }
-        }
-    */
+    pub fn repair<P: AsRef<Path>>(
+        index: P,
+        storage_spec: Option<&str>,
+        _colors: bool,
+    ) -> Result<()> {
+        disk_revindex::DiskRevIndex::repair(index, storage_spec)
+    }
+
     pub fn create<P: AsRef<Path>>(index: P, collection: CollectionSet) -> Result<Self> {
         disk_revindex::DiskRevIndex::create(index.as_ref(), collection)
     }
@@ -517,6 +512,9 @@ pub struct DbStats {
 
     #[getset(get = "pub")]
     vcounts: histogram::Histogram,
+
+    #[getset(get = "pub")]
+    failed_keys: HashSet<HashIntoType>,
 }
 
 fn stats_for_cf(db: Arc<DB>, cf_name: &str, deep_check: bool, quick: bool) -> DbStats {
@@ -531,6 +529,7 @@ fn stats_for_cf(db: Arc<DB>, cf_name: &str, deep_check: bool, quick: bool) -> Db
     // Using power values from https://docs.rs/histogram/0.8.3/histogram/struct.Config.html#resulting-size
     let mut vcounts = Histogram::new(12, 64).expect("Error initializing histogram");
     let mut datasets: Datasets = Default::default();
+    let mut failed_keys = HashSet::new();
 
     for result in iter {
         let (key, value) = result.unwrap();
@@ -542,8 +541,8 @@ fn stats_for_cf(db: Arc<DB>, cf_name: &str, deep_check: bool, quick: bool) -> Db
 
         if !quick && deep_check {
             match Datasets::from_slice(&value) {
-                Err(e) => {
-                    eprintln!("key {k} error for value: {e}");
+                Err(_) => {
+                    failed_keys.insert(k);
                 }
 
                 Ok(v) => {
@@ -561,6 +560,7 @@ fn stats_for_cf(db: Arc<DB>, cf_name: &str, deep_check: bool, quick: bool) -> Db
         kcount,
         vcount,
         vcounts,
+        failed_keys,
     }
 }
 

--- a/src/core/src/index/revindex/mod.rs
+++ b/src/core/src/index/revindex/mod.rs
@@ -1360,4 +1360,79 @@ mod test {
 
         Ok(())
     }
+
+    #[test]
+    fn disk_revindex_repair() -> Result<()> {
+        use crate::index::revindex::disk_revindex::DiskRevIndex;
+        use crate::storage::rocksdb::HASHES;
+        use byteorder::{LittleEndian, WriteBytesExt};
+
+        let mut basedir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        basedir.push("../../tests/test-data/scaled/");
+
+        let siglist: Vec<_> = (10..=12)
+            .map(|i| {
+                let mut filename = basedir.clone();
+                filename.push(format!("genome-s{}.fa.gz.sig", i));
+                filename
+            })
+            .collect();
+
+        let selection = Selection::builder().ksize(31).scaled(10000).build();
+        let output = TempDir::new()?;
+
+        let mut query = None;
+        let query_sig = Signature::from_path(&siglist[0])?
+            .swap_remove(0)
+            .select(&selection)?;
+        if let Some(q) = prepare_query(query_sig, &selection) {
+            query = Some(q);
+        }
+        let query = query.unwrap();
+
+        // Extract one hash to corrupt
+        let failed_hash = query.mins()[0];
+
+        let collection = Collection::from_paths(&siglist)?.select(&selection)?;
+        {
+            let index = RevIndex::create(output.path(), collection.try_into()?)?;
+            assert_eq!(
+                index.location(),
+                output.path().to_str().expect("cannot convert")
+            );
+
+            if let RevIndex::Disk(ref index) = index {
+                let mut hash_bytes = [0u8; 8];
+                (&mut hash_bytes[..])
+                    .write_u64::<LittleEndian>(failed_hash)
+                    .expect("error writing bytes");
+                unsafe {
+                    let db = index.db();
+                    let cf_hashes = db.cf_handle(HASHES).unwrap();
+                    db.put_cf(&cf_hashes, &hash_bytes[..], b"0xbadda7a")
+                        .expect("error putting new value");
+                }
+            }
+        }
+        // TODO: trigger error here
+        /*
+        {
+        let index = RevIndex::open(output.path(), true, None)?;
+        let counter = index.counter_for_query(&query, None);
+        }
+        */
+
+        // Repair DB
+        {
+            DiskRevIndex::repair(output.path(), None)?;
+        }
+
+        let index = RevIndex::open(output.path(), true, None)?;
+        let counter = index.counter_for_query(&query, None);
+        let matches = index.matches_from_counter(counter, 0);
+
+        assert_eq!(matches, [("../genome-s10.fa.gz".into(), 48)]);
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
Fix #3862 

- Re-enable `repair` functionality, so we can recover from errors due to dataset list corruption (the `RoaringBitmap unknown cookie` error)
- Bump core to `0.23.0`
- `counter_for_query`,`prepare_gather_counters`,`load_hashes` all return `Result<...>` now, so we can capture errors.
- `stats_for_cf` now reports `failed_keys`  if doing a full check, so we can capture errors due to dataset list corruption
- Bump codecov-action, install codecov-cli from pypi
- Only reuse shared lib for rocksdb in Linux, macOS has issues finding it from the pixi env