### PR TITLE
fix: error out when --singleton is combined with --merge/--name

### DIFF
--- a/src/sourmash/command_sketch.py
+++ b/src/sourmash/command_sketch.py
@@ -229,6 +229,14 @@ def _execute_sketch(args, signatures_factory):
         error("ERROR: must specify -o with --merge")
         sys.exit(-1)
 
+    if args.merge and args.singleton:
+        error(
+            "ERROR: --singleton cannot be used with --merge/--name/--set-name; "
+            "--merge produces a single sketch, while --singleton produces one "
+            "sketch per sequence record."
+        )
+        sys.exit(-1)
+
     if args.output and args.output_dir:
         error("ERROR: --output-dir doesn't make sense with -o/--output")
         sys.exit(-1)

--- a/tests/test_sourmash_sketch.py
+++ b/tests/test_sourmash_sketch.py
@@ -904,6 +904,34 @@ def test_do_sourmash_sketchdna_name_fail_no_output(runtmp):
     assert runtmp.last_result.status == -1
 
 
+@pytest.mark.parametrize("moltype", ["dna", "translate"])
+@pytest.mark.parametrize("name_arg", ["--merge", "--name", "--set-name"])
+def test_do_sourmash_sketch_singleton_and_merge_fail(runtmp, moltype, name_arg):
+    # --merge asks for one sketch across all records, while --singleton asks
+    # for one sketch per record; previously --merge silently won and
+    # --singleton was ignored. See #3817.
+    testdata1 = utils.get_test_data("short.fa")
+
+    with pytest.raises(SourmashCommandFailed):
+        runtmp.sourmash(
+            "sketch",
+            moltype,
+            name_arg,
+            "foo",
+            "--singleton",
+            testdata1,
+            "-o",
+            "foo.sig",
+        )
+
+    assert runtmp.last_result.status == -1
+    assert (
+        "ERROR: --singleton cannot be used with --merge/--name/--set-name"
+        in runtmp.last_result.err
+    )
+    assert not os.path.exists(runtmp.output("foo.sig"))
+
+
 def test_do_sourmash_sketchdna_fail_no_output(runtmp):
     testdata1 = utils.get_test_data("short.fa")
 


### PR DESCRIPTION
`--name` and `--set-name` are aliases for `--merge` (dest="merge"), and `_execute_sketch` dispatches to `_compute_merged()` whenever `args.merge` is set. `args.singleton` is only ever read inside `_compute_individual()`, so passing both silently ignored `--singleton` and produced a single merged sketch, exiting 0.

The two options are contradictory -- `--merge` produces one sketch across all records, `--singleton` produces one per record -- so error out instead of silently picking one. The check lives in `_execute_sketch`, so it covers `sketch dna`, `sketch protein`, and `sketch translate`.

Fixes #3817.

## The problem

`--name` and `--set-name` are aliases for `--merge` (they share `dest="merge"`), and `_execute_sketch()` dispatches on `args.merge`:

```python
if args.merge:      # --name sets this
    _compute_merged(args, signatures_factory)
else:
    _compute_individual(args, signatures_factory)   # only place args.singleton is read
```
## The fix

`--merge` produces one sketch across all records; `--singleton` produces one per record. They're contradictory, so error out instead of silently picking one:

```
ERROR: --singleton cannot be used with --merge/--name/--set-name; --merge produces
a single sketch, while --singleton produces one sketch per sequence record.
```

## Test

Six new parametrized tests over all three aliases `(--merge/--name/--set-name)` × two moltypes, asserting exit status, error text, and that no output file is written. There was previously no test covering `--singleton` together with `--name/--merge`.

`tests/test_sourmash_sketch.py` + `tests/test_sourmash_compute.py`: 176 passed, no regressions. ruff format / ruff check clean.

## Note

The deprecated (4.0) sourmash compute has the same bug (`command_compute.py` dispatches on `args.merge` the same way). 